### PR TITLE
Updates integration tests Dockerfile, allowing integration tests to run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,16 @@
-FROM fedora:34
+FROM fedora:36
 ENV GOPATH=/go
 ENV PATH=$PATH:/go/bin
 RUN echo fuk
-RUN dnf install -y git make gcc gcc-c++ which iproute iputils procps-ng vim-minimal tmux net-tools htop tar jq npm openssl-devel perl rust cargo golang
+RUN dnf update -y
+RUN dnf install -y golang git make gcc gcc-c++ which iproute iputils procps-ng vim-minimal tmux net-tools htop tar jq npm openssl-devel perl rust cargo golang
 
 RUN PATH="$HOME/.cargo/bin:$PATH" && cargo install ibc-relayer-cli --bin hermes --locked
 
 # Copy in the repo under test
 ADD . /interchain-security
+
+RUN go version
 
 # Build the Go module
 RUN pushd /interchain-security/ && PATH=$PATH:/usr/local/go/bin GOPROXY=https://proxy.golang.org make && PATH=$PATH:/usr/local/go/bin make install


### PR DESCRIPTION
The integration tests rebroke when I bumped the go.mod go ver to 1.18 because fedora 34 uses less than 1.18 by default.

Fedora 36 uses go 1.18

https://packages.fedoraproject.org/pkgs/golang/golang/