### PR TITLE
Make gosec pass

### DIFF
--- a/app/provider/export.go
+++ b/app/provider/export.go
@@ -165,7 +165,9 @@ func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []str
 		counter++
 	}
 
-	iter.Close()
+	if err := iter.Close(); err != nil {
+		panic(err)
+	}
 
 	if _, err := app.StakingKeeper.ApplyAndReturnValidatorSetUpdates(ctx); err != nil {
 		panic(err)

--- a/integration-tests/actions.go
+++ b/integration-tests/actions.go
@@ -26,6 +26,7 @@ func (s System) sendTokens(
 	verbose bool,
 ) {
 	binaryName := s.chainConfigs[action.chain].binaryName
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	cmd := exec.Command("docker", "exec", s.containerConfig.instanceName, binaryName,
 
 		"tx", "bank", "send",
@@ -101,6 +102,7 @@ func (s System) startChain(
 		genesisChanges = chainConfig.genesisChanges
 	}
 
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	cmd := exec.Command("docker", "exec", s.containerConfig.instanceName, "/bin/bash",
 		"/testnet-scripts/start-chain.sh", chainConfig.binaryName, string(vals),
 		chainConfig.chainId, chainConfig.ipPrefix, genesisChanges,
@@ -154,6 +156,7 @@ func (s System) submitTextProposal(
 	action SubmitTextProposalAction,
 	verbose bool,
 ) {
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	bz, err := exec.Command("docker", "exec", s.containerConfig.instanceName, s.chainConfigs[action.chain].binaryName,
 
 		"tx", "gov", "submit-proposal",
@@ -218,12 +221,14 @@ func (s System) submitConsumerProposal(
 		log.Fatal(err)
 	}
 
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	bz, err = exec.Command("docker", "exec", s.containerConfig.instanceName, "/bin/bash", "-c", fmt.Sprintf(`echo '%s' > %s`, string(bz), "/temp-proposal.json")).CombinedOutput()
 
 	if err != nil {
 		log.Fatal(err, "\n", string(bz))
 	}
 
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	bz, err = exec.Command("docker", "exec", s.containerConfig.instanceName, s.chainConfigs[action.chain].binaryName,
 
 		"tx", "gov", "submit-proposal", "create-consumer-chain",
@@ -260,6 +265,7 @@ func (s System) voteGovProposal(
 		vote := action.vote[i]
 		go func(val uint, vote string) {
 			defer wg.Done()
+			//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 			bz, err := exec.Command("docker", "exec", s.containerConfig.instanceName, s.chainConfigs[action.chain].binaryName,
 
 				"tx", "gov", "vote",
@@ -294,6 +300,7 @@ func (s System) startConsumerChain(
 	action StartConsumerChainAction,
 	verbose bool,
 ) {
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	cmd := exec.Command("docker", "exec", s.containerConfig.instanceName, s.chainConfigs[action.providerChain].binaryName,
 
 		"query", "provider", "consumer-genesis",
@@ -372,6 +379,7 @@ func (s System) addChainToRelayer(
 
 	bashCommand := fmt.Sprintf(`echo '%s' >> %s`, chainConfig, "/root/.hermes/config.toml")
 
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	bz, err := exec.Command("docker", "exec", s.containerConfig.instanceName, "bash", "-c",
 		bashCommand,
 	).CombinedOutput()
@@ -379,6 +387,7 @@ func (s System) addChainToRelayer(
 		log.Fatal(err, "\n", string(bz))
 	}
 
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	bz, err = exec.Command("docker", "exec", s.containerConfig.instanceName, "/root/.cargo/bin/hermes",
 		"keys", "restore",
 		"--mnemonic", s.validatorConfigs[action.validator].mnemonic,
@@ -402,6 +411,7 @@ func (s System) addIbcConnection(
 	action AddIbcConnectionAction,
 	verbose bool,
 ) {
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	cmd := exec.Command("docker", "exec", s.containerConfig.instanceName, "/root/.cargo/bin/hermes",
 		"create", "connection",
 		s.chainConfigs[action.chainA].chainId,
@@ -448,6 +458,7 @@ func (s System) addIbcChannel(
 	action AddIbcChannelAction,
 	verbose bool,
 ) {
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	cmd := exec.Command("docker", "exec", s.containerConfig.instanceName, "/root/.cargo/bin/hermes",
 		"create", "channel",
 		"--order", action.order,
@@ -499,6 +510,7 @@ func (s System) relayPackets(
 	verbose bool,
 ) {
 	// hermes clear packets ibc0 transfer channel-13
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	cmd := exec.Command("docker", "exec", s.containerConfig.instanceName, "/root/.cargo/bin/hermes", "clear", "packets",
 		s.chainConfigs[action.chain].chainId, action.port, "channel-"+fmt.Sprint(action.channel),
 	)
@@ -523,6 +535,7 @@ func (s System) delegateTokens(
 	action DelegateTokensAction,
 	verbose bool,
 ) {
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	bz, err := exec.Command("docker", "exec", s.containerConfig.instanceName, s.chainConfigs[action.chain].binaryName,
 
 		"tx", "staking", "delegate",
@@ -547,6 +560,7 @@ var queryValidatorRegex = regexp.MustCompile(`(\d+)`)
 
 func (s System) getValidatorNum(chain uint) uint {
 	// Get first subdirectory of the directory of this chain, which will be the home directory of one of the validators
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	bz, err := exec.Command("docker", "exec", s.containerConfig.instanceName, "bash", "-c", `cd /`+s.chainConfigs[chain].chainId+`; ls -d */ | awk '{print $1}' | head -n 1`).CombinedOutput()
 
 	if err != nil {

--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -87,6 +87,7 @@ docker run --name "$INSTANCE_NAME" --cap-add=NET_ADMIN "$CONTAINER_NAME" /bin/ba
 `
 
 func (s System) startDocker() {
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	cmd := exec.Command("/bin/bash", "-c", fmt.Sprintf(startDockerScript, s.containerConfig.containerName, s.containerConfig.instanceName))
 
 	cmdReader, err := cmd.StdoutPipe()

--- a/integration-tests/state.go
+++ b/integration-tests/state.go
@@ -80,6 +80,7 @@ func (s System) getChainState(chain uint, modelState ChainState) ChainState {
 var blockHeightRegex = regexp.MustCompile(`block_height: "(\d+)"`)
 
 func (s System) getBlockHeight(chain uint) uint {
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	bz, err := exec.Command("docker", "exec", s.containerConfig.instanceName, s.chainConfigs[chain].binaryName,
 
 		"query", "tendermint-validator-set",
@@ -139,6 +140,7 @@ func (s System) getValPowers(chain uint, modelState map[uint]uint) map[uint]uint
 }
 
 func (s System) getBalance(chain uint, validator uint) uint {
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	bz, err := exec.Command("docker", "exec", s.containerConfig.instanceName, s.chainConfigs[chain].binaryName,
 
 		"query", "bank", "balances",
@@ -161,6 +163,7 @@ var noProposalRegex = regexp.MustCompile(`doesn't exist: key not found`)
 
 // interchain-securityd query gov proposals
 func (s System) getProposal(chain uint, proposal uint) Proposal {
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	bz, err := exec.Command("docker", "exec", s.containerConfig.instanceName, s.chainConfigs[chain].binaryName,
 
 		"query", "gov", "proposal",
@@ -239,6 +242,7 @@ type ValPubKey struct {
 }
 
 func (s System) getValPower(chain uint, validator uint) uint {
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	bz, err := exec.Command("docker", "exec", s.containerConfig.instanceName, s.chainConfigs[chain].binaryName,
 
 		"query", "tendermint-validator-set",

--- a/x/ccv/consumer/keeper/relay.go
+++ b/x/ccv/consumer/keeper/relay.go
@@ -71,16 +71,17 @@ func (k Keeper) OnRecvVSCPacket(ctx sdk.Context, packet channeltypes.Packet, new
 // UnbondMaturePackets will iterate over the unbonding packets in order and write acknowledgements for all
 // packets that have finished unbonding.
 func (k Keeper) UnbondMaturePackets(ctx sdk.Context) error {
-	channelID, ok := k.GetProviderChannel(ctx)
-	if !ok {
-		return nil
-	}
 
 	store := ctx.KVStore(k.storeKey)
 	maturityIterator := sdk.KVStorePrefixIterator(store, []byte(types.PacketMaturityTimePrefix))
 	defer maturityIterator.Close()
 
 	currentTime := uint64(ctx.BlockTime().UnixNano())
+
+	channelID, ok := k.GetProviderChannel(ctx)
+	if !ok {
+		return sdkerrors.Wrap(channeltypes.ErrChannelNotFound, "provider channel not set")
+	}
 
 	for maturityIterator.Valid() {
 		vscId := types.GetIdFromPacketMaturityTimeKey(maturityIterator.Key())

--- a/x/ccv/consumer/keeper/relay.go
+++ b/x/ccv/consumer/keeper/relay.go
@@ -71,16 +71,16 @@ func (k Keeper) OnRecvVSCPacket(ctx sdk.Context, packet channeltypes.Packet, new
 // UnbondMaturePackets will iterate over the unbonding packets in order and write acknowledgements for all
 // packets that have finished unbonding.
 func (k Keeper) UnbondMaturePackets(ctx sdk.Context) error {
+	channelID, ok := k.GetProviderChannel(ctx)
+	if !ok {
+		return nil
+	}
+
 	store := ctx.KVStore(k.storeKey)
 	maturityIterator := sdk.KVStorePrefixIterator(store, []byte(types.PacketMaturityTimePrefix))
 	defer maturityIterator.Close()
 
 	currentTime := uint64(ctx.BlockTime().UnixNano())
-
-	channelID, ok := k.GetProviderChannel(ctx)
-	if !ok {
-		return sdkerrors.Wrap(channeltypes.ErrChannelNotFound, "provider channel not set")
-	}
 
 	for maturityIterator.Valid() {
 		vscId := types.GetIdFromPacketMaturityTimeKey(maturityIterator.Key())

--- a/x/ccv/consumer/keeper/relay.go
+++ b/x/ccv/consumer/keeper/relay.go
@@ -40,9 +40,13 @@ func (k Keeper) OnRecvVSCPacket(ctx sdk.Context, packet channeltypes.Packet, new
 	} else {
 		pendingChanges = utils.AccumulateChanges(currentChanges.ValidatorUpdates, newChanges.ValidatorUpdates)
 	}
-	k.SetPendingChanges(ctx, ccv.ValidatorSetChangePacketData{
+
+	err := k.SetPendingChanges(ctx, ccv.ValidatorSetChangePacketData{
 		ValidatorUpdates: pendingChanges,
 	})
+	if err != nil {
+		panic(fmt.Errorf("pending validator set change could not be persisted: %w", err))
+	}
 
 	// Save maturity time and packet
 	unbondingPeriod, found := k.GetUnbondingTime(ctx)

--- a/x/ccv/consumer/module.go
+++ b/x/ccv/consumer/module.go
@@ -182,7 +182,10 @@ func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.V
 		panic(err)
 	}
 
-	am.keeper.UnbondMaturePackets(ctx)
+	err = am.keeper.UnbondMaturePackets(ctx)
+	if err != nil {
+		panic(err)
+	}
 
 	data, ok := am.keeper.GetPendingChanges(ctx)
 	if !ok {

--- a/x/ccv/consumer/module.go
+++ b/x/ccv/consumer/module.go
@@ -182,9 +182,13 @@ func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.V
 		panic(err)
 	}
 
-	err = am.keeper.UnbondMaturePackets(ctx)
-	if err != nil {
-		panic(err)
+	// Unbond mature packets only if provider channel has been set
+	_, ok := am.keeper.GetProviderChannel(ctx)
+	if ok {
+		err = am.keeper.UnbondMaturePackets(ctx)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	data, ok := am.keeper.GetPendingChanges(ctx)

--- a/x/ccv/provider/client/proposal_handler.go
+++ b/x/ccv/provider/client/proposal_handler.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"time"
 
+	"path/filepath"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -114,7 +116,7 @@ type CreateConsumerChainProposalReq struct {
 func ParseCreateConsumerChainProposalJSON(proposalFile string) (CreateConsumerChainProposalJSON, error) {
 	proposal := CreateConsumerChainProposalJSON{}
 
-	contents, err := ioutil.ReadFile(proposalFile)
+	contents, err := ioutil.ReadFile(filepath.Clean(proposalFile))
 	if err != nil {
 		return proposal, err
 	}

--- a/x/ccv/provider/module.go
+++ b/x/ccv/provider/module.go
@@ -77,7 +77,10 @@ func (AppModuleBasic) RegisterRESTRoutes(clientCtx client.Context, rtr *mux.Rout
 // RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the ibc-provider module.
 // TODO
 func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
-	types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
+	err := types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx))
+	if err != nil {
+		panic(err)
+	}
 }
 
 // GetTxCmd implements AppModuleBasic interface

--- a/x/ccv/types/ccv_test.go
+++ b/x/ccv/types/ccv_test.go
@@ -86,7 +86,7 @@ func TestMarshalPacketData(t *testing.T) {
 	require.NoError(t, err, "marshalling packet data returned error")
 
 	recovered := types.ValidatorSetChangePacketData{}
-	recovered.Unmarshal(bz)
-
+	err = recovered.Unmarshal(bz)
+	require.Nil(t, err)
 	require.Equal(t, vpd, recovered, "unmarshaled packet data does not equal original value")
 }


### PR DESCRIPTION
Closes #223 and #228

Comments: 
- SonarCloud analysis is still failing due to repetition in new code (expected for error handling) 
- I chose to be explicit and tag each instance which should bypass gosec's warning: ```G204 (CWE-78): Subprocess launched with a potential tainted input or cmd arguments```. If the integration-tests directory is _never_ relevant to gosec, I can add a one-liner to exclude that directory from the lint altogether
- I added a call to ```filepath.Clean()``` [here](https://github.com/cosmos/interchain-security/blob/make-gosec-pass/x/ccv/provider/client/proposal_handler.go#L119), following [this suggestion](https://stackoverflow.com/questions/52320708/how-to-handle-gosec-linter-warning-potential-file-inclusion-via-variable/52321435). From my understanding of the Clean method, this should be fine, but correct me if I'm wrong  