### PR TITLE
Fix integration test driver #167

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -128,8 +128,6 @@ require (
 
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
-	// github.com/cosmos/cosmos-sdk => /Users/danwt/Documents/work/cosmos-sdk
-	// github.com/cosmos/ibc-go/v3 => /Users/danwt/Documents/work/informal-ibc-go
 	github.com/cosmos/ibc-go/v3 => github.com/informalsystems/ibc-go/v3 v3.0.0-beta1.0.20220621053640-83aa2792664d
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2

--- a/go.mod
+++ b/go.mod
@@ -128,6 +128,8 @@ require (
 
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
+	// github.com/cosmos/cosmos-sdk => /Users/danwt/Documents/work/cosmos-sdk
+	// github.com/cosmos/ibc-go/v3 => /Users/danwt/Documents/work/informal-ibc-go
 	github.com/cosmos/ibc-go/v3 => github.com/informalsystems/ibc-go/v3 v3.0.0-beta1.0.20220621053640-83aa2792664d
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2

--- a/integration-tests/actions.go
+++ b/integration-tests/actions.go
@@ -290,14 +290,20 @@ func (s System) startConsumerChain(
 	action StartConsumerChainAction,
 	verbose bool,
 ) {
-	bz, err := exec.Command("docker", "exec", s.containerConfig.instanceName, s.chainConfigs[action.consumerChain].binaryName,
+	cmd := exec.Command("docker", "exec", s.containerConfig.instanceName, s.chainConfigs[action.providerChain].binaryName,
 
 		"query", "provider", "consumer-genesis",
 		s.chainConfigs[action.consumerChain].chainId,
 
 		`--node`, s.getValidatorNode(action.providerChain, s.getValidatorNum(action.providerChain)),
 		`-o`, `json`,
-	).CombinedOutput()
+	)
+
+	if verbose {
+		log.Println("startConsumerChain cmd: ", cmd.String())
+	}
+
+	bz, err := cmd.CombinedOutput()
 
 	if err != nil {
 		log.Fatal(err, "\n", string(bz))

--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -50,7 +50,7 @@ func (s System) runStep(step Step, verbose bool) {
 	case DelegateTokensAction:
 		s.delegateTokens(action, verbose)
 	default:
-		log.Fatal(fmt.Sprintf(`unknown action: %#v`, action))
+		log.Fatalf(fmt.Sprintf(`unknown action: %#v`, action))
 	}
 
 	modelState := step.state

--- a/integration-tests/testnet-scripts/start-chain.sh
+++ b/integration-tests/testnet-scripts/start-chain.sh
@@ -103,17 +103,19 @@ do
     fi
 
     # Make a gentx (this command also sets up validator state on disk even if we are not going to use the gentx for anything)
-    STAKE_AMOUNT=$(echo "$VALIDATORS" | jq -r ".[$i].stake")
-    $BIN gentx validator$VAL_ID "$STAKE_AMOUNT" \
-        --home /$CHAIN_ID/validator$VAL_ID \
-        --keyring-backend test \
-        --moniker validator$VAL_ID \
-        --chain-id=$CHAIN_ID
-    
-    # Copy gentxs to the first validator for possible future collection. 
-    # Obviously we don't need to copy the first validator's gentx to itself
-    if [ $VAL_ID != $FIRST_VAL_ID ]; then
-        cp /$CHAIN_ID/validator$VAL_ID/config/gentx/* /$CHAIN_ID/validator$FIRST_VAL_ID/config/gentx/
+    if [ "$SKIP_GENTX" = "false" ] ; then 
+        STAKE_AMOUNT=$(echo "$VALIDATORS" | jq -r ".[$i].stake")
+        $BIN gentx validator$VAL_ID "$STAKE_AMOUNT" \
+            --home /$CHAIN_ID/validator$VAL_ID \
+            --keyring-backend test \
+            --moniker validator$VAL_ID \
+            --chain-id=$CHAIN_ID
+
+        # Copy gentxs to the first validator for possible future collection. 
+        # Obviously we don't need to copy the first validator's gentx to itself
+        if [ $VAL_ID != $FIRST_VAL_ID ]; then
+            cp /$CHAIN_ID/validator$VAL_ID/config/gentx/* /$CHAIN_ID/validator$FIRST_VAL_ID/config/gentx/
+        fi
     fi
 
     # Modify tendermint configs of validator


### PR DESCRIPTION
This PR fixes the driver. The driver is now able to drive actions. This PR does not fix the actual test contents, which can be found in [steps.go](https://github.com/cosmos/interchain-security/blob/main/integration-tests/steps.go), [steps.json](https://github.com/cosmos/interchain-security/blob/main/integration-tests/steps.json). This PR also does not fix the SUT. Therefore, the integration tests are _still failing_, although this PR does make the driver correct.

Closes 

- https://github.com/cosmos/interchain-security/issues/167

Does _not_ close

- https://github.com/cosmos/interchain-security/issues/168

Credit to @sainoe for the actual logical fixes.