### PR TITLE
rename paramSpace and accountKeeper

### DIFF
--- a/x/ccv/consumer/keeper/distribution.go
+++ b/x/ccv/consumer/keeper/distribution.go
@@ -19,7 +19,7 @@ const TransferTimeDelay = 1 * 7 * 24 * time.Hour // 1 weeks
 // The fraction of tokens allocated to the consumer redistribution address
 // during distribution events. The fraction is a string representing a
 // decimal number. For example "0.75" would represent 75%.
- const ConsumerRedistributeFrac = "0.75"
+const ConsumerRedistributeFrac = "0.75"
 
 // Simple model, send tokens to the fee pool of the provider validator set
 // reference: cosmos/ibc-go/v3/modules/apps/transfer/keeper/msg_server.go
@@ -37,7 +37,7 @@ func (k Keeper) DistributeToProviderValidatorSet(ctx sdk.Context) error {
 		return nil
 	}
 
-	consumerFeePoolAddr := k.accountKeeper.GetModuleAccount(ctx, k.feeCollectorName).GetAddress()
+	consumerFeePoolAddr := k.authKeeper.GetModuleAccount(ctx, k.feeCollectorName).GetAddress()
 	fpTokens := k.bankKeeper.GetAllBalances(ctx, consumerFeePoolAddr)
 
 	// split the fee pool, send the consumer's fraction to the consumer redistribution address
@@ -66,12 +66,12 @@ func (k Keeper) DistributeToProviderValidatorSet(ctx sdk.Context) error {
 		return err
 	}
 	// empty out the toSendToProviderTokens address
-	tstProviderAddr := k.accountKeeper.GetModuleAccount(ctx,
+	tstProviderAddr := k.authKeeper.GetModuleAccount(ctx,
 		types.ConsumerToSendToProviderName).GetAddress()
 	tstProviderTokens := k.bankKeeper.GetAllBalances(ctx, tstProviderAddr)
 	ch := k.GetDistributionTransmissionChannel(ctx)
 	providerAddr := k.GetProviderFeePoolAddrStr(ctx)
-	timeoutHeight := clienttypes.Height{0, 0}
+	timeoutHeight := clienttypes.ZeroHeight()
 	timeoutTimestamp := uint64(ctx.BlockTime().Add(TransferTimeDelay).UnixNano())
 	for _, token := range tstProviderTokens {
 		err := k.ibcTransferKeeper.SendTransfer(ctx,

--- a/x/ccv/consumer/keeper/keeper.go
+++ b/x/ccv/consumer/keeper/keeper.go
@@ -26,7 +26,7 @@ import (
 type Keeper struct {
 	storeKey          sdk.StoreKey
 	cdc               codec.BinaryCodec
-	paramSpace        paramtypes.Subspace
+	paramStore        paramtypes.Subspace
 	scopedKeeper      capabilitykeeper.ScopedKeeper
 	channelKeeper     ccv.ChannelKeeper
 	portKeeper        ccv.PortKeeper
@@ -35,7 +35,7 @@ type Keeper struct {
 	slashingKeeper    ccv.SlashingKeeper
 	hooks             ccv.ConsumerHooks
 	bankKeeper        ccv.BankKeeper
-	accountKeeper     ccv.AccountKeeper
+	authKeeper        ccv.AccountKeeper
 	ibcTransferKeeper ccv.IBCTransferKeeper
 	ibcCoreKeeper     ccv.IBCCoreKeeper
 	feeCollectorName  string
@@ -61,7 +61,7 @@ func NewKeeper(
 	return Keeper{
 		storeKey:          key,
 		cdc:               cdc,
-		paramSpace:        paramSpace,
+		paramStore:        paramSpace,
 		scopedKeeper:      scopedKeeper,
 		channelKeeper:     channelKeeper,
 		portKeeper:        portKeeper,
@@ -69,7 +69,7 @@ func NewKeeper(
 		clientKeeper:      clientKeeper,
 		slashingKeeper:    slashingKeeper,
 		bankKeeper:        bankKeeper,
-		accountKeeper:     accountKeeper,
+		authKeeper:        accountKeeper,
 		ibcTransferKeeper: ibcTransferKeeper,
 		ibcCoreKeeper:     ibcCoreKeeper,
 		feeCollectorName:  feeCollectorName,

--- a/x/ccv/consumer/keeper/params.go
+++ b/x/ccv/consumer/keeper/params.go
@@ -18,42 +18,42 @@ func (k Keeper) GetParams(ctx sdk.Context) types.Params {
 
 // SetParams sets the paramset for the consumer module
 func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
-	k.paramSpace.SetParamSet(ctx, &params)
+	k.paramStore.SetParamSet(ctx, &params)
 }
 
 // GetEnabled returns the enabled flag for the consumer module
 func (k Keeper) GetEnabled(ctx sdk.Context) bool {
 	var enabled bool
-	k.paramSpace.Get(ctx, types.KeyEnabled, &enabled)
+	k.paramStore.Get(ctx, types.KeyEnabled, &enabled)
 	return enabled
 }
 
 func (k Keeper) GetBlocksPerDistributionTransmission(ctx sdk.Context) int64 {
 	var bpdt int64
-	k.paramSpace.Get(ctx, types.KeyBlocksPerDistributionTransmission, &bpdt)
+	k.paramStore.Get(ctx, types.KeyBlocksPerDistributionTransmission, &bpdt)
 	return bpdt
 }
 
 func (k Keeper) SetBlocksPerDistributionTransmission(ctx sdk.Context, bpdt int64) {
-	k.paramSpace.Set(ctx, types.KeyBlocksPerDistributionTransmission, bpdt)
+	k.paramStore.Set(ctx, types.KeyBlocksPerDistributionTransmission, bpdt)
 }
 
 func (k Keeper) GetDistributionTransmissionChannel(ctx sdk.Context) string {
 	var s string
-	k.paramSpace.Get(ctx, types.KeyDistributionTransmissionChannel, &s)
+	k.paramStore.Get(ctx, types.KeyDistributionTransmissionChannel, &s)
 	return s
 }
 
 func (k Keeper) SetDistributionTransmissionChannel(ctx sdk.Context, channel string) {
-	k.paramSpace.Set(ctx, types.KeyDistributionTransmissionChannel, channel)
+	k.paramStore.Set(ctx, types.KeyDistributionTransmissionChannel, channel)
 }
 
 func (k Keeper) GetProviderFeePoolAddrStr(ctx sdk.Context) string {
 	var s string
-	k.paramSpace.Get(ctx, types.KeyProviderFeePoolAddrStr, &s)
+	k.paramStore.Get(ctx, types.KeyProviderFeePoolAddrStr, &s)
 	return s
 }
 
 func (k Keeper) SetProviderFeePoolAddrStr(ctx sdk.Context, addr string) {
-	k.paramSpace.Set(ctx, types.KeyProviderFeePoolAddrStr, addr)
+	k.paramStore.Set(ctx, types.KeyProviderFeePoolAddrStr, addr)
 }


### PR DESCRIPTION
spin out of https://github.com/cosmos/interchain-security/pull/98

- rename paramSpace to paramStore
- rename accountKeeper to authKeeper 