### PR TITLE
Upgrade to ibc go v3.0.0

### DIFF
--- a/app/consumer/ante_handler.go
+++ b/app/consumer/ante_handler.go
@@ -5,7 +5,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	ibcante "github.com/cosmos/ibc-go/v3/modules/core/ante"
-	"github.com/cosmos/ibc-go/v3/modules/core/keeper"
+	ibckeeper "github.com/cosmos/ibc-go/v3/modules/core/keeper"
 	consumerante "github.com/cosmos/interchain-security/app/consumer/ante"
 	ibcconsumerkeeper "github.com/cosmos/interchain-security/x/ccv/consumer/keeper"
 )
@@ -15,7 +15,7 @@ import (
 type HandlerOptions struct {
 	ante.HandlerOptions
 
-	IBCChannelKeeper *keeper.Keeper
+	IBCChannelKeeper *ibckeeper.Keeper
 	ConsumerKeeper   ibcconsumerkeeper.Keeper
 }
 

--- a/app/consumer/ante_handler.go
+++ b/app/consumer/ante_handler.go
@@ -15,8 +15,8 @@ import (
 type HandlerOptions struct {
 	ante.HandlerOptions
 
-	IBCChannelKeeper *ibckeeper.Keeper
-	ConsumerKeeper   ibcconsumerkeeper.Keeper
+	IBCKeeper      *ibckeeper.Keeper
+	ConsumerKeeper ibcconsumerkeeper.Keeper
 }
 
 func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
@@ -51,7 +51,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer),
 		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
-		ibcante.NewAnteDecorator(options.IBCChannelKeeper),
+		ibcante.NewAnteDecorator(options.IBCKeeper),
 	}
 
 	return sdk.ChainAnteDecorators(anteDecorators...), nil

--- a/app/consumer/ante_handler.go
+++ b/app/consumer/ante_handler.go
@@ -4,8 +4,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
-	channelkeeper "github.com/cosmos/ibc-go/v3/modules/core/04-channel/keeper"
 	ibcante "github.com/cosmos/ibc-go/v3/modules/core/ante"
+	"github.com/cosmos/ibc-go/v3/modules/core/keeper"
 	consumerante "github.com/cosmos/interchain-security/app/consumer/ante"
 	ibcconsumerkeeper "github.com/cosmos/interchain-security/x/ccv/consumer/keeper"
 )
@@ -15,7 +15,7 @@ import (
 type HandlerOptions struct {
 	ante.HandlerOptions
 
-	IBCChannelkeeper channelkeeper.Keeper
+	IBCChannelKeeper *keeper.Keeper
 	ConsumerKeeper   ibcconsumerkeeper.Keeper
 }
 
@@ -51,7 +51,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer),
 		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
-		ibcante.NewAnteDecorator(options.IBCChannelkeeper),
+		ibcante.NewAnteDecorator(options.IBCChannelKeeper),
 	}
 
 	return sdk.ChainAnteDecorators(anteDecorators...), nil

--- a/app/consumer/app.go
+++ b/app/consumer/app.go
@@ -529,8 +529,8 @@ func New(
 				SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
 				SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
 			},
-			IBCChannelKeeper: app.IBCKeeper,
-			ConsumerKeeper:   app.ConsumerKeeper,
+			IBCKeeper:      app.IBCKeeper,
+			ConsumerKeeper: app.ConsumerKeeper,
 		},
 	)
 	if err != nil {

--- a/app/consumer/app.go
+++ b/app/consumer/app.go
@@ -529,7 +529,7 @@ func New(
 				SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
 				SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
 			},
-			IBCChannelKeeper: app.IBCKeeper.ChannelKeeper,
+			IBCChannelKeeper: app.IBCKeeper,
 			ConsumerKeeper:   app.ConsumerKeeper,
 		},
 	)

--- a/app/consumer/app.go
+++ b/app/consumer/app.go
@@ -529,7 +529,7 @@ func New(
 				SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
 				SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
 			},
-			IBCChannelkeeper: app.IBCKeeper.ChannelKeeper,
+			IBCChannelKeeper: app.IBCKeeper.ChannelKeeper,
 			ConsumerKeeper:   app.ConsumerKeeper,
 		},
 	)

