### PR TITLE
MVCC part B

### DIFF
--- a/app/consumer/app.go
+++ b/app/consumer/app.go
@@ -43,55 +43,33 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	crisiskeeper "github.com/cosmos/cosmos-sdk/x/crisis/keeper"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
-	distr "github.com/cosmos/cosmos-sdk/x/distribution"
-	distrclient "github.com/cosmos/cosmos-sdk/x/distribution/client"
-	distrkeeper "github.com/cosmos/cosmos-sdk/x/distribution/keeper"
-	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/evidence"
 	evidencekeeper "github.com/cosmos/cosmos-sdk/x/evidence/keeper"
 	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
 	"github.com/cosmos/cosmos-sdk/x/feegrant"
 	feegrantkeeper "github.com/cosmos/cosmos-sdk/x/feegrant/keeper"
 	feegrantmodule "github.com/cosmos/cosmos-sdk/x/feegrant/module"
-	"github.com/cosmos/cosmos-sdk/x/genutil"
-	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
-	"github.com/cosmos/cosmos-sdk/x/gov"
-	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
-	govkeeper "github.com/cosmos/cosmos-sdk/x/gov/keeper"
-	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
-	"github.com/cosmos/cosmos-sdk/x/mint"
-	mintkeeper "github.com/cosmos/cosmos-sdk/x/mint/keeper"
-	minttypes "github.com/cosmos/cosmos-sdk/x/mint/types"
 	"github.com/cosmos/cosmos-sdk/x/params"
-	paramsclient "github.com/cosmos/cosmos-sdk/x/params/client"
 	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
-	paramproposal "github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 	"github.com/cosmos/cosmos-sdk/x/slashing"
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/cosmos/cosmos-sdk/x/upgrade"
-	upgradeclient "github.com/cosmos/cosmos-sdk/x/upgrade/client"
 	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	"github.com/cosmos/ibc-go/v3/modules/apps/transfer"
 	ibctransferkeeper "github.com/cosmos/ibc-go/v3/modules/apps/transfer/keeper"
 	ibctransfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
 	ibc "github.com/cosmos/ibc-go/v3/modules/core"
-	ibcclient "github.com/cosmos/ibc-go/v3/modules/core/02-client"
-	ibcclientclient "github.com/cosmos/ibc-go/v3/modules/core/02-client/client"
-	ibcclienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 	ibcconnectiontypes "github.com/cosmos/ibc-go/v3/modules/core/03-connection/types"
 	porttypes "github.com/cosmos/ibc-go/v3/modules/core/05-port/types"
 	ibchost "github.com/cosmos/ibc-go/v3/modules/core/24-host"
 	ibckeeper "github.com/cosmos/ibc-go/v3/modules/core/keeper"
 	ibctesting "github.com/cosmos/ibc-go/v3/testing"
 	"github.com/gorilla/mux"
-	"github.com/gravity-devs/liquidity/x/liquidity"
-	liquiditykeeper "github.com/gravity-devs/liquidity/x/liquidity/keeper"
-	liquiditytypes "github.com/gravity-devs/liquidity/x/liquidity/types"
 	"github.com/rakyll/statik/fs"
 	"github.com/spf13/cast"
 	"github.com/tendermint/spm/cosmoscmd"
@@ -116,23 +94,6 @@ const (
 	AccountAddressPrefix = "cosmos"
 )
 
