### PR TITLE
Make pass the tests after #113

### DIFF
--- a/app/consumer/app.go
+++ b/app/consumer/app.go
@@ -669,6 +669,7 @@ func New(
 				SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
 			},
 			IBCChannelkeeper: app.IBCKeeper.ChannelKeeper,
+			ConsumerKeeper:   app.ConsumerKeeper,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Pass consumer keeper to ante handler options in consumer app.go