--- a/app/provider/ante_handler.go
+++ b/app/provider/ante_handler.go
@@ -5,7 +5,7 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	ibcante "github.com/cosmos/ibc-go/v3/modules/core/ante"
-	"github.com/cosmos/ibc-go/v3/modules/core/keeper"
+	ibckeeper "github.com/cosmos/ibc-go/v3/modules/core/keeper"
 )
 
 // HandlerOptions extend the SDK's AnteHandler options by requiring the IBC
@@ -13,7 +13,7 @@ import (
 type HandlerOptions struct {
 	ante.HandlerOptions
 
-	IBCChannelKeeper *keeper.Keeper
+	IBCChannelKeeper *ibckeeper.Keeper
 }
 
 func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {

--- a/app/provider/ante_handler.go
+++ b/app/provider/ante_handler.go
@@ -4,8 +4,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
-	channelkeeper "github.com/cosmos/ibc-go/v3/modules/core/04-channel/keeper"
 	ibcante "github.com/cosmos/ibc-go/v3/modules/core/ante"
+	"github.com/cosmos/ibc-go/v3/modules/core/keeper"
 )
 
 // HandlerOptions extend the SDK's AnteHandler options by requiring the IBC
@@ -13,7 +13,7 @@ import (
 type HandlerOptions struct {
 	ante.HandlerOptions
 
-	IBCChannelkeeper channelkeeper.Keeper
+	IBCChannelKeeper *keeper.Keeper
 }
 
 func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
@@ -47,7 +47,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer),
 		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
-		ibcante.NewAnteDecorator(options.IBCChannelkeeper),
+		ibcante.NewAnteDecorator(options.IBCChannelKeeper),
 	}
 
 	return sdk.ChainAnteDecorators(anteDecorators...), nil

--- a/app/provider/ante_handler.go
+++ b/app/provider/ante_handler.go
@@ -13,7 +13,7 @@ import (
 type HandlerOptions struct {
 	ante.HandlerOptions
 
-	IBCChannelKeeper *ibckeeper.Keeper
+	IBCKeeper *ibckeeper.Keeper
 }
 
 func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
@@ -47,7 +47,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewSigGasConsumeDecorator(options.AccountKeeper, sigGasConsumer),
 		ante.NewSigVerificationDecorator(options.AccountKeeper, options.SignModeHandler),
 		ante.NewIncrementSequenceDecorator(options.AccountKeeper),
-		ibcante.NewAnteDecorator(options.IBCChannelKeeper),
+		ibcante.NewAnteDecorator(options.IBCKeeper),
 	}
 
 	return sdk.ChainAnteDecorators(anteDecorators...), nil

--- a/app/provider/app.go
+++ b/app/provider/app.go
@@ -659,7 +659,7 @@ func New(
 				SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
 				SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
 			},
-			IBCChannelKeeper: app.IBCKeeper.ChannelKeeper,
+			IBCChannelKeeper: app.IBCKeeper,
 		},
 	)
 	if err != nil {

--- a/app/provider/app.go
+++ b/app/provider/app.go
@@ -659,7 +659,7 @@ func New(
 				SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
 				SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
 			},
-			IBCChannelkeeper: app.IBCKeeper.ChannelKeeper,
+			IBCChannelKeeper: app.IBCKeeper.ChannelKeeper,
 		},
 	)
 	if err != nil {

--- a/app/provider/app.go
+++ b/app/provider/app.go
@@ -659,7 +659,7 @@ func New(
 				SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
 				SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
 			},
-			IBCChannelKeeper: app.IBCKeeper,
+			IBCKeeper: app.IBCKeeper,
 		},
 	)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
