### PR TITLE
Ensure VSCMature packets are sent even if no ValidatorUpdates are received

### DIFF
--- a/x/ccv/consumer/module.go
+++ b/x/ccv/consumer/module.go
@@ -167,6 +167,8 @@ func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.V
 		panic(err)
 	}
 
+	am.keeper.UnbondMaturePackets(ctx)
+
 	data, ok := am.keeper.GetPendingChanges(ctx)
 	if !ok {
 		return []abci.ValidatorUpdate{}
@@ -174,7 +176,6 @@ func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.V
 	// apply changes to cross-chain validator set
 	am.keeper.ApplyCCValidatorChanges(ctx, data.ValidatorUpdates)
 	am.keeper.DeletePendingChanges(ctx)
-	am.keeper.UnbondMaturePackets(ctx)
 
 	return data.ValidatorUpdates
 }


### PR DESCRIPTION
Fixes

- https://github.com/cosmos/interchain-security/issues/106