-// this line is used by starport scaffolding # stargate/wasm/app/enabledProposals
-
-func getGovProposalHandlers() []govclient.ProposalHandler {
-	var govProposalHandlers []govclient.ProposalHandler
-	// this line is used by starport scaffolding # stargate/app/govProposalHandlers
-
-	govProposalHandlers = append(govProposalHandlers,
-		paramsclient.ProposalHandler,
-		distrclient.ProposalHandler,
-		upgradeclient.ProposalHandler,
-		upgradeclient.CancelProposalHandler,
-		// this line is used by starport scaffolding # stargate/app/govProposalHandler
-	)
-
-	return govProposalHandlers
-}
-
 var (
 	// DefaultNodeHome default home directories for the application daemon
 	DefaultNodeHome string
@@ -142,20 +103,9 @@ var (
 	// and genesis verification.
 	ModuleBasics = module.NewBasicManager(
 		auth.AppModuleBasic{},
-		genutil.AppModuleBasic{},
 		bank.AppModuleBasic{},
 		capability.AppModuleBasic{},
 		ccvstaking.AppModuleBasic{},
-		mint.AppModuleBasic{},
-		distr.AppModuleBasic{},
-		gov.NewAppModuleBasic(
-			paramsclient.ProposalHandler,
-			distrclient.ProposalHandler,
-			upgradeclient.ProposalHandler,
-			upgradeclient.CancelProposalHandler,
-			ibcclientclient.UpdateClientProposalHandler,
-			ibcclientclient.UpgradeProposalHandler,
-		),
 		params.AppModuleBasic{},
 		crisis.AppModuleBasic{},
 		slashing.AppModuleBasic{},
@@ -166,7 +116,6 @@ var (
 		evidence.AppModuleBasic{},
 		transfer.AppModuleBasic{},
 		vesting.AppModuleBasic{},
-		liquidity.AppModuleBasic{},
 		//router.AppModuleBasic{},
 		ibcconsumer.AppModuleBasic{},
 	)
@@ -176,12 +125,8 @@ var (
 		authtypes.FeeCollectorName:                    nil,
 		ibcconsumertypes.ConsumerRedistributeName:     nil,
 		ibcconsumertypes.ConsumerToSendToProviderName: nil,
-		distrtypes.ModuleName:                         nil,
-		minttypes.ModuleName:                          {authtypes.Minter},
 		stakingtypes.BondedPoolName:                   {authtypes.Burner, authtypes.Staking},
 		stakingtypes.NotBondedPoolName:                {authtypes.Burner, authtypes.Staking},
-		govtypes.ModuleName:                           {authtypes.Burner},
-		liquiditytypes.ModuleName:                     {authtypes.Minter, authtypes.Burner},
 		ibctransfertypes.ModuleName:                   {authtypes.Minter, authtypes.Burner},
 	}
 )
@@ -215,24 +160,20 @@ type App struct { // nolint: golint
 	CapabilityKeeper *capabilitykeeper.Keeper
 	StakingKeeper    stakingkeeper.Keeper
 	SlashingKeeper   slashingkeeper.Keeper
-	MintKeeper       mintkeeper.Keeper
 
 	// NOTE the distribution keeper should either be removed
 	// from consumer chain or set to use an independant
 	// different fee-pool from the consumer chain ConsumerKeeper
-	DistrKeeper distrkeeper.Keeper
 
-	GovKeeper       govkeeper.Keeper
-	CrisisKeeper    crisiskeeper.Keeper
-	UpgradeKeeper   upgradekeeper.Keeper
-	ParamsKeeper    paramskeeper.Keeper
-	IBCKeeper       *ibckeeper.Keeper // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
-	EvidenceKeeper  evidencekeeper.Keeper
-	TransferKeeper  ibctransferkeeper.Keeper
-	FeeGrantKeeper  feegrantkeeper.Keeper
-	AuthzKeeper     authzkeeper.Keeper
-	LiquidityKeeper liquiditykeeper.Keeper
-	ConsumerKeeper  ibcconsumerkeeper.Keeper
+	CrisisKeeper   crisiskeeper.Keeper
+	UpgradeKeeper  upgradekeeper.Keeper
+	ParamsKeeper   paramskeeper.Keeper
+	IBCKeeper      *ibckeeper.Keeper // IBC Keeper must be a pointer in the app, so we can SetRouter on it correctly
+	EvidenceKeeper evidencekeeper.Keeper
+	TransferKeeper ibctransferkeeper.Keeper
+	FeeGrantKeeper feegrantkeeper.Keeper
+	AuthzKeeper    authzkeeper.Keeper
+	ConsumerKeeper ibcconsumerkeeper.Keeper
 
 	// make scoped keepers public for test purposes
 	ScopedIBCKeeper         capabilitykeeper.ScopedKeeper
@@ -280,10 +221,9 @@ func New(
 	bApp.SetInterfaceRegistry(interfaceRegistry)
 
 	keys := sdk.NewKVStoreKeys(
-		authtypes.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey,
-		minttypes.StoreKey, distrtypes.StoreKey, slashingtypes.StoreKey,
-		govtypes.StoreKey, paramstypes.StoreKey, ibchost.StoreKey, upgradetypes.StoreKey,
-		evidencetypes.StoreKey, liquiditytypes.StoreKey, ibctransfertypes.StoreKey,
+		authtypes.StoreKey, banktypes.StoreKey, stakingtypes.StoreKey, slashingtypes.StoreKey,
+		paramstypes.StoreKey, ibchost.StoreKey, upgradetypes.StoreKey,
+		evidencetypes.StoreKey, ibctransfertypes.StoreKey,
 		capabilitytypes.StoreKey, feegrant.StoreKey, authzkeeper.StoreKey,
 		ibcconsumertypes.StoreKey,
 	)
@@ -366,25 +306,6 @@ func New(
 		app.BankKeeper,
 		app.GetSubspace(stakingtypes.ModuleName),
 	)
-	app.MintKeeper = mintkeeper.NewKeeper(
-		appCodec,
-		keys[minttypes.StoreKey],
-		app.GetSubspace(minttypes.ModuleName),
-		&stakingKeeper,
-		app.AccountKeeper,
-		app.BankKeeper,
-		authtypes.FeeCollectorName,
-	)
-	app.DistrKeeper = distrkeeper.NewKeeper(
-		appCodec,
-		keys[distrtypes.StoreKey],
-		app.GetSubspace(distrtypes.ModuleName),
-		app.AccountKeeper,
-		app.BankKeeper,
-		&stakingKeeper,
-		authtypes.FeeCollectorName,
-		app.ModuleAccountAddrs(),
-	)
 	app.SlashingKeeper = slashingkeeper.NewKeeper(
 		appCodec,
 		keys[slashingtypes.StoreKey],
@@ -404,20 +325,11 @@ func New(
 		homePath,
 		app.BaseApp,
 	)
-	app.LiquidityKeeper = liquiditykeeper.NewKeeper(
-		appCodec,
-		keys[liquiditytypes.StoreKey],
-		app.GetSubspace(liquiditytypes.ModuleName),
-		app.BankKeeper,
-		app.AccountKeeper,
-		app.DistrKeeper,
-	)
 
 	// register the staking hooks
 	// NOTE: stakingKeeper above is passed by reference, so that it will contain these hooks
 	app.StakingKeeper = *stakingKeeper.SetHooks(
 		stakingtypes.NewMultiStakingHooks(
-			app.DistrKeeper.Hooks(),
 			app.SlashingKeeper.Hooks(),
 		),
 	)
@@ -462,26 +374,6 @@ func New(
 	app.ConsumerKeeper = *app.ConsumerKeeper.SetHooks(app.SlashingKeeper.Hooks())
 	consumerModule := ibcconsumer.NewAppModule(app.ConsumerKeeper)
 
-	// register the proposal types
-	govRouter := govtypes.NewRouter()
-	govRouter.
-		AddRoute(govtypes.RouterKey, govtypes.ProposalHandler).
-		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.ParamsKeeper)).
-		AddRoute(distrtypes.RouterKey, distr.NewCommunityPoolSpendProposalHandler(app.DistrKeeper)).
-		AddRoute(upgradetypes.RouterKey, upgrade.NewSoftwareUpgradeProposalHandler(app.UpgradeKeeper)).
-		AddRoute(ibchost.RouterKey, ibcclient.NewClientProposalHandler(app.IBCKeeper.ClientKeeper)).
-		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(app.IBCKeeper.ClientKeeper))
-
-	app.GovKeeper = govkeeper.NewKeeper(
-		appCodec,
-		keys[govtypes.StoreKey],
-		app.GetSubspace(govtypes.ModuleName),
-		app.AccountKeeper,
-		app.BankKeeper,
-		&stakingKeeper,
-		govRouter,
-	)
-
 	app.TransferKeeper = ibctransferkeeper.NewKeeper(
 		appCodec,
 		keys[ibctransfertypes.StoreKey],
@@ -517,21 +409,12 @@ func New(
 	// NOTE: Any module instantiated in the module manager that is later modified
 	// must be passed by reference here.
 	app.MM = module.NewManager(
-		genutil.NewAppModule(
-			app.AccountKeeper,
-			app.StakingKeeper,
-			app.BaseApp.DeliverTx,
-			encodingConfig.TxConfig,
-		),
 		auth.NewAppModule(appCodec, app.AccountKeeper, nil),
 		vesting.NewAppModule(app.AccountKeeper, app.BankKeeper),
 		bank.NewAppModule(appCodec, app.BankKeeper, app.AccountKeeper),
 		capability.NewAppModule(appCodec, *app.CapabilityKeeper),
 		crisis.NewAppModule(&app.CrisisKeeper, skipGenesisInvariants),
-		gov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper),
-		mint.NewAppModule(appCodec, app.MintKeeper, app.AccountKeeper),
 		slashing.NewAppModule(appCodec, app.SlashingKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
-		distr.NewAppModule(appCodec, app.DistrKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
 		ccvstaking.NewAppModule(appCodec, app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
 		upgrade.NewAppModule(app.UpgradeKeeper),
 		evidence.NewAppModule(app.EvidenceKeeper),
@@ -539,7 +422,6 @@ func New(
 		authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
 		ibc.NewAppModule(app.IBCKeeper),
 		params.NewAppModule(app.ParamsKeeper),
-		liquidity.NewAppModule(appCodec, app.LiquidityKeeper, app.AccountKeeper, app.BankKeeper, app.DistrKeeper),
 		transferModule,
 		consumerModule,
 	)
@@ -554,17 +436,12 @@ func New(
 		upgradetypes.ModuleName,
 		capabilitytypes.ModuleName,
 		crisistypes.ModuleName,
-		govtypes.ModuleName,
 		stakingtypes.ModuleName,
-		liquiditytypes.ModuleName,
 		ibctransfertypes.ModuleName,
 		ibchost.ModuleName,
 		authtypes.ModuleName,
 		banktypes.ModuleName,
-		distrtypes.ModuleName,
 		slashingtypes.ModuleName,
-		minttypes.ModuleName,
-		genutiltypes.ModuleName,
 		evidencetypes.ModuleName,
 		authz.ModuleName,
 		feegrant.ModuleName,
@@ -574,9 +451,7 @@ func New(
 	)
 	app.MM.SetOrderEndBlockers(
 		crisistypes.ModuleName,
-		govtypes.ModuleName,
 		stakingtypes.ModuleName,
-		liquiditytypes.ModuleName,
 		ibctransfertypes.ModuleName,
 		ibchost.ModuleName,
 		feegrant.ModuleName,
@@ -584,10 +459,7 @@ func New(
 		capabilitytypes.ModuleName,
 		authtypes.ModuleName,
 		banktypes.ModuleName,
-		distrtypes.ModuleName,
 		slashingtypes.ModuleName,
-		minttypes.ModuleName,
-		genutiltypes.ModuleName,
 		evidencetypes.ModuleName,
 		paramstypes.ModuleName,
 		upgradetypes.ModuleName,
@@ -603,21 +475,16 @@ func New(
 	// can do so safely.
 	app.MM.SetOrderInitGenesis(
 		capabilitytypes.ModuleName,
-		banktypes.ModuleName,
-		distrtypes.ModuleName,
-		stakingtypes.ModuleName,
+		banktypes.ModuleName, stakingtypes.ModuleName,
 		slashingtypes.ModuleName,
-		govtypes.ModuleName,
-		minttypes.ModuleName,
 		crisistypes.ModuleName,
 		ibchost.ModuleName,
 		evidencetypes.ModuleName,
-		liquiditytypes.ModuleName,
 		ibctransfertypes.ModuleName,
 		feegrant.ModuleName,
 		authz.ModuleName,
 		authtypes.ModuleName,
-		genutiltypes.ModuleName,
+
 		paramstypes.ModuleName,
 		upgradetypes.ModuleName,
 		vestingtypes.ModuleName,
@@ -640,15 +507,9 @@ func New(
 		capability.NewAppModule(appCodec, *app.CapabilityKeeper),
 		feegrantmodule.NewAppModule(appCodec, app.AccountKeeper, app.BankKeeper, app.FeeGrantKeeper, app.interfaceRegistry),
 		authzmodule.NewAppModule(appCodec, app.AuthzKeeper, app.AccountKeeper, app.BankKeeper, app.interfaceRegistry),
-		gov.NewAppModule(appCodec, app.GovKeeper, app.AccountKeeper, app.BankKeeper),
-		mint.NewAppModule(appCodec, app.MintKeeper, app.AccountKeeper),
-		ccvstaking.NewAppModule(appCodec, app.StakingKeeper, app.AccountKeeper, app.BankKeeper),
-		distr.NewAppModule(appCodec, app.DistrKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
-		slashing.NewAppModule(appCodec, app.SlashingKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
+		ccvstaking.NewAppModule(appCodec, app.StakingKeeper, app.AccountKeeper, app.BankKeeper), slashing.NewAppModule(appCodec, app.SlashingKeeper, app.AccountKeeper, app.BankKeeper, app.StakingKeeper),
 		params.NewAppModule(app.ParamsKeeper),
-		evidence.NewAppModule(app.EvidenceKeeper),
-		liquidity.NewAppModule(appCodec, app.LiquidityKeeper, app.AccountKeeper, app.BankKeeper, app.DistrKeeper),
-		ibc.NewAppModule(app.IBCKeeper),
+		evidence.NewAppModule(app.EvidenceKeeper), ibc.NewAppModule(app.IBCKeeper),
 		transferModule,
 	)
 
@@ -903,12 +764,8 @@ func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino
 	paramsKeeper.Subspace(authtypes.ModuleName)
 	paramsKeeper.Subspace(banktypes.ModuleName)
 	paramsKeeper.Subspace(stakingtypes.ModuleName)
-	paramsKeeper.Subspace(minttypes.ModuleName)
-	paramsKeeper.Subspace(distrtypes.ModuleName)
 	paramsKeeper.Subspace(slashingtypes.ModuleName)
-	paramsKeeper.Subspace(govtypes.ModuleName).WithKeyTable(govtypes.ParamKeyTable())
 	paramsKeeper.Subspace(crisistypes.ModuleName)
-	paramsKeeper.Subspace(liquiditytypes.ModuleName)
 	paramsKeeper.Subspace(ibctransfertypes.ModuleName)
 	paramsKeeper.Subspace(ibchost.ModuleName)
 	paramsKeeper.Subspace(ibcconsumertypes.ModuleName)

--- a/app/consumer/export.go
+++ b/app/consumer/export.go
@@ -35,7 +35,7 @@ func (app *App) ExportAppStateAndValidators(
 		return servertypes.ExportedApp{}, err
 	}
 
-	validators, err := app.WriteValidators(ctx)
+	validators, err := app.GetValidatorSet(ctx)
 	if err != nil {
 		return servertypes.ExportedApp{}, err
 	}
@@ -183,7 +183,8 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 	)
 }
 
-func (app *App) WriteValidators(ctx sdk.Context) ([]tmtypes.GenesisValidator, error) {
+// GetValidatorSet returns a slice of bonded validators.
+func (app *App) GetValidatorSet(ctx sdk.Context) ([]tmtypes.GenesisValidator, error) {
 	cVals := app.ConsumerKeeper.GetAllCCValidator(ctx)
 	if len(cVals) == 0 {
 		return nil, fmt.Errorf("empty validator set")

--- a/app/consumer/export.go
+++ b/app/consumer/export.go
@@ -75,50 +75,50 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 	/* Handle fee distribution state. */
 
 	// withdraw all validator commission
-	app.StakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
-		_, err := app.DistrKeeper.WithdrawValidatorCommission(ctx, val.GetOperator())
-		if err != nil {
-			panic(err)
-		}
-		return false
-	})
+	// app.StakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
+	// 	_, err := app.DistrKeeper.WithdrawValidatorCommission(ctx, val.GetOperator())
+	// 	if err != nil {
+	// 		panic(err)
+	// 	}
+	// 	return false
+	// })
 
 	// withdraw all delegator rewards
-	dels := app.StakingKeeper.GetAllDelegations(ctx)
-	for _, delegation := range dels {
-		_, err := app.DistrKeeper.WithdrawDelegationRewards(ctx, delegation.GetDelegatorAddr(), delegation.GetValidatorAddr())
-		if err != nil {
-			panic(err)
-		}
-	}
+	// dels := app.StakingKeeper.GetAllDelegations(ctx)
+	// for _, delegation := range dels {
+	// 	_, err := app.DistrKeeper.WithdrawDelegationRewards(ctx, delegation.GetDelegatorAddr(), delegation.GetValidatorAddr())
+	// 	if err != nil {
+	// 		panic(err)
+	// 	}
+	// }
 
 	// clear validator slash events
-	app.DistrKeeper.DeleteAllValidatorSlashEvents(ctx)
+	// app.DistrKeeper.DeleteAllValidatorSlashEvents(ctx)
 
 	// clear validator historical rewards
-	app.DistrKeeper.DeleteAllValidatorHistoricalRewards(ctx)
+	// app.DistrKeeper.DeleteAllValidatorHistoricalRewards(ctx)
 
 	// set context height to zero
 	height := ctx.BlockHeight()
 	ctx = ctx.WithBlockHeight(0)
 
 	// reinitialize all validators
-	app.StakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
-		// donate any unwithdrawn outstanding reward fraction tokens to the community pool
-		scraps := app.DistrKeeper.GetValidatorOutstandingRewardsCoins(ctx, val.GetOperator())
-		feePool := app.DistrKeeper.GetFeePool(ctx)
-		feePool.CommunityPool = feePool.CommunityPool.Add(scraps...)
-		app.DistrKeeper.SetFeePool(ctx, feePool)
+	// app.StakingKeeper.IterateValidators(ctx, func(_ int64, val stakingtypes.ValidatorI) (stop bool) {
+	// 	// donate any unwithdrawn outstanding reward fraction tokens to the community pool
+	// 	scraps := app.DistrKeeper.GetValidatorOutstandingRewardsCoins(ctx, val.GetOperator())
+	// 	feePool := app.DistrKeeper.GetFeePool(ctx)
+	// 	feePool.CommunityPool = feePool.CommunityPool.Add(scraps...)
+	// 	app.DistrKeeper.SetFeePool(ctx, feePool)
 
-		app.DistrKeeper.Hooks().AfterValidatorCreated(ctx, val.GetOperator())
-		return false
-	})
+	// 	app.DistrKeeper.Hooks().AfterValidatorCreated(ctx, val.GetOperator())
+	// 	return false
+	// })
 
 	// reinitialize all delegations
-	for _, del := range dels {
-		app.DistrKeeper.Hooks().BeforeDelegationCreated(ctx, del.GetDelegatorAddr(), del.GetValidatorAddr())
-		app.DistrKeeper.Hooks().AfterDelegationModified(ctx, del.GetDelegatorAddr(), del.GetValidatorAddr())
-	}
+	// for _, del := range dels {
+	// 	app.DistrKeeper.Hooks().BeforeDelegationCreated(ctx, del.GetDelegatorAddr(), del.GetValidatorAddr())
+	// 	app.DistrKeeper.Hooks().AfterDelegationModified(ctx, del.GetDelegatorAddr(), del.GetValidatorAddr())
+	// }
 
 	// reset context height
 	ctx = ctx.WithBlockHeight(height)

--- a/app/consumer/export.go
+++ b/app/consumer/export.go
@@ -2,15 +2,14 @@ package app
 
 import (
 	"encoding/json"
-	"log"
+	"fmt"
 
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
-	"github.com/cosmos/cosmos-sdk/x/staking"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	tmtypes "github.com/tendermint/tendermint/types"
 )
 
 // ExportAppStateAndValidators exports the state of the application for a genesis
@@ -36,7 +35,7 @@ func (app *App) ExportAppStateAndValidators(
 		return servertypes.ExportedApp{}, err
 	}
 
-	validators, err := staking.WriteValidators(ctx, app.StakingKeeper)
+	validators, err := app.WriteValidators(ctx)
 	if err != nil {
 		return servertypes.ExportedApp{}, err
 	}
@@ -52,22 +51,22 @@ func (app *App) ExportAppStateAndValidators(
 // NOTE zero height genesis is a temporary feature which will be deprecated
 //      in favour of export at a block height
 func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []string) {
-	applyAllowedAddrs := false
+	// applyAllowedAddrs := false
 
 	// check if there is a allowed address list
-	if len(jailAllowedAddrs) > 0 {
-		applyAllowedAddrs = true
-	}
+	// if len(jailAllowedAddrs) > 0 {
+	// 	applyAllowedAddrs = true
+	// }
 
-	allowedAddrsMap := make(map[string]bool)
+	// allowedAddrsMap := make(map[string]bool)
 
-	for _, addr := range jailAllowedAddrs {
-		_, err := sdk.ValAddressFromBech32(addr)
-		if err != nil {
-			log.Fatal(err)
-		}
-		allowedAddrsMap[addr] = true
-	}
+	// for _, addr := range jailAllowedAddrs {
+	// 	_, err := sdk.ValAddressFromBech32(addr)
+	// 	if err != nil {
+	// 		log.Fatal(err)
+	// 	}
+	// 	allowedAddrsMap[addr] = true
+	// }
 
 	/* Just to be safe, assert the invariants on current state. */
 	app.CrisisKeeper.AssertInvariants(ctx)
@@ -126,50 +125,50 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 	/* Handle staking state. */
 
 	// iterate through redelegations, reset creation height
-	app.StakingKeeper.IterateRedelegations(ctx, func(_ int64, red stakingtypes.Redelegation) (stop bool) {
-		for i := range red.Entries {
-			red.Entries[i].CreationHeight = 0
-		}
-		app.StakingKeeper.SetRedelegation(ctx, red)
-		return false
-	})
+	// app.StakingKeeper.IterateRedelegations(ctx, func(_ int64, red stakingtypes.Redelegation) (stop bool) {
+	// 	for i := range red.Entries {
+	// 		red.Entries[i].CreationHeight = 0
+	// 	}
+	// 	app.StakingKeeper.SetRedelegation(ctx, red)
+	// 	return false
+	// })
 
 	// iterate through unbonding delegations, reset creation height
-	app.StakingKeeper.IterateUnbondingDelegations(ctx, func(_ int64, ubd stakingtypes.UnbondingDelegation) (stop bool) {
-		for i := range ubd.Entries {
-			ubd.Entries[i].CreationHeight = 0
-		}
-		app.StakingKeeper.SetUnbondingDelegation(ctx, ubd)
-		return false
-	})
+	// app.StakingKeeper.IterateUnbondingDelegations(ctx, func(_ int64, ubd stakingtypes.UnbondingDelegation) (stop bool) {
+	// 	for i := range ubd.Entries {
+	// 		ubd.Entries[i].CreationHeight = 0
+	// 	}
+	// 	app.StakingKeeper.SetUnbondingDelegation(ctx, ubd)
+	// 	return false
+	// })
 
 	// Iterate through validators by power descending, reset bond heights, and
 	// update bond intra-tx counters.
-	store := ctx.KVStore(app.keys[stakingtypes.StoreKey])
-	iter := sdk.KVStoreReversePrefixIterator(store, stakingtypes.ValidatorsKey)
-	counter := int16(0)
+	// store := ctx.KVStore(app.keys[stakingtypes.StoreKey])
+	// iter := sdk.KVStoreReversePrefixIterator(store, stakingtypes.ValidatorsKey)
+	// counter := int16(0)
 
-	for ; iter.Valid(); iter.Next() {
-		addr := sdk.ValAddress(iter.Key()[1:])
-		validator, found := app.StakingKeeper.GetValidator(ctx, addr)
-		if !found {
-			panic("expected validator, not found")
-		}
+	// for ; iter.Valid(); iter.Next() {
+	// 	addr := sdk.ValAddress(iter.Key()[1:])
+	// 	validator, found := app.StakingKeeper.GetValidator(ctx, addr)
+	// 	if !found {
+	// 		panic("expected validator, not found")
+	// 	}
 
-		validator.UnbondingHeight = 0
-		if applyAllowedAddrs && !allowedAddrsMap[addr.String()] {
-			validator.Jailed = true
-		}
+	// 	validator.UnbondingHeight = 0
+	// 	if applyAllowedAddrs && !allowedAddrsMap[addr.String()] {
+	// 		validator.Jailed = true
+	// 	}
 
-		app.StakingKeeper.SetValidator(ctx, validator)
-		counter++
-	}
+	// 	app.StakingKeeper.SetValidator(ctx, validator)
+	// 	counter++
+	// }
 
-	iter.Close()
+	// iter.Close()
 
-	if _, err := app.StakingKeeper.ApplyAndReturnValidatorSetUpdates(ctx); err != nil {
-		panic(err)
-	}
+	// if _, err := app.StakingKeeper.ApplyAndReturnValidatorSetUpdates(ctx); err != nil {
+	// 	panic(err)
+	// }
 
 	/* Handle slashing state. */
 
@@ -182,4 +181,17 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 			return false
 		},
 	)
+}
+
+func (app *App) WriteValidators(ctx sdk.Context) ([]tmtypes.GenesisValidator, error) {
+	cVals := app.ConsumerKeeper.GetAllCCValidator(ctx)
+	if len(cVals) == 0 {
+		return nil, fmt.Errorf("empty validator set")
+	}
+
+	vals := []tmtypes.GenesisValidator{}
+	for _, v := range cVals {
+		vals = append(vals, tmtypes.GenesisValidator{Address: v.Address, Power: v.Power})
+	}
+	return vals, nil
 }

--- a/app/provider/app.go
+++ b/app/provider/app.go
@@ -816,7 +816,7 @@ func (app *App) GetBaseApp() *baseapp.BaseApp {
 }
 
 // GetStakingKeeper implements the TestingApp interface.
-func (app *App) GetStakingKeeper() stakingkeeper.Keeper {
+func (app *App) GetStakingKeeper() ibcclienttypes.StakingKeeper {
 	return app.StakingKeeper
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cosmos/interchain-security
 go 1.17
 
 require (
-	github.com/cosmos/cosmos-sdk v0.45.2-0.20220523134417-4cc285142ba7
+	github.com/cosmos/cosmos-sdk v0.45.2-0.20220613134718-c783aea68fbd
 	github.com/cosmos/ibc-go v1.2.2
 	github.com/cosmos/ibc-go/v3 v3.0.0-alpha1.0.20220210141024-fb2f0416254b
 	github.com/gogo/protobuf v1.3.3
@@ -128,7 +128,7 @@ require (
 
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
-	github.com/cosmos/ibc-go/v3 => github.com/informalsystems/ibc-go/v3 v3.0.0-alpha1.0.20220505161112-1f45da82fc75
+	github.com/cosmos/ibc-go/v3 => github.com/informalsystems/ibc-go/v3 v3.0.0-alpha1.0.20220613150813-131733136a7a
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,8 @@ github.com/cosmos/cosmos-sdk v0.44.2/go.mod h1:fwQJdw+aECatpTvQTo1tSfHEsxACdZYU8
 github.com/cosmos/cosmos-sdk v0.44.3/go.mod h1:bA3+VenaR/l/vDiYzaiwbWvRPWHMBX2jG0ygiFtiBp0=
 github.com/cosmos/cosmos-sdk v0.45.0/go.mod h1:XXS/asyCqWNWkx2rW6pSuen+EVcpAFxq6khrhnZgHaQ=
 github.com/cosmos/cosmos-sdk v0.45.2-0.20220210215401-58c103ca4daf/go.mod h1:XXS/asyCqWNWkx2rW6pSuen+EVcpAFxq6khrhnZgHaQ=
-github.com/cosmos/cosmos-sdk v0.45.2-0.20220523134417-4cc285142ba7 h1:Qtw4vUwBtOYFD6+3Ril6OGxAgVq9U1T4KZYYHMuVOD4=
-github.com/cosmos/cosmos-sdk v0.45.2-0.20220523134417-4cc285142ba7/go.mod h1:XXS/asyCqWNWkx2rW6pSuen+EVcpAFxq6khrhnZgHaQ=
+github.com/cosmos/cosmos-sdk v0.45.2-0.20220613134718-c783aea68fbd h1:RnlmTvxpFerW6SGfXGAiwfOjnr5svuRKtmuxCAYoO60=
+github.com/cosmos/cosmos-sdk v0.45.2-0.20220613134718-c783aea68fbd/go.mod h1:XXS/asyCqWNWkx2rW6pSuen+EVcpAFxq6khrhnZgHaQ=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
@@ -626,8 +626,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/informalsystems/ibc-go/v3 v3.0.0-alpha1.0.20220505161112-1f45da82fc75 h1:flrFoFHQYOW8ajzGsEdHURYu9TxOT+lqnrPmYj3AP24=
-github.com/informalsystems/ibc-go/v3 v3.0.0-alpha1.0.20220505161112-1f45da82fc75/go.mod h1:VFtxCEVvhoTFJP6HA3oT2N27bcV5JbV72AiyCO253/Y=
+github.com/informalsystems/ibc-go/v3 v3.0.0-alpha1.0.20220613150813-131733136a7a h1:Pnm4PT7kdDab6Qe118BsLimhd1OTEdEVsNl8Wn6VLX4=
+github.com/informalsystems/ibc-go/v3 v3.0.0-alpha1.0.20220613150813-131733136a7a/go.mod h1:VFtxCEVvhoTFJP6HA3oT2N27bcV5JbV72AiyCO253/Y=
 github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e/go.mod h1:G1CVv03EnqU1wYL2dFwXxW2An0az9JTl/ZsqXQeBlkU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/x/ccv/consumer/keeper/keeper_test.go
+++ b/x/ccv/consumer/keeper/keeper_test.go
@@ -90,7 +90,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 	// set chains sender account number
 	// TODO: to be fixed in #151
 	suite.path.EndpointB.Chain.SenderAccount.SetAccountNumber(6)
-	suite.path.EndpointA.Chain.SenderAccount.SetAccountNumber(3)
+	suite.path.EndpointA.Chain.SenderAccount.SetAccountNumber(1)
 
 	// create consumer client on provider chain and set as consumer client for consumer chainID in provider keeper.
 	suite.path.EndpointB.CreateClient()

--- a/x/ccv/consumer/keeper/keeper_test.go
+++ b/x/ccv/consumer/keeper/keeper_test.go
@@ -83,12 +83,14 @@ func (suite *KeeperTestSuite) SetupTest() {
 	if !ok {
 		panic("must already have provider client on consumer chain")
 	}
+
 	// set consumer endpoint's clientID
 	suite.path.EndpointA.ClientID = providerClient
 
-	// TODO: No idea why or how this works, but it seems that it needs to be done.
+	// set chains sender account number
+	// TODO: to be fixed in #151
 	suite.path.EndpointB.Chain.SenderAccount.SetAccountNumber(6)
-	suite.path.EndpointA.Chain.SenderAccount.SetAccountNumber(6)
+	suite.path.EndpointA.Chain.SenderAccount.SetAccountNumber(3)
 
 	// create consumer client on provider chain and set as consumer client for consumer chainID in provider keeper.
 	suite.path.EndpointB.CreateClient()

--- a/x/ccv/consumer/keeper/validators.go
+++ b/x/ccv/consumer/keeper/validators.go
@@ -51,7 +51,9 @@ func (k Keeper) ApplyCCValidatorChanges(ctx sdk.Context, changes []abci.Validato
 	}
 }
 
-// IterateValidators - unimplemented on CCV keeper but perform a no-op in order to pass the slashing module InitGenesis
+// IterateValidators - unimplemented on CCV keeper but perform a no-op in order to pass the slashing module InitGenesis.
+// It is allowed since the condition verifying validator public keys in HandleValidatorSignature (x/slashing/keeper/infractions.go) is removed
+// therefore it isn't required to store any validator public keys to the slashing states during genesis.
 func (k Keeper) IterateValidators(sdk.Context, func(index int64, validator stakingtypes.ValidatorI) (stop bool)) {
 }
 
@@ -103,7 +105,7 @@ func (k Keeper) MaxValidators(sdk.Context) uint32 {
 	panic("unimplemented on CCV keeper")
 }
 
-// UnbondingTime return consumer unbonding time
+// UnbondingTime returns consumer unbonding time
 func (k Keeper) UnbondingTime(_ sdk.Context) time.Duration {
 	return types.UnbondingTime
 }

--- a/x/ccv/consumer/keeper/validators.go
+++ b/x/ccv/consumer/keeper/validators.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"fmt"
+	"time"
 
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 
@@ -51,9 +52,8 @@ func (k Keeper) ApplyCCValidatorChanges(ctx sdk.Context, changes []abci.Validato
 	}
 }
 
-// IterateValidators - unimplemented on CCV keeper
+// IterateValidators - unimplemented on CCV keeper but perform a no-op in order to pass the slashing module InitGenesis
 func (k Keeper) IterateValidators(sdk.Context, func(index int64, validator stakingtypes.ValidatorI) (stop bool)) {
-	panic("unimplemented on CCV keeper")
 }
 
 // Validator - unimplemented on CCV keeper
@@ -102,6 +102,11 @@ func (k Keeper) Delegation(sdk.Context, sdk.AccAddress, sdk.ValAddress) stakingt
 // MaxValidators - unimplemented on CCV keeper
 func (k Keeper) MaxValidators(sdk.Context) uint32 {
 	panic("unimplemented on CCV keeper")
+}
+
+// UnbondingTime return consumer unbonding time
+func (k Keeper) UnbondingTime(_ sdk.Context) time.Duration {
+	return types.UnbondingTime
 }
 
 // GetHistoricalInfo gets the historical info at a given height

--- a/x/ccv/consumer/module_test.go
+++ b/x/ccv/consumer/module_test.go
@@ -83,12 +83,14 @@ func (suite *ConsumerTestSuite) SetupTest() {
 	if !ok {
 		panic("must already have provider client on consumer chain")
 	}
+
 	// set consumer endpoint's clientID
 	path.EndpointA.ClientID = providerClient
 
-	// TODO: No idea why or how this works, but it seems that it needs to be done.
+	// set chains sender account number
+	// TODO: to be fixed in #151
 	path.EndpointB.Chain.SenderAccount.SetAccountNumber(6)
-	path.EndpointA.Chain.SenderAccount.SetAccountNumber(6)
+	path.EndpointA.Chain.SenderAccount.SetAccountNumber(3)
 
 	// create consumer client on provider chain and set as consumer client for consumer chainID in provider keeper.
 	path.EndpointB.CreateClient()

--- a/x/ccv/consumer/module_test.go
+++ b/x/ccv/consumer/module_test.go
@@ -90,7 +90,7 @@ func (suite *ConsumerTestSuite) SetupTest() {
 	// set chains sender account number
 	// TODO: to be fixed in #151
 	path.EndpointB.Chain.SenderAccount.SetAccountNumber(6)
-	path.EndpointA.Chain.SenderAccount.SetAccountNumber(3)
+	path.EndpointA.Chain.SenderAccount.SetAccountNumber(1)
 
 	// create consumer client on provider chain and set as consumer client for consumer chainID in provider keeper.
 	path.EndpointB.CreateClient()

--- a/x/ccv/consumer/types/keys.go
+++ b/x/ccv/consumer/types/keys.go
@@ -37,7 +37,7 @@ const (
 	// UnbondingPacketPrefix is the key prefix that will store the unbonding packet at the given sequence
 	UnbondingPacketPrefix = "unbondingpacket"
 
-	// UnbondingTimePrefix is the key prefix that will store unbonding time fqor each recently received packet.
+	// UnbondingTimePrefix is the key prefix that will store unbonding time for each recently received packet.
 	UnbondingTimePrefix = "unbondingtime"
 
 	// UnbondingTime is set to 3 weeks

--- a/x/ccv/consumer/types/keys.go
+++ b/x/ccv/consumer/types/keys.go
@@ -41,7 +41,7 @@ const (
 	UnbondingTimePrefix = "unbondingtime"
 
 	// UnbondingTime is set to 3 weeks
-	// TODO: must be the same than the provider chain at the moment; update test setup to solve this
+	// TODO: must match default IBC-GO default value see #153
 	UnbondingTime = 3 * 7 * 24 * time.Hour
 
 	// HistoricalEntries is set to 10000 like the staking module parameter DefaultHistoricalEntries

--- a/x/ccv/consumer/types/keys.go
+++ b/x/ccv/consumer/types/keys.go
@@ -41,7 +41,7 @@ const (
 	UnbondingTimePrefix = "unbondingtime"
 
 	// UnbondingTime is set to 4 weeks
-	UnbondingTime = 4 * 7 * 24 * time.Hour
+	UnbondingTime = 3 * 7 * 24 * time.Hour
 
 	// HistoricalEntries is set to 10000 like the staking module parameter DefaultHistoricalEntries
 	HistoricalEntries uint32 = 10000

--- a/x/ccv/consumer/types/keys.go
+++ b/x/ccv/consumer/types/keys.go
@@ -37,11 +37,11 @@ const (
 	// UnbondingPacketPrefix is the key prefix that will store the unbonding packet at the given sequence
 	UnbondingPacketPrefix = "unbondingpacket"
 
-	// UnbondingTimePrefix is the key prefix that will store unbonding time for each recently received packet.
+	// UnbondingTimePrefix is the key prefix that will store unbonding time fqor each recently received packet.
 	UnbondingTimePrefix = "unbondingtime"
 
 	// UnbondingTime is set to 3 weeks
-	// TODO: must be the same than the provider chain at the moment; fix tests to not use NewDefaultEndpoint for both chains
+	// TODO: must be the same than the provider chain at the moment; update test setup to solve this
 	UnbondingTime = 3 * 7 * 24 * time.Hour
 
 	// HistoricalEntries is set to 10000 like the staking module parameter DefaultHistoricalEntries

--- a/x/ccv/consumer/types/keys.go
+++ b/x/ccv/consumer/types/keys.go
@@ -40,7 +40,8 @@ const (
 	// UnbondingTimePrefix is the key prefix that will store unbonding time for each recently received packet.
 	UnbondingTimePrefix = "unbondingtime"
 
-	// UnbondingTime is set to 4 weeks
+	// UnbondingTime is set to 3 weeks
+	// TODO: must be the same than the provider chain at the moment; fix tests to not use NewDefaultEndpoint for both chains
 	UnbondingTime = 3 * 7 * 24 * time.Hour
 
 	// HistoricalEntries is set to 10000 like the staking module parameter DefaultHistoricalEntries

--- a/x/ccv/provider/keeper/keeper_test.go
+++ b/x/ccv/provider/keeper/keeper_test.go
@@ -93,7 +93,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 	// set chains sender account number
 	// TODO: to be fixed in #151
 	suite.path.EndpointB.Chain.SenderAccount.SetAccountNumber(6)
-	suite.path.EndpointA.Chain.SenderAccount.SetAccountNumber(3)
+	suite.path.EndpointA.Chain.SenderAccount.SetAccountNumber(1)
 
 	// create consumer client on provider chain and set as consumer client for consumer chainID in provider keeper.
 	suite.path.EndpointB.CreateClient()
@@ -249,7 +249,7 @@ func (suite *KeeperTestSuite) TestHandleSlashPacketDoubleSigning() {
 }
 
 func (suite *KeeperTestSuite) TestHandleSlashPacketErrors() {
-	providerStakingKeeper := suite.providerChain.App.GetStakingKeeper()
+	providerStakingKeeper := suite.providerChain.App.(*appProvider.App).StakingKeeper
 	ProviderKeeper := suite.providerChain.App.(*appProvider.App).ProviderKeeper
 	providerSlashingKeeper := suite.providerChain.App.(*appProvider.App).SlashingKeeper
 	consumerChainID := suite.consumerChain.ChainID
@@ -332,7 +332,7 @@ func (suite *KeeperTestSuite) TestHandleSlashPacketErrors() {
 // by varying the slash packet VSC ID mapping to infraction heights
 // lesser, equal or greater than the undelegation entry creation height
 func (suite *KeeperTestSuite) TestHandleSlashPacketDistribution() {
-	providerStakingKeeper := suite.providerChain.App.GetStakingKeeper()
+	providerStakingKeeper := suite.providerChain.App.(*appProvider.App).StakingKeeper
 	providerKeeper := suite.providerChain.App.(*appProvider.App).ProviderKeeper
 
 	// choose a validator

--- a/x/ccv/provider/keeper/keeper_test.go
+++ b/x/ccv/provider/keeper/keeper_test.go
@@ -86,12 +86,14 @@ func (suite *KeeperTestSuite) SetupTest() {
 	if !ok {
 		panic("must already have provider client on consumer chain")
 	}
+
 	// set consumer endpoint's clientID
 	suite.path.EndpointA.ClientID = providerClient
 
-	// TODO: No idea why or how this works, but it seems that it needs to be done.
+	// set chains sender account number
+	// TODO: to be fixed in #151
 	suite.path.EndpointB.Chain.SenderAccount.SetAccountNumber(6)
-	suite.path.EndpointA.Chain.SenderAccount.SetAccountNumber(6)
+	suite.path.EndpointA.Chain.SenderAccount.SetAccountNumber(3)
 
 	// create consumer client on provider chain and set as consumer client for consumer chainID in provider keeper.
 	suite.path.EndpointB.CreateClient()

--- a/x/ccv/provider/provider_test.go
+++ b/x/ccv/provider/provider_test.go
@@ -104,7 +104,7 @@ func (suite *ProviderTestSuite) SetupTest() {
 	// set chains sender account number
 	// TODO: to be fixed in #151
 	suite.path.EndpointB.Chain.SenderAccount.SetAccountNumber(6)
-	suite.path.EndpointA.Chain.SenderAccount.SetAccountNumber(3)
+	suite.path.EndpointA.Chain.SenderAccount.SetAccountNumber(1)
 
 	// create consumer client on provider chain and set as consumer client for consumer chainID in provider keeper.
 	suite.path.EndpointB.CreateClient()
@@ -156,7 +156,7 @@ func TestProviderTestSuite(t *testing.T) {
 func (s *ProviderTestSuite) TestPacketRoundtrip() {
 	s.SetupCCVChannel()
 	providerCtx := s.providerChain.GetContext()
-	providerStakingKeeper := s.providerChain.App.GetStakingKeeper()
+	providerStakingKeeper := s.providerChain.App.(*appProvider.App).StakingKeeper
 
 	origTime := s.ctx.BlockTime()
 	bondAmt := sdk.NewInt(1000000)
@@ -198,9 +198,6 @@ func (s *ProviderTestSuite) TestPacketRoundtrip() {
 	err = s.path.EndpointA.RecvPacket(packet)
 	s.Require().NoError(err)
 
-	// Update chilchain hist info for the current block
-	s.UpdateConsumerHistInfo(packetData.ValidatorUpdates)
-
 	// - End provider unbonding period
 	providerCtx = providerCtx.WithBlockTime(origTime.Add(consumertypes.UnbondingTime).Add(3 * time.Hour))
 	s.providerChain.App.EndBlock(abci.RequestEndBlock{})
@@ -240,7 +237,7 @@ func (s *ProviderTestSuite) TestSendSlashPacketDowntime() {
 	s.SetupCCVChannel()
 	validatorsPerChain := len(s.consumerChain.Vals.Validators)
 
-	providerStakingKeeper := s.providerChain.App.GetStakingKeeper()
+	providerStakingKeeper := s.providerChain.App.(*appProvider.App).StakingKeeper
 	providerSlashingKeeper := s.providerChain.App.(*appProvider.App).SlashingKeeper
 
 	consumerKeeper := s.consumerChain.App.(*appConsumer.App).ConsumerKeeper
@@ -323,9 +320,6 @@ func (s *ProviderTestSuite) TestSendSlashPacketDowntime() {
 	// check that the consumer update its VSC ID for the subsequent block
 	s.Require().Equal(consumerKeeper.GetHeightValsetUpdateID(s.consumerCtx(), uint64(s.consumerCtx().BlockHeight())+1), valsetUpdateID)
 
-	// update consumer chain hist info
-	s.UpdateConsumerHistInfo(packetData2.ValidatorUpdates)
-
 	// check that the validator was removed from the consumer validator set
 	s.Require().Len(s.consumerChain.Vals.Validators, validatorsPerChain-1)
 
@@ -333,7 +327,8 @@ func (s *ProviderTestSuite) TestSendSlashPacketDowntime() {
 	s.Require().NoError(err)
 
 	// check that the validator is successfully jailed on provider
-	validatorJailed, ok := s.providerChain.App.GetStakingKeeper().GetValidatorByConsAddr(s.providerCtx(), consAddr)
+
+	validatorJailed, ok := s.providerChain.App.(*appProvider.App).StakingKeeper.GetValidatorByConsAddr(s.providerCtx(), consAddr)
 	s.Require().True(ok)
 	s.Require().True(validatorJailed.Jailed)
 	s.Require().Equal(validatorJailed.Status, stakingtypes.Unbonding)
@@ -362,7 +357,7 @@ func (s *ProviderTestSuite) TestSendSlashPacketDoubleSign() {
 	s.SetupCCVChannel()
 	validatorsPerChain := len(s.consumerChain.Vals.Validators)
 
-	providerStakingKeeper := s.providerChain.App.GetStakingKeeper()
+	providerStakingKeeper := s.providerChain.App.(*appProvider.App).StakingKeeper
 	providerSlashingKeeper := s.providerChain.App.(*appProvider.App).SlashingKeeper
 	consumerKeeper := s.consumerChain.App.(*appConsumer.App).ConsumerKeeper
 
@@ -441,9 +436,6 @@ func (s *ProviderTestSuite) TestSendSlashPacketDoubleSign() {
 	// check that the consumer update its VSC ID for the subsequent block
 	s.Require().Equal(consumerKeeper.GetHeightValsetUpdateID(s.consumerCtx(), uint64(s.consumerCtx().BlockHeight())+1), valsetUpdateID)
 
-	// update consumer chain hist info
-	s.UpdateConsumerHistInfo(packetData2.ValidatorUpdates)
-
 	// check that the validator was removed from the consumer validator set
 	s.Require().Len(s.consumerChain.Vals.Validators, validatorsPerChain-1)
 
@@ -451,7 +443,7 @@ func (s *ProviderTestSuite) TestSendSlashPacketDoubleSign() {
 	s.Require().NoError(err)
 
 	// check that the validator is successfully jailed on provider
-	validatorJailed, ok := s.providerChain.App.GetStakingKeeper().GetValidatorByConsAddr(s.providerCtx(), consAddr)
+	validatorJailed, ok := s.providerChain.App.(*appProvider.App).StakingKeeper.GetValidatorByConsAddr(s.providerCtx(), consAddr)
 	s.Require().True(ok)
 	s.Require().True(validatorJailed.Jailed)
 	s.Require().Equal(validatorJailed.Status, stakingtypes.Unbonding)
@@ -476,7 +468,7 @@ func (s *ProviderTestSuite) getVal(index int) (validator stakingtypes.Validator,
 	tmValidator := s.providerChain.Vals.Validators[index]
 	valAddr, err := sdk.ValAddressFromHex(tmValidator.Address.String())
 	s.Require().NoError(err)
-	validator, found := s.providerChain.App.GetStakingKeeper().GetValidator(s.providerCtx(), valAddr)
+	validator, found := s.providerChain.App.(*appProvider.App).StakingKeeper.GetValidator(s.providerCtx(), valAddr)
 	s.Require().True(found)
 
 	return validator, valAddr
@@ -497,46 +489,6 @@ func (s *ProviderTestSuite) TestSlashPacketAcknowldgement() {
 
 	err = consumerKeeper.OnAcknowledgementPacket(s.consumerCtx(), packet, ccv.SlashPacketData{}, channeltypes.NewErrorAcknowledgement("another error"))
 	s.Require().Error(err)
-}
-
-// UpdateConsumerHistInfo updates consumer chains historical info manually since
-// the staking keeper is disabled. Provider chains need this to update their client trusted validators
-// in IBC-GO testing (see ConstructUpdateTMClientHeaderWithTrustedHeight in chain.go)
-func (s *ProviderTestSuite) UpdateConsumerHistInfo(changes []abci.ValidatorUpdate) {
-	// map changes per pubkey
-	changesPower := make(map[string]int64)
-	for _, c := range changes {
-		pk, err := cryptocodec.FromTmProtoPublicKey(c.PubKey)
-		s.Require().NoError(err)
-		changesPower[pk.String()] = c.Power
-	}
-
-	// update validators power
-	var validators stakingtypes.Validators
-	for _, v := range s.consumerChain.Vals.Validators {
-		pk, err := cryptocodec.FromTmPubKeyInterface(v.PubKey)
-		s.Require().NoError(err)
-		val, err := stakingtypes.NewValidator(nil, pk, stakingtypes.Description{})
-		s.Require().NoError(err)
-
-		if p, ok := changesPower[pk.String()]; ok {
-			val.Tokens = sdk.TokensFromConsensusPower(p, sdk.DefaultPowerReduction)
-		} else {
-			val.Tokens = sdk.TokensFromConsensusPower(v.VotingPower, sdk.DefaultPowerReduction)
-		}
-
-		if val.Tokens.IsZero() {
-			val.Status = stakingtypes.Unbonding
-			val.Jailed = true
-		} else {
-			val.Status = stakingtypes.Bonded
-		}
-		validators = append(validators, val)
-	}
-
-	// update chain historical info
-	hi := stakingtypes.NewHistoricalInfo(s.ctx.BlockHeader(), validators, sdk.DefaultPowerReduction)
-	s.consumerChain.App.GetStakingKeeper().SetHistoricalInfo(s.consumerCtx(), s.consumerCtx().BlockHeight(), &hi)
 }
 
 func (s *ProviderTestSuite) DisableConsumerDistribution() {

--- a/x/ccv/provider/provider_test.go
+++ b/x/ccv/provider/provider_test.go
@@ -1,13 +1,11 @@
 package provider_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
@@ -16,7 +14,6 @@ import (
 
 	transfertypes "github.com/cosmos/ibc-go/v3/modules/apps/transfer/types"
 	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
-	channelkeeper "github.com/cosmos/ibc-go/v3/modules/core/04-channel/keeper"
 	channeltypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	commitmenttypes "github.com/cosmos/ibc-go/v3/modules/core/23-commitment/types"
 	ibctmtypes "github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types"
@@ -100,12 +97,14 @@ func (suite *ProviderTestSuite) SetupTest() {
 	if !ok {
 		panic("must already have provider client on consumer chain")
 	}
+
 	// set consumer endpoint's clientID
 	suite.path.EndpointA.ClientID = providerClient
 
-	// TODO: No idea why or how this works, but it seems that it needs to be done.
+	// set chains sender account number
+	// TODO: to be fixed in #151
 	suite.path.EndpointB.Chain.SenderAccount.SetAccountNumber(6)
-	suite.path.EndpointA.Chain.SenderAccount.SetAccountNumber(6)
+	suite.path.EndpointA.Chain.SenderAccount.SetAccountNumber(3)
 
 	// create consumer client on provider chain and set as consumer client for consumer chainID in provider keeper.
 	suite.path.EndpointB.CreateClient()
@@ -574,122 +573,122 @@ func (s *ProviderTestSuite) ReenableProviderDistribution() {
 
 // TestDistribution tests that tokens are distributed to the
 // provider chain from the consumer chain appropriately
-func (s *ProviderTestSuite) TestDistribution() {
-	s.SetupCCVChannel() // also sets up transfer channels
-	// NOTE s.transferPath.EndpointA == Consumer Chain
-	//      s.transferPath.EndpointB == Provider Chain
+// func (s *ProviderTestSuite) TestDistribution() {
+// 	s.SetupCCVChannel() // also sets up transfer channels
+// 	// NOTE s.transferPath.EndpointA == Consumer Chain
+// 	//      s.transferPath.EndpointB == Provider Chain
 
-	pChain, cChain := s.providerChain, s.consumerChain
-	pApp, cApp := pChain.App.(*appProvider.App), cChain.App.(*appConsumer.App)
-	cKeep := cApp.ConsumerKeeper
+// 	pChain, cChain := s.providerChain, s.consumerChain
+// 	pApp, cApp := pChain.App.(*appProvider.App), cChain.App.(*appConsumer.App)
+// 	cKeep := cApp.ConsumerKeeper
 
-	// Get the receiving fee pool on the provider chain
-	fcAddr := pApp.ProviderKeeper.GetFeeCollectorAddressStr(pChain.GetContext())
+// 	// Get the receiving fee pool on the provider chain
+// 	fcAddr := pApp.ProviderKeeper.GetFeeCollectorAddressStr(pChain.GetContext())
 
-	// Ensure that the provider fee pool address stored on the consumer chain
-	// is the correct address
-	fcAddr2 := cApp.ConsumerKeeper.GetProviderFeePoolAddrStr(cChain.GetContext())
-	s.Require().Equal(fcAddr, fcAddr2)
+// 	// Ensure that the provider fee pool address stored on the consumer chain
+// 	// is the correct address
+// 	fcAddr2 := cApp.ConsumerKeeper.GetProviderFeePoolAddrStr(cChain.GetContext())
+// 	s.Require().Equal(fcAddr, fcAddr2)
 
-	// make sure we're starting at consumer height 21 (some blocks commited during setup)
-	s.Require().Equal(int64(21), cChain.GetContext().BlockHeight())
+// 	// make sure we're starting at consumer height 21 (some blocks commited during setup)
+// 	s.Require().Equal(int64(21), cChain.GetContext().BlockHeight())
 
-	// get last consumer transmission
-	ltbh, err := cKeep.GetLastTransmissionBlockHeight(cChain.GetContext())
-	s.Require().NoError(err)
-	s.Require().Equal(int64(0), ltbh.Height)
+// 	// get last consumer transmission
+// 	ltbh, err := cKeep.GetLastTransmissionBlockHeight(cChain.GetContext())
+// 	s.Require().NoError(err)
+// 	s.Require().Equal(int64(0), ltbh.Height)
 
-	bpdt := cKeep.GetBlocksPerDistributionTransmission(cChain.GetContext())
-	s.Require().Equal(int64(1000), bpdt)
+// 	bpdt := cKeep.GetBlocksPerDistributionTransmission(cChain.GetContext())
+// 	s.Require().Equal(int64(1000), bpdt)
 
-	// check the consumer chain fee pool
-	consumerFeePoolAddr := cApp.AccountKeeper.GetModuleAccount(
-		cChain.GetContext(), authtypes.FeeCollectorName).GetAddress()
-	providerFeePoolAddr := pApp.AccountKeeper.GetModuleAccount(
-		pChain.GetContext(), authtypes.FeeCollectorName).GetAddress()
-	balance := cApp.BankKeeper.GetBalance(cChain.GetContext(), consumerFeePoolAddr, "stake")
-	s.Assert().Equal(balance.Amount.Int64(), int64(140062235461521))
+// 	// check the consumer chain fee pool
+// 	consumerFeePoolAddr := cApp.AccountKeeper.GetModuleAccount(
+// 		cChain.GetContext(), authtypes.FeeCollectorName).GetAddress()
+// 	providerFeePoolAddr := pApp.AccountKeeper.GetModuleAccount(
+// 		pChain.GetContext(), authtypes.FeeCollectorName).GetAddress()
+// 	balance := cApp.BankKeeper.GetBalance(cChain.GetContext(), consumerFeePoolAddr, "stake")
+// 	s.Assert().Equal(balance.Amount.Int64(), int64(140062235461521))
 
-	// Commit some new blocks (commit blocks less than the distribution event blocks)
-	s.coordinator.CommitNBlocks(cChain, (1000-1)-21)
-	err = s.path.EndpointB.UpdateClient()
-	s.Require().Equal(int64(1000), cChain.GetContext().BlockHeight())
+// 	// Commit some new blocks (commit blocks less than the distribution event blocks)
+// 	s.coordinator.CommitNBlocks(cChain, (1000-1)-21)
+// 	err = s.path.EndpointB.UpdateClient()
+// 	s.Require().Equal(int64(1000), cChain.GetContext().BlockHeight())
 
-	// check the consumer chain fee pool (should have increased
-	balance = cApp.BankKeeper.GetBalance(cChain.GetContext(), consumerFeePoolAddr, "stake")
-	expFeePoolAtDistr := int64(4175822659438993)
-	s.Assert().Equal(balance.Amount.Int64(), expFeePoolAtDistr)
+// 	// check the consumer chain fee pool (should have increased
+// 	balance = cApp.BankKeeper.GetBalance(cChain.GetContext(), consumerFeePoolAddr, "stake")
+// 	expFeePoolAtDistr := int64(4175822659438993)
+// 	s.Assert().Equal(balance.Amount.Int64(), expFeePoolAtDistr)
 
-	// Verify that the destinationChannel exists
-	// if this doesn't exist then the transfer logic will fail when
-	// a the distribution transfer is invoked in the next block.
-	ctx := cChain.GetContext()
-	sourcePort := transfertypes.PortID
-	sourceChannel := cKeep.GetDistributionTransmissionChannel(ctx)
-	sourceChannelEnd, found := cApp.IBCKeeper.ChannelKeeper.GetChannel(ctx, sourcePort, sourceChannel)
-	s.Require().True(found)
-	destinationChannel := sourceChannelEnd.GetCounterparty().GetChannelID()
-	s.Require().True(len(destinationChannel) > 0)
+// 	// Verify that the destinationChannel exists
+// 	// if this doesn't exist then the transfer logic will fail when
+// 	// a the distribution transfer is invoked in the next block.
+// 	ctx := cChain.GetContext()
+// 	sourcePort := transfertypes.PortID
+// 	sourceChannel := cKeep.GetDistributionTransmissionChannel(ctx)
+// 	sourceChannelEnd, found := cApp.IBCKeeper.ChannelKeeper.GetChannel(ctx, sourcePort, sourceChannel)
+// 	s.Require().True(found)
+// 	destinationChannel := sourceChannelEnd.GetCounterparty().GetChannelID()
+// 	s.Require().True(len(destinationChannel) > 0)
 
-	// commit 1 more block (which should invoke a distribution event)
-	rspEB, _, _ := s.coordinator.CommitBlockGetResponses(cChain)
+// 	// commit 1 more block (which should invoke a distribution event)
+// 	rspEB, _, _ := s.coordinator.CommitBlockGetResponses(cChain)
 
-	// get the packet from the endblock events
-	var packet channeltypes.Packet
-	var ftpd transfertypes.FungibleTokenPacketData
-	found = false
-	for _, evnt := range rspEB.Events {
-		if evnt.Type == channeltypes.EventTypeSendPacket {
-			found = true
-			packet, err = channelkeeper.ReconstructPacketFromEvent(evnt)
-			s.Require().NoError(err)
-			cApp.AppCodec().MustUnmarshalJSON(packet.GetData(), &ftpd)
-		}
-	}
-	s.Require().True(found)
+// 	// get the packet from the endblock events
+// 	var packet channeltypes.Packet
+// 	var ftpd transfertypes.FungibleTokenPacketData
+// 	found = false
+// 	for _, evnt := range rspEB.Events {
+// 		if evnt.Type == channeltypes.EventTypeSendPacket {
+// 			found = true
+// 			packet, err = channelkeeper.ReconstructPacketFromEvent(evnt)
+// 			s.Require().NoError(err)
+// 			cApp.AppCodec().MustUnmarshalJSON(packet.GetData(), &ftpd)
+// 		}
+// 	}
+// 	s.Require().True(found)
 
-	// ensure the correct amount is being transmitted within the packet
-	expConsRedistrAmt := expFeePoolAtDistr * 3 / 4 // because of default 75% redistribute fraction (will truc decimal)
-	expProviderAmt := expFeePoolAtDistr - expConsRedistrAmt
-	s.Assert().Equal(ftpd.Amount, fmt.Sprintf("%v", expProviderAmt))
+// 	// ensure the correct amount is being transmitted within the packet
+// 	expConsRedistrAmt := expFeePoolAtDistr * 3 / 4 // because of default 75% redistribute fraction (will truc decimal)
+// 	expProviderAmt := expFeePoolAtDistr - expConsRedistrAmt
+// 	s.Assert().Equal(ftpd.Amount, fmt.Sprintf("%v", expProviderAmt))
 
-	// halt provider distribution (for testing purposes to be able to review the
-	// provider fee pool)
-	s.DisableProviderDistribution()
+// 	// halt provider distribution (for testing purposes to be able to review the
+// 	// provider fee pool)
+// 	s.DisableProviderDistribution()
 
-	// relay the packet
-	err = s.transferPath.RelayPacket(packet)
-	s.Require().NoError(err)
+// 	// relay the packet
+// 	err = s.transferPath.RelayPacket(packet)
+// 	s.Require().NoError(err)
 
-	// check the consumer chain fee pool which should be now emptied (besides
-	// new minted tokens since the transfer)
-	balance = cApp.BankKeeper.GetBalance(cChain.GetContext(), consumerFeePoolAddr, "stake")
-	s.Assert().Equal(balance.Amount.Int64(), int64(26786189989304)) // this is "small"
+// 	// check the consumer chain fee pool which should be now emptied (besides
+// 	// new minted tokens since the transfer)
+// 	balance = cApp.BankKeeper.GetBalance(cChain.GetContext(), consumerFeePoolAddr, "stake")
+// 	s.Assert().Equal(balance.Amount.Int64(), int64(26786189989304)) // this is "small"
 
-	// check the provider chain fee pool which should now have
-	// the consumer chain tokens
-	balance = pApp.BankKeeper.GetBalance(pChain.GetContext(), providerFeePoolAddr,
-		"ibc/3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9")
-	s.Assert().Equal(balance.Amount.Int64(), expProviderAmt)
+// 	// check the provider chain fee pool which should now have
+// 	// the consumer chain tokens
+// 	balance = pApp.BankKeeper.GetBalance(pChain.GetContext(), providerFeePoolAddr,
+// 		"ibc/3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9")
+// 	s.Assert().Equal(balance.Amount.Int64(), expProviderAmt)
 
-	// check the consumer redistribution amount arrives in the module account
-	consumerRedistrAddr := cApp.AccountKeeper.GetModuleAccount(ctx,
-		consumertypes.ConsumerRedistributeName).GetAddress()
-	balance = cApp.BankKeeper.GetBalance(cChain.GetContext(), consumerRedistrAddr, "stake")
-	s.Assert().Equal(balance.Amount.Int64(), expConsRedistrAmt)
+// 	// check the consumer redistribution amount arrives in the module account
+// 	consumerRedistrAddr := cApp.AccountKeeper.GetModuleAccount(ctx,
+// 		consumertypes.ConsumerRedistributeName).GetAddress()
+// 	balance = cApp.BankKeeper.GetBalance(cChain.GetContext(), consumerRedistrAddr, "stake")
+// 	s.Assert().Equal(balance.Amount.Int64(), expConsRedistrAmt)
 
-	// Ensure provider pool emptied and that allocation was called normally
-	// allocation would result in validator rewards, but due to limitations in
-	// the testing framework (where validators do not actually sign votes and
-	// therefor do not produce abci.VoteInfo) the expected behaviour of
-	// allocation is to send all rewards to the community pool
-	s.ReenableProviderDistribution()
-	s.coordinator.CommitNBlocks(pChain, 1)
-	balance = pApp.BankKeeper.GetBalance(pChain.GetContext(), providerFeePoolAddr,
-		"ibc/3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9")
-	s.Assert().Equal(balance.Amount.Int64(), int64(0))
-	communityPool := pApp.DistrKeeper.GetFeePool(pChain.GetContext()).CommunityPool
-	balanceI64 := communityPool.AmountOf(
-		"ibc/3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9").RoundInt64()
-	s.Assert().Equal(balanceI64, expProviderAmt)
-}
+// 	// Ensure provider pool emptied and that allocation was called normally
+// 	// allocation would result in validator rewards, but due to limitations in
+// 	// the testing framework (where validators do not actually sign votes and
+// 	// therefor do not produce abci.VoteInfo) the expected behaviour of
+// 	// allocation is to send all rewards to the community pool
+// 	s.ReenableProviderDistribution()
+// 	s.coordinator.CommitNBlocks(pChain, 1)
+// 	balance = pApp.BankKeeper.GetBalance(pChain.GetContext(), providerFeePoolAddr,
+// 		"ibc/3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9")
+// 	s.Assert().Equal(balance.Amount.Int64(), int64(0))
+// 	communityPool := pApp.DistrKeeper.GetFeePool(pChain.GetContext()).CommunityPool
+// 	balanceI64 := communityPool.AmountOf(
+// 		"ibc/3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9").RoundInt64()
+// 	s.Assert().Equal(balanceI64, expProviderAmt)
+// }

--- a/x/ccv/provider/unbonding_hook_test.go
+++ b/x/ccv/provider/unbonding_hook_test.go
@@ -51,7 +51,7 @@ func (s *ProviderTestSuite) TestStakingHooks2() {
 	s.providerChain.App.EndBlock(abci.RequestEndBlock{})
 
 	// Get validator update created in Endblock to use in reconstructing packet
-	valUpdates := s.providerChain.App.GetStakingKeeper().GetValidatorUpdates(s.providerCtx())
+	valUpdates := s.providerChain.App.(*appProvider.App).StakingKeeper.GetValidatorUpdates(s.providerCtx())
 
 	// Get current blocktime
 	oldBlockTime := s.providerCtx().BlockTime()
@@ -121,7 +121,7 @@ func (s *ProviderTestSuite) TestStakingHooks1() {
 	s.providerChain.App.EndBlock(abci.RequestEndBlock{})
 
 	// Get validator update created in Endblock to use in reconstructing packet
-	valUpdates := s.providerChain.App.GetStakingKeeper().GetValidatorUpdates(s.providerCtx())
+	valUpdates := s.providerChain.App.(*appProvider.App).StakingKeeper.GetValidatorUpdates(s.providerCtx())
 
 	// Get current blocktime
 	oldBlockTime := s.providerCtx().BlockTime()
@@ -203,7 +203,7 @@ func (s *ProviderTestSuite) TestUnbondingEdgeCase() {
 	s.Require().NotNil(commit, "did not find packet commitment")
 
 	// Get validator update created in Endblock to use in reconstructing packet
-	valUpdates := s.providerChain.App.GetStakingKeeper().GetValidatorUpdates(s.providerCtx())
+	valUpdates := s.providerChain.App.(*appProvider.App).StakingKeeper.GetValidatorUpdates(s.providerCtx())
 
 	// Get current blocktime
 	oldBlockTime := s.providerCtx().BlockTime()
@@ -287,7 +287,7 @@ func bondAndUnbond(s *ProviderTestSuite, delAddr sdk.AccAddress, bondAmt sdk.Int
 
 	// INITIAL BOND
 	// Bond some tokens on provider to change validator powers
-	shares, err := s.providerChain.App.GetStakingKeeper().Delegate(s.providerCtx(), delAddr, bondAmt, stakingtypes.Unbonded, stakingtypes.Validator(validator), true)
+	shares, err := s.providerChain.App.(*appProvider.App).StakingKeeper.Delegate(s.providerCtx(), delAddr, bondAmt, stakingtypes.Unbonded, stakingtypes.Validator(validator), true)
 	s.Require().NoError(err)
 
 	// Check that the correct number of tokens were taken out of the delegator's account
@@ -295,7 +295,7 @@ func bondAndUnbond(s *ProviderTestSuite, delAddr sdk.AccAddress, bondAmt sdk.Int
 
 	// UNDELEGATE
 	// Undelegate half
-	_, err = s.providerChain.App.GetStakingKeeper().Undelegate(s.providerCtx(), delAddr, valAddr, shares.QuoInt64(shareDiv))
+	_, err = s.providerChain.App.(*appProvider.App).StakingKeeper.Undelegate(s.providerCtx(), delAddr, valAddr, shares.QuoInt64(shareDiv))
 	s.Require().NoError(err)
 
 	// Check that the tokens have not been returned yet
@@ -311,7 +311,7 @@ func endProviderUnbondingPeriod(s *ProviderTestSuite, origTime time.Time) sdk.Co
 	// - End provider unbonding period
 	providerCtx := s.providerCtx().WithBlockTime(origTime.Add(consumertypes.UnbondingTime).Add(3 * time.Hour))
 	// s.providerChain.App.EndBlock(abci.RequestEndBlock{}) // <- this doesn't work because we can't modify the ctx
-	s.providerChain.App.GetStakingKeeper().BlockValidatorUpdates(providerCtx)
+	s.providerChain.App.(*appProvider.App).StakingKeeper.BlockValidatorUpdates(providerCtx)
 
 	return providerCtx
 }
@@ -325,7 +325,7 @@ func endConsumerUnbondingPeriod(s *ProviderTestSuite, origTime time.Time) {
 }
 
 func checkStakingUnbondingOps(s *ProviderTestSuite, id uint64, found bool, onHold bool) {
-	stakingUnbondingOp, wasFound := GetStakingUnbondingDelegationEntry(s.providerCtx(), s.providerChain.App.GetStakingKeeper(), id)
+	stakingUnbondingOp, wasFound := GetStakingUnbondingDelegationEntry(s.providerCtx(), s.providerChain.App.(*appProvider.App).StakingKeeper, id)
 	s.Require().True(found == wasFound)
 	s.Require().True(onHold == stakingUnbondingOp.UnbondingOnHold)
 }
@@ -344,9 +344,6 @@ func sendValUpdatePacket(s *ProviderTestSuite, valUpdates []abci.ValidatorUpdate
 	// Receive CCV packet on consumer chain
 	err := s.path.EndpointA.RecvPacket(packet)
 	s.Require().NoError(err)
-
-	// update consumer chain hist info
-	s.UpdateConsumerHistInfo(valUpdates)
 
 	return packet, packetData
 }


### PR DESCRIPTION
Disable the staking module from the consumer chain.
* Close #139 

* Built upon #152 & #150
  

The following changes are required due to ibc-go testing limitations:

-  The consumer `UnbondingTime` value is set to match the ibc-go testing [default client config](https://github.com/cosmos/ibc-go/blob/a71fc1029ad1fc6d377d642781d02ad3cbfa0910/testing/endpoint.go#L48-L53) (see #153).

-  The `GetSakingKeeper` function signature in `app.go`s returns an [ibcclienttypes.StakingKeeper](https://github.com/cosmos/ibc-go/blob/a71fc1029ad1fc6d377d642781d02ad3cbfa0910/modules/core/02-client/types/expected_keepers.go#L12) interface rather than a concrete [StakingKeeper type](https://github.com/cosmos/cosmos-sdk/blob/748b9f08bc77e36047175a14313c4d593846ce4f/x/staking/keeper/keeper.go#L24).




 