-	// github.com/cosmos/ibc-go/v3 => github.com/informalsystems/ibc-go/v3 v3.0.0-alpha1.0.20220505161112-1f45da82fc75
+	// github.com/cosmos/ibc-go/v3 => github.com/informalsystems/ibc-go/v3 v3.0.0-beta1.0.20220621053640-83aa2792664d
 	github.com/cosmos/ibc-go/v3 => /Users/danwt/Documents/work/informal-ibc-go
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/coinbase/rosetta-sdk-go v0.7.0 // indirect
-	github.com/confio/ics23/go v0.6.6 // indirect
+	github.com/confio/ics23/go v0.7.0 // indirect
 	github.com/cosmos/btcutil v1.0.4 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/iavl v0.17.3 // indirect
@@ -128,7 +128,8 @@ require (
 
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
-	github.com/cosmos/ibc-go/v3 => github.com/informalsystems/ibc-go/v3 v3.0.0-alpha1.0.20220505161112-1f45da82fc75
+	// github.com/cosmos/ibc-go/v3 => github.com/informalsystems/ibc-go/v3 v3.0.0-alpha1.0.20220505161112-1f45da82fc75
+	github.com/cosmos/ibc-go/v3 => /Users/danwt/Documents/work/informal-ibc-go
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -208,8 +208,9 @@ github.com/coinbase/rosetta-sdk-go v0.7.0 h1:lmTO/JEpCvZgpbkOITL95rA80CPKb5CtMzL
 github.com/coinbase/rosetta-sdk-go v0.7.0/go.mod h1:7nD3oBPIiHqhRprqvMgPoGxe/nyq3yftRmpsy29coWE=
 github.com/confio/ics23/go v0.0.0-20200817220745-f173e6211efb/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
 github.com/confio/ics23/go v0.6.3/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
-github.com/confio/ics23/go v0.6.6 h1:pkOy18YxxJ/r0XFDCnrl4Bjv6h4LkBSpLS6F38mrKL8=
 github.com/confio/ics23/go v0.6.6/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
+github.com/confio/ics23/go v0.7.0 h1:00d2kukk7sPoHWL4zZBZwzxnpA2pec1NPdwbSokJ5w8=
+github.com/confio/ics23/go v0.7.0/go.mod h1:E45NqnlpxGnpfTWL/xauN7MRwEE28T4Dd4uraToOaKg=
 github.com/containerd/console v1.0.2/go.mod h1:ytZPjGgY2oeTkAONYafi2kSj0aYggsf8acV1PGKCbzQ=
 github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.1.0 h1:UFRRY5JemiAhPZrr/uE0n8fMTLcZsUvySPr1+D7pgr8=
@@ -626,8 +627,6 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/informalsystems/ibc-go/v3 v3.0.0-alpha1.0.20220505161112-1f45da82fc75 h1:flrFoFHQYOW8ajzGsEdHURYu9TxOT+lqnrPmYj3AP24=
-github.com/informalsystems/ibc-go/v3 v3.0.0-alpha1.0.20220505161112-1f45da82fc75/go.mod h1:VFtxCEVvhoTFJP6HA3oT2N27bcV5JbV72AiyCO253/Y=
 github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e/go.mod h1:G1CVv03EnqU1wYL2dFwXxW2An0az9JTl/ZsqXQeBlkU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/x/ccv/consumer/module.go
+++ b/x/ccv/consumer/module.go
@@ -290,7 +290,8 @@ func (am AppModule) OnChanOpenAck(
 	ctx sdk.Context,
 	portID,
 	channelID string,
-	counterpartyMetadata string,
+	counterpartyChannelID string,
+	counterpartyVersion string,
 ) error {
 	// ensure provider channel has already been created
 	if providerChannel, ok := am.keeper.GetProviderChannel(ctx); ok {

--- a/x/ccv/consumer/module.go
+++ b/x/ccv/consumer/module.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/cosmos/interchain-security/x/ccv/consumer/keeper"
 	"github.com/cosmos/interchain-security/x/ccv/consumer/types"
-	providertypes "github.com/cosmos/interchain-security/x/ccv/provider/types"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
 )
 
@@ -299,18 +298,12 @@ func (am AppModule) OnChanOpenAck(
 			"provider channel: %s already established", providerChannel)
 	}
 
-	var md providertypes.HandshakeMetadata
-	if err := (&md).Unmarshal([]byte(counterpartyMetadata)); err != nil {
-		return sdkerrors.Wrapf(ccv.ErrInvalidHandshakeMetadata,
-			"error unmarshalling ibc-ack metadata: \n%v; \nmetadata: %v", err, counterpartyMetadata)
-	}
-
-	if md.Version != ccv.Version {
+	if counterpartyVersion != ccv.Version {
 		return sdkerrors.Wrapf(ccv.ErrInvalidVersion,
-			"invalid counterparty version: %s, expected %s", md.Version, ccv.Version)
+			"invalid counterparty version: %s, expected %s", counterpartyVersion, ccv.Version)
 	}
 
-	am.keeper.SetProviderFeePoolAddrStr(ctx, md.ProviderFeePoolAddr)
+	am.keeper.SetProviderFeePoolAddrStr(ctx, ProviderFeePoolAddr)
 
 	///////////////////////////////////////////////////
 	// Initialize distribution token transfer channel

--- a/x/ccv/consumer/module_test.go
+++ b/x/ccv/consumer/module_test.go
@@ -305,7 +305,14 @@ func (suite *ConsumerTestSuite) TestOnChanOpenAck() {
 
 			consumerModule := consumer.NewAppModule(suite.consumerChain.App.(*appConsumer.App).ConsumerKeeper)
 
-			err := consumerModule.OnChanOpenAck(suite.ctx, consumertypes.PortID, channelID, counterChannelID, suite.path.EndpointB.ChannelConfig.Version)
+			md := providertypes.HandshakeMetadata{
+				ProviderFeePoolAddr: "", // dummy address used
+				Version:             suite.path.EndpointB.ChannelConfig.Version,
+			}
+			mdBz, err := (&md).Marshal()
+			suite.Require().NoError(err)
+
+			err = consumerModule.OnChanOpenAck(suite.ctx, consumertypes.PortID, channelID, counterChannelID, string(mdBz))
 			if tc.expError {
 				suite.Require().Error(err)
 			} else {

--- a/x/ccv/consumer/module_test.go
+++ b/x/ccv/consumer/module_test.go
@@ -247,6 +247,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenTry() {
 
 func (suite *ConsumerTestSuite) TestOnChanOpenAck() {
 	channelID := "channel-1"
+	counterChannelID := "channel-2"
 	testCases := []struct {
 		name     string
 		setup    func(suite *ConsumerTestSuite)
@@ -304,14 +305,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenAck() {
 
 			consumerModule := consumer.NewAppModule(suite.consumerChain.App.(*appConsumer.App).ConsumerKeeper)
 
-			md := providertypes.HandshakeMetadata{
-				ProviderFeePoolAddr: "", // dummy address used
-				Version:             suite.path.EndpointB.ChannelConfig.Version,
-			}
-			mdBz, err := (&md).Marshal()
-			suite.Require().NoError(err)
-
-			err = consumerModule.OnChanOpenAck(suite.ctx, consumertypes.PortID, channelID, string(mdBz))
+			err := consumerModule.OnChanOpenAck(suite.ctx, consumertypes.PortID, channelID, counterChannelID, suite.path.EndpointB.ChannelConfig.Version)
 			if tc.expError {
 				suite.Require().Error(err)
 			} else {

--- a/x/ccv/provider/module.go
+++ b/x/ccv/provider/module.go
@@ -293,6 +293,7 @@ func (am AppModule) OnChanOpenAck(
 	ctx sdk.Context,
 	portID,
 	channelID string,
+	counterpartyChannelID string,
 	counterpartyVersion string,
 ) error {
 	return sdkerrors.Wrap(ccv.ErrInvalidChannelFlow, "channel handshake must be initiated by consumer chain")


### PR DESCRIPTION
Together with 

- https://github.com/informalsystems/ibc-go/pull/4

tackles

- https://github.com/cosmos/interchain-security/issues/107

# Explanation

Long story short, the v3.0.0 that cosmwasm uses changes the signature of `OnChanOpenAck` so this had to be changed on interchain-sec side. On ibc-go side I rebased onto v3.0.0. 

Note that

- https://github.com/informalsystems/ibc-go/pull/4

should be merged first as I'll have to change the version in go.mod here.