### PR TITLE
Constant Length Key Prefixes

### DIFF
--- a/x/ccv/consumer/keeper/distribution.go
+++ b/x/ccv/consumer/keeper/distribution.go
@@ -98,7 +98,7 @@ func (k Keeper) GetLastTransmissionBlockHeight(ctx sdk.Context) (
 	*types.LastTransmissionBlockHeight, error) {
 
 	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.LastDistributionTransmissionKey)
+	bz := store.Get(types.LastDistributionTransmissionKey())
 	ltbh := &types.LastTransmissionBlockHeight{}
 	if bz != nil {
 		err := ltbh.Unmarshal(bz)
@@ -117,7 +117,7 @@ func (k Keeper) SetLastTransmissionBlockHeight(ctx sdk.Context,
 	if err != nil {
 		return err
 	}
-	store.Set(types.LastDistributionTransmissionKey, bz)
+	store.Set(types.LastDistributionTransmissionKey(), bz)
 	return nil
 }
 

--- a/x/ccv/consumer/keeper/keeper.go
+++ b/x/ccv/consumer/keeper/keeper.go
@@ -237,11 +237,12 @@ func (k Keeper) DeletePendingChanges(ctx sdk.Context) {
 // IteratePacketMaturityTime iterates through the VSC packet maturity times set in the store
 func (k Keeper) IteratePacketMaturityTime(ctx sdk.Context, cb func(vscId, timeNs uint64) bool) {
 	store := ctx.KVStore(k.storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, types.PacketMaturityTimePrefix())
+	iterator := sdk.KVStorePrefixIterator(store, []byte{types.PacketMaturityTimeBytePrefix})
 
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
-		seqBytes := iterator.Key()[len(types.PacketMaturityTimePrefix()):]
+		// Extract bytes following the 1 byte prefix
+		seqBytes := iterator.Key()[1:]
 		seq := binary.BigEndian.Uint64(seqBytes)
 
 		timeNs := binary.BigEndian.Uint64(iterator.Value())
@@ -376,7 +377,7 @@ func (k Keeper) DeleteCCValidator(ctx sdk.Context, addr []byte) {
 // GetAllCCValidator returns all cross-chain validators
 func (k Keeper) GetAllCCValidator(ctx sdk.Context) (validators []types.CrossChainValidator) {
 	store := ctx.KVStore(k.storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, types.CrossChainValidatorPrefix())
+	iterator := sdk.KVStorePrefixIterator(store, []byte{types.CrossChainValidatorBytePrefix})
 
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
@@ -396,13 +397,13 @@ func (k Keeper) SetPendingSlashRequests(ctx sdk.Context, requests []types.SlashR
 	if err != nil {
 		panic(fmt.Errorf("failed to encode slash request json: %w", err))
 	}
-	store.Set(types.PendingSlashRequestsPrefix(), buf.Bytes())
+	store.Set([]byte{types.PendingSlashRequestsBytePrefix}, buf.Bytes())
 }
 
 // GetPendingSlashRequest returns the pending slash requests in store
 func (k Keeper) GetPendingSlashRequests(ctx sdk.Context) (requests []types.SlashRequest) {
 	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.PendingSlashRequestsPrefix())
+	bz := store.Get([]byte{types.PendingSlashRequestsBytePrefix})
 	if bz == nil {
 		return
 	}
@@ -425,5 +426,5 @@ func (k Keeper) AppendPendingSlashRequests(ctx sdk.Context, req types.SlashReque
 // ClearPendingSlashRequests clears the pending slash requests in store
 func (k Keeper) ClearPendingSlashRequests(ctx sdk.Context) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete(types.PendingSlashRequestsPrefix())
+	store.Delete([]byte{types.PendingSlashRequestsBytePrefix})
 }

--- a/x/ccv/consumer/keeper/keeper.go
+++ b/x/ccv/consumer/keeper/keeper.go
@@ -120,13 +120,13 @@ func (k Keeper) BindPort(ctx sdk.Context, portID string) error {
 // GetPort returns the portID for the transfer module. Used in ExportGenesis
 func (k Keeper) GetPort(ctx sdk.Context) string {
 	store := ctx.KVStore(k.storeKey)
-	return string(store.Get(types.PortKey))
+	return string(store.Get(types.PortKey()))
 }
 
 // SetPort sets the portID for the transfer module. Used in InitGenesis
 func (k Keeper) SetPort(ctx sdk.Context, portID string) {
 	store := ctx.KVStore(k.storeKey)
-	store.Set(types.PortKey, []byte(portID))
+	store.Set(types.PortKey(), []byte(portID))
 }
 
 // AuthenticateCapability wraps the scopedKeeper's AuthenticateCapability function
@@ -237,11 +237,11 @@ func (k Keeper) DeletePendingChanges(ctx sdk.Context) {
 // IteratePacketMaturityTime iterates through the VSC packet maturity times set in the store
 func (k Keeper) IteratePacketMaturityTime(ctx sdk.Context, cb func(vscId, timeNs uint64) bool) {
 	store := ctx.KVStore(k.storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, []byte(types.PacketMaturityTimePrefix))
+	iterator := sdk.KVStorePrefixIterator(store, types.PacketMaturityTimePrefix())
 
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
-		seqBytes := iterator.Key()[len([]byte(types.PacketMaturityTimePrefix)):]
+		seqBytes := iterator.Key()[len(types.PacketMaturityTimePrefix()):]
 		seq := binary.BigEndian.Uint64(seqBytes)
 
 		timeNs := binary.BigEndian.Uint64(iterator.Value())
@@ -351,13 +351,13 @@ func (k Keeper) SetCCValidator(ctx sdk.Context, v types.CrossChainValidator) {
 	store := ctx.KVStore(k.storeKey)
 	bz := k.cdc.MustMarshal(&v)
 
-	store.Set(types.GetCrossChainValidatorKey(v.Address), bz)
+	store.Set(types.CrossChainValidatorKey(v.Address), bz)
 }
 
 // GetCCValidator returns a cross-chain validator for a given address
 func (k Keeper) GetCCValidator(ctx sdk.Context, addr []byte) (validator types.CrossChainValidator, found bool) {
 	store := ctx.KVStore(k.storeKey)
-	v := store.Get(types.GetCrossChainValidatorKey(addr))
+	v := store.Get(types.CrossChainValidatorKey(addr))
 	if v == nil {
 		return
 	}
@@ -370,13 +370,13 @@ func (k Keeper) GetCCValidator(ctx sdk.Context, addr []byte) (validator types.Cr
 // DeleteCCValidator deletes a cross-chain validator for a given address
 func (k Keeper) DeleteCCValidator(ctx sdk.Context, addr []byte) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete(types.GetCrossChainValidatorKey(addr))
+	store.Delete(types.CrossChainValidatorKey(addr))
 }
 
 // GetAllCCValidator returns all cross-chain validators
 func (k Keeper) GetAllCCValidator(ctx sdk.Context) (validators []types.CrossChainValidator) {
 	store := ctx.KVStore(k.storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, []byte(types.CrossChainValidatorPrefix))
+	iterator := sdk.KVStorePrefixIterator(store, types.CrossChainValidatorPrefix())
 
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
@@ -396,13 +396,13 @@ func (k Keeper) SetPendingSlashRequests(ctx sdk.Context, requests []types.SlashR
 	if err != nil {
 		panic(fmt.Errorf("failed to encode slash request json: %w", err))
 	}
-	store.Set([]byte(types.PendingSlashRequestsPrefix), buf.Bytes())
+	store.Set(types.PendingSlashRequestsPrefix(), buf.Bytes())
 }
 
 // GetPendingSlashRequest returns the pending slash requests in store
 func (k Keeper) GetPendingSlashRequests(ctx sdk.Context) (requests []types.SlashRequest) {
 	store := ctx.KVStore(k.storeKey)
-	bz := store.Get([]byte(types.PendingSlashRequestsPrefix))
+	bz := store.Get(types.PendingSlashRequestsPrefix())
 	if bz == nil {
 		return
 	}
@@ -425,5 +425,5 @@ func (k Keeper) AppendPendingSlashRequests(ctx sdk.Context, req types.SlashReque
 // ClearPendingSlashRequests clears the pending slash requests in store
 func (k Keeper) ClearPendingSlashRequests(ctx sdk.Context) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete([]byte(types.PendingSlashRequestsPrefix))
+	store.Delete(types.PendingSlashRequestsPrefix())
 }

--- a/x/ccv/consumer/keeper/relay.go
+++ b/x/ccv/consumer/keeper/relay.go
@@ -73,7 +73,7 @@ func (k Keeper) OnRecvVSCPacket(ctx sdk.Context, packet channeltypes.Packet, new
 func (k Keeper) UnbondMaturePackets(ctx sdk.Context) error {
 
 	store := ctx.KVStore(k.storeKey)
-	maturityIterator := sdk.KVStorePrefixIterator(store, []byte(types.PacketMaturityTimePrefix))
+	maturityIterator := sdk.KVStorePrefixIterator(store, types.PacketMaturityTimePrefix())
 	defer maturityIterator.Close()
 
 	currentTime := uint64(ctx.BlockTime().UnixNano())
@@ -84,7 +84,7 @@ func (k Keeper) UnbondMaturePackets(ctx sdk.Context) error {
 	}
 
 	for maturityIterator.Valid() {
-		vscId := types.GetIdFromPacketMaturityTimeKey(maturityIterator.Key())
+		vscId := types.IdFromPacketMaturityTimeKey(maturityIterator.Key())
 		if currentTime >= binary.BigEndian.Uint64(maturityIterator.Value()) {
 			// send VSCMatured packet
 			// - construct validator set change packet data

--- a/x/ccv/consumer/keeper/relay.go
+++ b/x/ccv/consumer/keeper/relay.go
@@ -73,7 +73,7 @@ func (k Keeper) OnRecvVSCPacket(ctx sdk.Context, packet channeltypes.Packet, new
 func (k Keeper) UnbondMaturePackets(ctx sdk.Context) error {
 
 	store := ctx.KVStore(k.storeKey)
-	maturityIterator := sdk.KVStorePrefixIterator(store, types.PacketMaturityTimePrefix())
+	maturityIterator := sdk.KVStorePrefixIterator(store, []byte{types.PacketMaturityTimeBytePrefix})
 	defer maturityIterator.Close()
 
 	currentTime := uint64(ctx.BlockTime().UnixNano())

--- a/x/ccv/consumer/keeper/validators.go
+++ b/x/ccv/consumer/keeper/validators.go
@@ -123,7 +123,7 @@ func (k Keeper) UnbondingTime(ctx sdk.Context) time.Duration {
 // GetHistoricalInfo gets the historical info at a given height
 func (k Keeper) GetHistoricalInfo(ctx sdk.Context, height int64) (stakingtypes.HistoricalInfo, bool) {
 	store := ctx.KVStore(k.storeKey)
-	key := types.GetHistoricalInfoKey(height)
+	key := types.HistoricalInfoKey(height)
 
 	value := store.Get(key)
 	if value == nil {
@@ -136,7 +136,7 @@ func (k Keeper) GetHistoricalInfo(ctx sdk.Context, height int64) (stakingtypes.H
 // SetHistoricalInfo sets the historical info at a given height
 func (k Keeper) SetHistoricalInfo(ctx sdk.Context, height int64, hi *stakingtypes.HistoricalInfo) {
 	store := ctx.KVStore(k.storeKey)
-	key := types.GetHistoricalInfoKey(height)
+	key := types.HistoricalInfoKey(height)
 	value := k.cdc.MustMarshal(hi)
 
 	store.Set(key, value)
@@ -145,7 +145,7 @@ func (k Keeper) SetHistoricalInfo(ctx sdk.Context, height int64, hi *stakingtype
 // DeleteHistoricalInfo deletes the historical info at a given height
 func (k Keeper) DeleteHistoricalInfo(ctx sdk.Context, height int64) {
 	store := ctx.KVStore(k.storeKey)
-	key := types.GetHistoricalInfoKey(height)
+	key := types.HistoricalInfoKey(height)
 
 	store.Delete(key)
 }

--- a/x/ccv/consumer/types/keys.go
+++ b/x/ccv/consumer/types/keys.go
@@ -74,12 +74,12 @@ const (
 	CrossChainValidatorBytePrefix
 )
 
-// Returns the key to the port ID in the store
+// PortKey returns the key to the port ID in the store
 func PortKey() []byte {
 	return []byte{PortByteKey}
 }
 
-// Returns the key to the last distribution transmission in the store
+// LastDistributionTransmissionKey returns the key to the last distribution transmission in the store
 func LastDistributionTransmissionKey() []byte {
 	return []byte{LastDistributionTransmissionByteKey}
 }
@@ -104,33 +104,33 @@ func PendingChangesKey() []byte {
 	return []byte{PendingChangesByteKey}
 }
 
-// Returns the historical info key prefix for historical info on each height
+// HistoricalInfoPrefix returns the historical info key prefix for historical info on each height
 func HistoricalInfoPrefix() []byte {
 	return []byte{HistoricalInfoBytePrefix}
 }
 
-// Returns the key prefix of maturity times stored for each received VSC packet
+// PacketMaturityTimePrefix returns the key prefix of maturity times stored for each received VSC packet
 func PacketMaturityTimePrefix() []byte {
 	return []byte{PacketMaturityTimeBytePrefix}
 }
 
-// Returns the key prefix for the mapping from block height to valset update ID
+// HeightValsetUpdateIDPrefix returns the key prefix for the mapping from block height to valset update ID
 func HeightValsetUpdateIDPrefix() []byte {
 	return []byte{HeightValsetUpdateIDBytePrefix}
 }
 
-// Returns the key prefix for validators' outstanding downtime by consensus address
+// OutstandingDowntimePrefix returns the key prefix for validators' outstanding downtime by consensus address
 func OutstandingDowntimePrefix() []byte {
 	return []byte{OutstandingDowntimeBytePrefix}
 }
 
-// Returns the key prefix for a list of slash request that must be sent
+// PendingSlashRequestsPrefix returns the key prefix for a list of slash request that must be sent
 // to the provider chain once the CCV channel is established
 func PendingSlashRequestsPrefix() []byte {
 	return []byte{PendingSlashRequestsBytePrefix}
 }
 
-// Returns the key prefix for cross-chain validators by consensus address
+// CrossChainValidatorPrefix returns the key prefix for cross-chain validators by consensus address
 func CrossChainValidatorPrefix() []byte {
 	return []byte{CrossChainValidatorBytePrefix}
 }
@@ -142,29 +142,29 @@ func PacketMaturityTimeKey(id uint64) []byte {
 	return append(PacketMaturityTimePrefix(), seqBytes...)
 }
 
-// Returns the packet id corresponding to a maturity time full key (including prefix)
+// IdFromPacketMaturityTimeKey returns the packet id corresponding to a maturity time full key (including prefix)
 func IdFromPacketMaturityTimeKey(key []byte) uint64 {
 	return binary.BigEndian.Uint64(key[len(PacketMaturityTimePrefix()):])
 }
 
-// Returns the key to a valset update ID for a given block height
+// HeightValsetUpdateIDKey returns the key to a valset update ID for a given block height
 func HeightValsetUpdateIDKey(height uint64) []byte {
 	hBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(hBytes, height)
 	return append(HeightValsetUpdateIDPrefix(), hBytes...)
 }
 
-// Returns the key to a validators' outstanding downtime by consensus address
+// OutstandingDowntimeKey returns the key to a validators' outstanding downtime by consensus address
 func OutstandingDowntimeKey(v sdk.ConsAddress) []byte {
 	return append(OutstandingDowntimePrefix(), address.MustLengthPrefix(v.Bytes())...)
 }
 
-// Returns the key to a cross chain validator by consensus address
+// CrossChainValidatorKey returns the key to a cross chain validator by consensus address
 func CrossChainValidatorKey(addr []byte) []byte {
 	return append(CrossChainValidatorPrefix(), addr...)
 }
 
-// Returns the key to historical info to a given block height
+// HistoricalInfoKey returns the key to historical info to a given block height
 func HistoricalInfoKey(height int64) []byte {
 	hBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(hBytes, uint64(height))

--- a/x/ccv/consumer/types/keys.go
+++ b/x/ccv/consumer/types/keys.go
@@ -29,16 +29,16 @@ const (
 	// ConsumerRedistributeName the root string for the consumer-redistribution account address
 	ConsumerRedistributeName = "cons_redistribute"
 
-	// ConsumerToSendToProviderName is a "buffer" address for outgoing fees to be transferred to the provider chain.
+	// ConsumerToSendToProviderName is a "buffer" address for outgoing fees to be transferred to the provider chain
 	ConsumerToSendToProviderName = "cons_to_send_to_provider"
 )
 
-// Iota generated keys/key prefixes (as a byte), supports 256 possible values.
+// Iota generated keys/key prefixes (as a byte), supports 256 possible values
 const (
 	// PortByteKey defines the byte key to store the port ID in store
 	PortByteKey byte = iota
 
-	// LastDistributionTransmissionByteKey defines the byte key to store the last distribution transmission.
+	// LastDistributionTransmissionByteKey defines the byte key to store the last distribution transmission
 	LastDistributionTransmissionByteKey
 
 	// UnbondingTimeKeyString is the byte key for storing the unbonding period
@@ -74,10 +74,12 @@ const (
 	CrossChainValidatorBytePrefix
 )
 
+// Returns the key to the port ID in the store
 func PortKey() []byte {
 	return []byte{PortByteKey}
 }
 
+// Returns the key to the last distribution transmission in the store
 func LastDistributionTransmissionKey() []byte {
 	return []byte{LastDistributionTransmissionByteKey}
 }
@@ -92,7 +94,7 @@ func ProviderClientKey() []byte {
 	return []byte{ProviderClientByteKey}
 }
 
-// ProviderChannelKey returns the key for storing channelID of the provider chain.
+// ProviderChannelKey returns the key for storing channelID of the provider chain
 func ProviderChannelKey() []byte {
 	return []byte{ProviderChannelByteKey}
 }
@@ -102,26 +104,33 @@ func PendingChangesKey() []byte {
 	return []byte{PendingChangesByteKey}
 }
 
+// Returns the historical info key prefix for historical info on each height
 func HistoricalInfoPrefix() []byte {
 	return []byte{HistoricalInfoBytePrefix}
 }
 
+// Returns the key prefix of maturity times stored for each received VSC packet
 func PacketMaturityTimePrefix() []byte {
 	return []byte{PacketMaturityTimeBytePrefix}
 }
 
+// Returns the key prefix for the mapping from block height to valset update ID
 func HeightValsetUpdateIDPrefix() []byte {
 	return []byte{HeightValsetUpdateIDBytePrefix}
 }
 
+// Returns the key prefix for validators' outstanding downtime by consensus address
 func OutstandingDowntimePrefix() []byte {
 	return []byte{OutstandingDowntimeBytePrefix}
 }
 
+// Returns the key prefix for a list of slash request that must be sent
+// to the provider chain once the CCV channel is established
 func PendingSlashRequestsPrefix() []byte {
 	return []byte{PendingSlashRequestsBytePrefix}
 }
 
+// Returns the key prefix for cross-chain validators by consensus address
 func CrossChainValidatorPrefix() []byte {
 	return []byte{CrossChainValidatorBytePrefix}
 }
@@ -133,24 +142,29 @@ func PacketMaturityTimeKey(id uint64) []byte {
 	return append(PacketMaturityTimePrefix(), seqBytes...)
 }
 
+// Returns the packet id corresponding to a maturity time full key (including prefix)
 func IdFromPacketMaturityTimeKey(key []byte) uint64 {
 	return binary.BigEndian.Uint64(key[len(PacketMaturityTimePrefix()):])
 }
 
+// Returns the key to a valset update ID for a given block height
 func HeightValsetUpdateIDKey(height uint64) []byte {
 	hBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(hBytes, height)
 	return append(HeightValsetUpdateIDPrefix(), hBytes...)
 }
 
+// Returns the key to a validators' outstanding downtime by consensus address
 func OutstandingDowntimeKey(v sdk.ConsAddress) []byte {
 	return append(OutstandingDowntimePrefix(), address.MustLengthPrefix(v.Bytes())...)
 }
 
+// Returns the key to a cross chain validator by consensus address
 func CrossChainValidatorKey(addr []byte) []byte {
 	return append(CrossChainValidatorPrefix(), addr...)
 }
 
+// Returns the key to historical info to a given block height
 func HistoricalInfoKey(height int64) []byte {
 	hBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(hBytes, uint64(height))

--- a/x/ccv/consumer/types/keys.go
+++ b/x/ccv/consumer/types/keys.go
@@ -23,101 +23,136 @@ const (
 	// QuerierRoute is the querier route for IBC consumer
 	QuerierRoute = ModuleName
 
-	// UnbondingTimeKeyString is the key for storing the unbonding period
-	UnbondingTimeKeyString = "unbondingtime"
-
-	// ProviderClientKeyString is the key for storing the clientID of the provider client
-	ProviderClientKeyString = "providerclient"
-
-	// ProviderChannelKeyString is the key for storing the channelID of the CCV channel
-	ProviderChannelKeyString = "providerchannel"
-
-	// PendingChangesKeyString is the key that will store any pending validator set changes
-	// received over CCV channel but not yet flushed over ABCI
-	PendingChangesKeyString = "pendingchanges"
-
-	// PacketMaturityTimePrefix is the key prefix that will store maturity time for each received VSC packet
-	PacketMaturityTimePrefix = "packetmaturitytime"
-
 	// HistoricalEntries is set to 10000 like the staking module parameter DefaultHistoricalEntries
 	HistoricalEntries uint32 = 10000
-
-	// HeightValsetUpdateIDPrefix is the key prefix that will store the mapping from block height to valset update ID
-	HeightValsetUpdateIDPrefix = "heightvalsetupdateid"
-
-	// OutstandingDowntimePrefix is the key prefix that will store the validators outstanding downtime by consensus address
-	OutstandingDowntimePrefix = "outstandingdowntime"
-
-	// CrossChainValidatorPrefix is the key prefix that will store cross-chain validators by consensus address
-	CrossChainValidatorPrefix = "crosschainvalidator"
 
 	// ConsumerRedistributeName the root string for the consumer-redistribution account address
 	ConsumerRedistributeName = "cons_redistribute"
 
 	// ConsumerToSendToProviderName is a "buffer" address for outgoing fees to be transferred to the provider chain.
 	ConsumerToSendToProviderName = "cons_to_send_to_provider"
+)
 
-	// PendingSlashRequestsPrefix is the prefix that will store a list of slash request that must be sent
+// Iota generated keys/key prefixes (as a byte), supports 256 possible values.
+const (
+	// PortByteKey defines the byte key to store the port ID in store
+	PortByteKey byte = iota
+
+	// LastDistributionTransmissionByteKey defines the byte key to store the last distribution transmission.
+	LastDistributionTransmissionByteKey
+
+	// UnbondingTimeKeyString is the byte key for storing the unbonding period
+	UnbondingTimeByteKey
+
+	// ProviderClientKeyString is the byte key for storing the clientID of the provider client
+	ProviderClientByteKey
+
+	// ProviderChannelKeyString is the byte key for storing the channelID of the CCV channel
+	ProviderChannelByteKey
+
+	// PendingChangesKeyString is the byte key that will store any pending validator set changes
+	// received over CCV channel but not yet flushed over ABCI
+	PendingChangesByteKey
+
+	// HistoricalInfoKey is the byte prefix that will store the historical info for a given height
+	HistoricalInfoBytePrefix
+
+	// PacketMaturityTimePrefix is the byte prefix that will store maturity time for each received VSC packet
+	PacketMaturityTimeBytePrefix
+
+	// HeightValsetUpdateIDPrefix is the byte prefix that will store the mapping from block height to valset update ID
+	HeightValsetUpdateIDBytePrefix
+
+	// OutstandingDowntimePrefix is the byte prefix that will store the validators outstanding downtime by consensus address
+	OutstandingDowntimeBytePrefix
+
+	// PendingSlashRequestsPrefix is the byte prefix that will store a list of slash request that must be sent
 	// to the provider chain once the CCV channel is established
-	PendingSlashRequestsPrefix = "pendingslashrequests"
+	PendingSlashRequestsBytePrefix
 
-	// HistoricalInfoKey is the key prefix that will store the historical info for a given height
-	HistoricalInfoKey = "historicalinfokey"
+	// CrossChainValidatorPrefix is the byte prefix that will store cross-chain validators by consensus address
+	CrossChainValidatorBytePrefix
 )
 
-var (
-	// PortKey defines the key to store the port ID in store
-	PortKey                         = []byte{0x01}
-	LastDistributionTransmissionKey = []byte{0x02}
-)
+func PortKey() []byte {
+	return []byte{PortByteKey}
+}
+
+func LastDistributionTransmissionKey() []byte {
+	return []byte{LastDistributionTransmissionByteKey}
+}
 
 // UnbondingTimeKey returns the key for storing the unbonding period
 func UnbondingTimeKey() []byte {
-	return []byte(UnbondingTimeKeyString)
-}
-
-// ProviderChannelKey returns the key for storing channelID of the provider chain.
-func ProviderChannelKey() []byte {
-	return []byte(ProviderChannelKeyString)
+	return []byte{UnbondingTimeByteKey}
 }
 
 // ProviderClientKey returns the key for storing clientID of the provider
 func ProviderClientKey() []byte {
-	return []byte(ProviderClientKeyString)
+	return []byte{ProviderClientByteKey}
+}
+
+// ProviderChannelKey returns the key for storing channelID of the provider chain.
+func ProviderChannelKey() []byte {
+	return []byte{ProviderChannelByteKey}
 }
 
 // PendingChangesKey returns the key for storing pending validator set changes
 func PendingChangesKey() []byte {
-	return []byte(PendingChangesKeyString)
+	return []byte{PendingChangesByteKey}
+}
+
+func HistoricalInfoPrefix() []byte {
+	return []byte{HistoricalInfoBytePrefix}
+}
+
+func PacketMaturityTimePrefix() []byte {
+	return []byte{PacketMaturityTimeBytePrefix}
+}
+
+func HeightValsetUpdateIDPrefix() []byte {
+	return []byte{HeightValsetUpdateIDBytePrefix}
+}
+
+func OutstandingDowntimePrefix() []byte {
+	return []byte{OutstandingDowntimeBytePrefix}
+}
+
+func PendingSlashRequestsPrefix() []byte {
+	return []byte{PendingSlashRequestsBytePrefix}
+}
+
+func CrossChainValidatorPrefix() []byte {
+	return []byte{CrossChainValidatorBytePrefix}
 }
 
 // PacketMaturityTimeKey returns the key for storing maturity time for a given received VSC packet id
 func PacketMaturityTimeKey(id uint64) []byte {
 	seqBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(seqBytes, id)
-	return append([]byte(PacketMaturityTimePrefix), seqBytes...)
+	return append(PacketMaturityTimePrefix(), seqBytes...)
 }
 
-func GetIdFromPacketMaturityTimeKey(key []byte) uint64 {
-	return binary.BigEndian.Uint64(key[len(PacketMaturityTimePrefix):])
+func IdFromPacketMaturityTimeKey(key []byte) uint64 {
+	return binary.BigEndian.Uint64(key[len(PacketMaturityTimePrefix()):])
 }
 
 func HeightValsetUpdateIDKey(height uint64) []byte {
 	hBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(hBytes, height)
-	return append([]byte(HeightValsetUpdateIDPrefix), hBytes...)
+	return append(HeightValsetUpdateIDPrefix(), hBytes...)
 }
 
 func OutstandingDowntimeKey(v sdk.ConsAddress) []byte {
-	return append([]byte(OutstandingDowntimePrefix), address.MustLengthPrefix(v.Bytes())...)
+	return append(OutstandingDowntimePrefix(), address.MustLengthPrefix(v.Bytes())...)
 }
 
-func GetCrossChainValidatorKey(addr []byte) []byte {
-	return append([]byte(CrossChainValidatorPrefix), addr...)
+func CrossChainValidatorKey(addr []byte) []byte {
+	return append(CrossChainValidatorPrefix(), addr...)
 }
 
-func GetHistoricalInfoKey(height int64) []byte {
+func HistoricalInfoKey(height int64) []byte {
 	hBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(hBytes, uint64(height))
-	return append([]byte(HistoricalInfoKey), hBytes...)
+	return append(HistoricalInfoPrefix(), hBytes...)
 }

--- a/x/ccv/consumer/types/keys.go
+++ b/x/ccv/consumer/types/keys.go
@@ -104,69 +104,39 @@ func PendingChangesKey() []byte {
 	return []byte{PendingChangesByteKey}
 }
 
-// HistoricalInfoPrefix returns the historical info key prefix for historical info on each height
-func HistoricalInfoPrefix() []byte {
-	return []byte{HistoricalInfoBytePrefix}
-}
-
-// PacketMaturityTimePrefix returns the key prefix of maturity times stored for each received VSC packet
-func PacketMaturityTimePrefix() []byte {
-	return []byte{PacketMaturityTimeBytePrefix}
-}
-
-// HeightValsetUpdateIDPrefix returns the key prefix for the mapping from block height to valset update ID
-func HeightValsetUpdateIDPrefix() []byte {
-	return []byte{HeightValsetUpdateIDBytePrefix}
-}
-
-// OutstandingDowntimePrefix returns the key prefix for validators' outstanding downtime by consensus address
-func OutstandingDowntimePrefix() []byte {
-	return []byte{OutstandingDowntimeBytePrefix}
-}
-
-// PendingSlashRequestsPrefix returns the key prefix for a list of slash request that must be sent
-// to the provider chain once the CCV channel is established
-func PendingSlashRequestsPrefix() []byte {
-	return []byte{PendingSlashRequestsBytePrefix}
-}
-
-// CrossChainValidatorPrefix returns the key prefix for cross-chain validators by consensus address
-func CrossChainValidatorPrefix() []byte {
-	return []byte{CrossChainValidatorBytePrefix}
-}
-
 // PacketMaturityTimeKey returns the key for storing maturity time for a given received VSC packet id
 func PacketMaturityTimeKey(id uint64) []byte {
 	seqBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(seqBytes, id)
-	return append(PacketMaturityTimePrefix(), seqBytes...)
+	return append([]byte{PacketMaturityTimeBytePrefix}, seqBytes...)
 }
 
 // IdFromPacketMaturityTimeKey returns the packet id corresponding to a maturity time full key (including prefix)
 func IdFromPacketMaturityTimeKey(key []byte) uint64 {
-	return binary.BigEndian.Uint64(key[len(PacketMaturityTimePrefix()):])
+	// Bytes after single byte prefix are converted to uin64
+	return binary.BigEndian.Uint64(key[1:])
 }
 
 // HeightValsetUpdateIDKey returns the key to a valset update ID for a given block height
 func HeightValsetUpdateIDKey(height uint64) []byte {
 	hBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(hBytes, height)
-	return append(HeightValsetUpdateIDPrefix(), hBytes...)
+	return append([]byte{HeightValsetUpdateIDBytePrefix}, hBytes...)
 }
 
 // OutstandingDowntimeKey returns the key to a validators' outstanding downtime by consensus address
 func OutstandingDowntimeKey(v sdk.ConsAddress) []byte {
-	return append(OutstandingDowntimePrefix(), address.MustLengthPrefix(v.Bytes())...)
+	return append([]byte{OutstandingDowntimeBytePrefix}, address.MustLengthPrefix(v.Bytes())...)
 }
 
 // CrossChainValidatorKey returns the key to a cross chain validator by consensus address
 func CrossChainValidatorKey(addr []byte) []byte {
-	return append(CrossChainValidatorPrefix(), addr...)
+	return append([]byte{CrossChainValidatorBytePrefix}, addr...)
 }
 
 // HistoricalInfoKey returns the key to historical info to a given block height
 func HistoricalInfoKey(height int64) []byte {
 	hBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(hBytes, uint64(height))
-	return append(HistoricalInfoPrefix(), hBytes...)
+	return append([]byte{HistoricalInfoBytePrefix}, hBytes...)
 }

--- a/x/ccv/consumer/types/keys_test.go
+++ b/x/ccv/consumer/types/keys_test.go
@@ -29,7 +29,7 @@ func TestNoDuplicates(t *testing.T) {
 }
 
 // Returns all singular keys, or prefixes to fully resolved keys,
-// any of which should be a single byte.
+// any of which should be a single, unique byte.
 func getSingleByteKeys() [][]byte {
 
 	keys := make([][]byte, 12)
@@ -41,12 +41,12 @@ func getSingleByteKeys() [][]byte {
 	keys[i], i = ProviderClientKey(), i+1
 	keys[i], i = ProviderChannelKey(), i+1
 	keys[i], i = PendingChangesKey(), i+1
-	keys[i], i = HistoricalInfoPrefix(), i+1
-	keys[i], i = PacketMaturityTimePrefix(), i+1
-	keys[i], i = HeightValsetUpdateIDPrefix(), i+1
-	keys[i], i = OutstandingDowntimePrefix(), i+1
-	keys[i], i = PendingSlashRequestsPrefix(), i+1
-	keys[i] = CrossChainValidatorPrefix()
+	keys[i], i = []byte{HistoricalInfoBytePrefix}, i+1
+	keys[i], i = []byte{PacketMaturityTimeBytePrefix}, i+1
+	keys[i], i = []byte{HeightValsetUpdateIDBytePrefix}, i+1
+	keys[i], i = []byte{OutstandingDowntimeBytePrefix}, i+1
+	keys[i], i = []byte{PendingSlashRequestsBytePrefix}, i+1
+	keys[i] = []byte{CrossChainValidatorBytePrefix}
 
 	return keys
 }

--- a/x/ccv/consumer/types/keys_test.go
+++ b/x/ccv/consumer/types/keys_test.go
@@ -1,0 +1,52 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Tests that all singular keys, or prefixes to fully resolves keys are a single byte long,
+// preventing injection attacks into restricted parts of a full store.
+func TestSameLength(t *testing.T) {
+
+	keys := getSingleByteKeys()
+
+	for _, keyByteArray := range keys {
+		require.Equal(t, 1, len(keyByteArray))
+	}
+}
+
+// Tests that all singular keys, or prefixes to fully resolves keys are non duplicate byte values.
+func TestNoDuplicates(t *testing.T) {
+
+	keys := getSingleByteKeys()
+
+	for i, keyByteArray := range keys {
+		keys[i] = nil
+		require.NotContains(t, keys, keyByteArray)
+	}
+}
+
+// Returns all singular keys, or prefixes to fully resolved keys,
+// any of which should be a single byte.
+func getSingleByteKeys() [][]byte {
+
+	keys := make([][]byte, 12)
+	i := 0
+
+	keys[i], i = PortKey(), i+1
+	keys[i], i = LastDistributionTransmissionKey(), i+1
+	keys[i], i = UnbondingTimeKey(), i+1
+	keys[i], i = ProviderClientKey(), i+1
+	keys[i], i = ProviderChannelKey(), i+1
+	keys[i], i = PendingChangesKey(), i+1
+	keys[i], i = HistoricalInfoPrefix(), i+1
+	keys[i], i = PacketMaturityTimePrefix(), i+1
+	keys[i], i = HeightValsetUpdateIDPrefix(), i+1
+	keys[i], i = OutstandingDowntimePrefix(), i+1
+	keys[i], i = PendingSlashRequestsPrefix(), i+1
+	keys[i] = CrossChainValidatorPrefix()
+
+	return keys
+}

--- a/x/ccv/provider/keeper/genesis.go
+++ b/x/ccv/provider/keeper/genesis.go
@@ -33,8 +33,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 
 func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	store := ctx.KVStore(k.storeKey)
-	keyPrefix := string(types.ChannelToChainPrefix())
-	iterator := sdk.KVStorePrefixIterator(store, []byte(keyPrefix))
+	iterator := sdk.KVStorePrefixIterator(store, types.ChannelToChainPrefix())
 	defer iterator.Close()
 
 	if !iterator.Valid() {
@@ -44,7 +43,7 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	var consumerStates []types.ConsumerState
 
 	for ; iterator.Valid(); iterator.Next() {
-		channelID := string(iterator.Key()[len(keyPrefix):])
+		channelID := string(iterator.Key()[len(types.ChannelToChainPrefix()):])
 		chainID := string(iterator.Value())
 
 		cc := types.ConsumerState{

--- a/x/ccv/provider/keeper/genesis.go
+++ b/x/ccv/provider/keeper/genesis.go
@@ -33,7 +33,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 
 func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	store := ctx.KVStore(k.storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, types.ChannelToChainPrefix())
+	iterator := sdk.KVStorePrefixIterator(store, []byte{types.ChannelToChainBytePrefix})
 	defer iterator.Close()
 
 	if !iterator.Valid() {
@@ -43,7 +43,8 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	var consumerStates []types.ConsumerState
 
 	for ; iterator.Valid(); iterator.Next() {
-		channelID := string(iterator.Key()[len(types.ChannelToChainPrefix()):])
+		// channelID is extracted from bytes in key following the single byte prefix
+		channelID := string(iterator.Key()[1:])
 		chainID := string(iterator.Value())
 
 		cc := types.ConsumerState{

--- a/x/ccv/provider/keeper/genesis.go
+++ b/x/ccv/provider/keeper/genesis.go
@@ -33,7 +33,8 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 
 func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	store := ctx.KVStore(k.storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, []byte(providertypes.ChannelToChainKeyPrefix+"/"))
+	keyPrefix := string(types.ChannelToChainPrefix()) + "/"
+	iterator := sdk.KVStorePrefixIterator(store, []byte(keyPrefix))
 	defer iterator.Close()
 
 	if !iterator.Valid() {
@@ -43,7 +44,7 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	var consumerStates []types.ConsumerState
 
 	for ; iterator.Valid(); iterator.Next() {
-		channelID := string(iterator.Key()[len(providertypes.ChannelToChainKeyPrefix+"/"):])
+		channelID := string(iterator.Key()[len(keyPrefix):])
 		chainID := string(iterator.Value())
 
 		cc := types.ConsumerState{

--- a/x/ccv/provider/keeper/genesis.go
+++ b/x/ccv/provider/keeper/genesis.go
@@ -33,7 +33,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 
 func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	store := ctx.KVStore(k.storeKey)
-	keyPrefix := string(types.ChannelToChainPrefix()) + "/"
+	keyPrefix := string(types.ChannelToChainPrefix())
 	iterator := sdk.KVStorePrefixIterator(store, []byte(keyPrefix))
 	defer iterator.Close()
 

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -333,7 +333,7 @@ func (k Keeper) SetUnbondingOpIndex(ctx sdk.Context, chainID string, valsetUpdat
 // IterateOverUnbondingOpIndex iterates over the unbonding indexes for a given chain id.
 func (k Keeper) IterateOverUnbondingOpIndex(ctx sdk.Context, chainID string, cb func(vscID uint64, ubdIndex []uint64) bool) {
 	store := ctx.KVStore(k.storeKey)
-	prefix := append(types.UnbondingOpIndexPrefix(), []byte(chainID)...)
+	prefix := append(types.UnbondingOpIndexPrefix(), types.HashString(chainID)...)
 	iterator := sdk.KVStorePrefixIterator(store, prefix)
 
 	defer iterator.Close()

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -94,13 +94,13 @@ func (k Keeper) BindPort(ctx sdk.Context, portID string) error {
 // GetPort returns the portID for the transfer module. Used in ExportGenesis
 func (k Keeper) GetPort(ctx sdk.Context) string {
 	store := ctx.KVStore(k.storeKey)
-	return string(store.Get(types.PortKey))
+	return string(store.Get(types.PortKey()))
 }
 
 // SetPort sets the portID for the transfer module. Used in InitGenesis
 func (k Keeper) SetPort(ctx sdk.Context, portID string) {
 	store := ctx.KVStore(k.storeKey)
-	store.Set(types.PortKey, []byte(portID))
+	store.Set(types.PortKey(), []byte(portID))
 }
 
 // AuthenticateCapability wraps the scopedKeeper's AuthenticateCapability function
@@ -141,7 +141,7 @@ func (k Keeper) DeleteChainToChannel(ctx sdk.Context, chainID string) {
 // a stop boolean which will stop the iteration.
 func (k Keeper) IterateConsumerChains(ctx sdk.Context, cb func(ctx sdk.Context, chainID string) (stop bool)) {
 	store := ctx.KVStore(k.storeKey)
-	keyPrefix := types.ChainToClientKeyPrefix + "/"
+	keyPrefix := string(types.ChainToClientPrefix()) + "/"
 	iterator := sdk.KVStorePrefixIterator(store, []byte(keyPrefix))
 	defer iterator.Close()
 
@@ -186,7 +186,8 @@ func (k Keeper) DeleteChannelToChain(ctx sdk.Context, channelID string) {
 // or the callback returns stop=true
 func (k Keeper) IterateChannelToChain(ctx sdk.Context, cb func(ctx sdk.Context, channelID, chainID string) (stop bool)) {
 	store := ctx.KVStore(k.storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, []byte(types.ChannelToChainKeyPrefix+"/"))
+	keyPrefix := string(types.ChannelToChainPrefix()) + "/"
+	iterator := sdk.KVStorePrefixIterator(store, []byte(keyPrefix))
 	defer iterator.Close()
 
 	if !iterator.Valid() {
@@ -194,7 +195,9 @@ func (k Keeper) IterateChannelToChain(ctx sdk.Context, cb func(ctx sdk.Context, 
 	}
 
 	for ; iterator.Valid(); iterator.Next() {
-		channelID := string(iterator.Key())
+		// remove prefix from key to retrieve channelID
+		channelID := string(iterator.Key()[len(keyPrefix):])
+
 		chainID := string(iterator.Value())
 
 		if cb(ctx, channelID, chainID) {
@@ -330,7 +333,7 @@ func (k Keeper) SetUnbondingOpIndex(ctx sdk.Context, chainID string, valsetUpdat
 // IterateOverUnbondingOpIndex iterates over the unbonding indexes for a given chain id.
 func (k Keeper) IterateOverUnbondingOpIndex(ctx sdk.Context, chainID string, cb func(vscID uint64, ubdIndex []uint64) bool) {
 	store := ctx.KVStore(k.storeKey)
-	prefix := append(types.HashString(types.UnbondingOpIndexPrefix), types.HashString(chainID)...)
+	prefix := append(types.UnbondingOpIndexPrefix(), []byte(chainID)...)
 	iterator := sdk.KVStorePrefixIterator(store, prefix)
 
 	defer iterator.Close()
@@ -481,7 +484,7 @@ func (k Keeper) IncrementValidatorSetUpdateId(ctx sdk.Context) {
 	bz := make([]byte, 8)
 	binary.BigEndian.PutUint64(bz, validatorSetUpdateId)
 
-	store.Set([]byte(types.ValidatorSetUpdateIdPrefix), bz)
+	store.Set(types.ValidatorSetUpdateIdKey(), bz)
 }
 
 func (k Keeper) SetValidatorSetUpdateId(ctx sdk.Context, valUpdateID uint64) {
@@ -491,12 +494,12 @@ func (k Keeper) SetValidatorSetUpdateId(ctx sdk.Context, valUpdateID uint64) {
 	bz := make([]byte, 8)
 	binary.BigEndian.PutUint64(bz, valUpdateID)
 
-	store.Set([]byte(types.ValidatorSetUpdateIdPrefix), bz)
+	store.Set(types.ValidatorSetUpdateIdKey(), bz)
 }
 
 func (k Keeper) GetValidatorSetUpdateId(ctx sdk.Context) (validatorSetUpdateId uint64) {
 	store := ctx.KVStore(k.storeKey)
-	bz := store.Get([]byte(types.ValidatorSetUpdateIdPrefix))
+	bz := store.Get(types.ValidatorSetUpdateIdKey())
 
 	if bz == nil {
 		validatorSetUpdateId = 0
@@ -623,12 +626,12 @@ func (k Keeper) EmptySlashAcks(ctx sdk.Context, chainID string) (acks []string) 
 // IterateSlashAcks iterates through the slash acks set in the store
 func (k Keeper) IterateSlashAcks(ctx sdk.Context, cb func(chainID string, acks []string) bool) {
 	store := ctx.KVStore(k.storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, []byte(types.SlashAcksPrefix))
+	iterator := sdk.KVStorePrefixIterator(store, types.SlashAcksPrefix())
 
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
 
-		id := string(iterator.Key()[len(types.SlashAcksPrefix)+1:])
+		chainID := string(iterator.Key()[len(types.SlashAcksPrefix())+1:])
 
 		var data []string
 		buf := bytes.NewBuffer(iterator.Value())
@@ -638,7 +641,7 @@ func (k Keeper) IterateSlashAcks(ctx sdk.Context, cb func(chainID string, acks [
 			panic(fmt.Errorf("failed to decode json: %w", err))
 		}
 
-		if !cb(id, data) {
+		if !cb(chainID, data) {
 			return
 		}
 	}

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -141,8 +141,7 @@ func (k Keeper) DeleteChainToChannel(ctx sdk.Context, chainID string) {
 // a stop boolean which will stop the iteration.
 func (k Keeper) IterateConsumerChains(ctx sdk.Context, cb func(ctx sdk.Context, chainID string) (stop bool)) {
 	store := ctx.KVStore(k.storeKey)
-	keyPrefix := string(types.ChainToClientPrefix())
-	iterator := sdk.KVStorePrefixIterator(store, []byte(keyPrefix))
+	iterator := sdk.KVStorePrefixIterator(store, types.ChainToClientPrefix())
 	defer iterator.Close()
 
 	if !iterator.Valid() {
@@ -151,7 +150,7 @@ func (k Keeper) IterateConsumerChains(ctx sdk.Context, cb func(ctx sdk.Context, 
 
 	for ; iterator.Valid(); iterator.Next() {
 		// remove prefix from key to retrieve chainID
-		chainID := string(iterator.Key()[len(keyPrefix):])
+		chainID := string(iterator.Key()[len(types.ChainToClientPrefix()):])
 
 		stop := cb(ctx, chainID)
 		if stop {
@@ -186,8 +185,7 @@ func (k Keeper) DeleteChannelToChain(ctx sdk.Context, channelID string) {
 // or the callback returns stop=true
 func (k Keeper) IterateChannelToChain(ctx sdk.Context, cb func(ctx sdk.Context, channelID, chainID string) (stop bool)) {
 	store := ctx.KVStore(k.storeKey)
-	keyPrefix := string(types.ChannelToChainPrefix())
-	iterator := sdk.KVStorePrefixIterator(store, []byte(keyPrefix))
+	iterator := sdk.KVStorePrefixIterator(store, types.ChannelToChainPrefix())
 	defer iterator.Close()
 
 	if !iterator.Valid() {
@@ -196,7 +194,7 @@ func (k Keeper) IterateChannelToChain(ctx sdk.Context, cb func(ctx sdk.Context, 
 
 	for ; iterator.Valid(); iterator.Next() {
 		// remove prefix from key to retrieve channelID
-		channelID := string(iterator.Key()[len(keyPrefix):])
+		channelID := string(iterator.Key()[len(types.ChannelToChainPrefix()):])
 
 		chainID := string(iterator.Value())
 
@@ -333,8 +331,8 @@ func (k Keeper) SetUnbondingOpIndex(ctx sdk.Context, chainID string, valsetUpdat
 // IterateOverUnbondingOpIndex iterates over the unbonding indexes for a given chain id.
 func (k Keeper) IterateOverUnbondingOpIndex(ctx sdk.Context, chainID string, cb func(vscID uint64, ubdIndex []uint64) bool) {
 	store := ctx.KVStore(k.storeKey)
-	prefix := append(types.UnbondingOpIndexPrefix(), types.HashString(chainID)...)
-	iterator := sdk.KVStorePrefixIterator(store, prefix)
+	iterationPrefix := append(types.UnbondingOpIndexPrefix(), types.HashString(chainID)...)
+	iterator := sdk.KVStorePrefixIterator(store, iterationPrefix)
 
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -141,7 +141,7 @@ func (k Keeper) DeleteChainToChannel(ctx sdk.Context, chainID string) {
 // a stop boolean which will stop the iteration.
 func (k Keeper) IterateConsumerChains(ctx sdk.Context, cb func(ctx sdk.Context, chainID string) (stop bool)) {
 	store := ctx.KVStore(k.storeKey)
-	keyPrefix := string(types.ChainToClientPrefix()) + "/"
+	keyPrefix := string(types.ChainToClientPrefix())
 	iterator := sdk.KVStorePrefixIterator(store, []byte(keyPrefix))
 	defer iterator.Close()
 
@@ -186,7 +186,7 @@ func (k Keeper) DeleteChannelToChain(ctx sdk.Context, channelID string) {
 // or the callback returns stop=true
 func (k Keeper) IterateChannelToChain(ctx sdk.Context, cb func(ctx sdk.Context, channelID, chainID string) (stop bool)) {
 	store := ctx.KVStore(k.storeKey)
-	keyPrefix := string(types.ChannelToChainPrefix()) + "/"
+	keyPrefix := string(types.ChannelToChainPrefix())
 	iterator := sdk.KVStorePrefixIterator(store, []byte(keyPrefix))
 	defer iterator.Close()
 

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -141,7 +141,7 @@ func (k Keeper) DeleteChainToChannel(ctx sdk.Context, chainID string) {
 // a stop boolean which will stop the iteration.
 func (k Keeper) IterateConsumerChains(ctx sdk.Context, cb func(ctx sdk.Context, chainID string) (stop bool)) {
 	store := ctx.KVStore(k.storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, types.ChainToClientPrefix())
+	iterator := sdk.KVStorePrefixIterator(store, []byte{types.ChainToClientBytePrefix})
 	defer iterator.Close()
 
 	if !iterator.Valid() {
@@ -149,8 +149,8 @@ func (k Keeper) IterateConsumerChains(ctx sdk.Context, cb func(ctx sdk.Context, 
 	}
 
 	for ; iterator.Valid(); iterator.Next() {
-		// remove prefix from key to retrieve chainID
-		chainID := string(iterator.Key()[len(types.ChainToClientPrefix()):])
+		// remove 1 byte prefix from key to retrieve chainID
+		chainID := string(iterator.Key()[1:])
 
 		stop := cb(ctx, chainID)
 		if stop {
@@ -185,7 +185,7 @@ func (k Keeper) DeleteChannelToChain(ctx sdk.Context, channelID string) {
 // or the callback returns stop=true
 func (k Keeper) IterateChannelToChain(ctx sdk.Context, cb func(ctx sdk.Context, channelID, chainID string) (stop bool)) {
 	store := ctx.KVStore(k.storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, types.ChannelToChainPrefix())
+	iterator := sdk.KVStorePrefixIterator(store, []byte{types.ChannelToChainBytePrefix})
 	defer iterator.Close()
 
 	if !iterator.Valid() {
@@ -194,7 +194,7 @@ func (k Keeper) IterateChannelToChain(ctx sdk.Context, cb func(ctx sdk.Context, 
 
 	for ; iterator.Valid(); iterator.Next() {
 		// remove prefix from key to retrieve channelID
-		channelID := string(iterator.Key()[len(types.ChannelToChainPrefix()):])
+		channelID := string(iterator.Key()[1:])
 
 		chainID := string(iterator.Value())
 
@@ -331,7 +331,7 @@ func (k Keeper) SetUnbondingOpIndex(ctx sdk.Context, chainID string, valsetUpdat
 // IterateOverUnbondingOpIndex iterates over the unbonding indexes for a given chain id.
 func (k Keeper) IterateOverUnbondingOpIndex(ctx sdk.Context, chainID string, cb func(vscID uint64, ubdIndex []uint64) bool) {
 	store := ctx.KVStore(k.storeKey)
-	iterationPrefix := append(types.UnbondingOpIndexPrefix(), types.HashString(chainID)...)
+	iterationPrefix := append([]byte{types.UnbondingOpIndexBytePrefix}, types.HashString(chainID)...)
 	iterator := sdk.KVStorePrefixIterator(store, iterationPrefix)
 
 	defer iterator.Close()
@@ -624,12 +624,12 @@ func (k Keeper) EmptySlashAcks(ctx sdk.Context, chainID string) (acks []string) 
 // IterateSlashAcks iterates through the slash acks set in the store
 func (k Keeper) IterateSlashAcks(ctx sdk.Context, cb func(chainID string, acks []string) bool) {
 	store := ctx.KVStore(k.storeKey)
-	iterator := sdk.KVStorePrefixIterator(store, types.SlashAcksPrefix())
+	iterator := sdk.KVStorePrefixIterator(store, []byte{types.SlashAcksBytePrefix})
 
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
 
-		chainID := string(iterator.Key()[len(types.SlashAcksPrefix())+1:])
+		chainID := string(iterator.Key()[1:])
 
 		var data []string
 		buf := bytes.NewBuffer(iterator.Value())

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -234,7 +234,7 @@ func (k Keeper) GetPendingClientInfo(ctx sdk.Context, timestamp time.Time, chain
 
 func (k Keeper) PendingClientIterator(ctx sdk.Context) sdk.Iterator {
 	store := ctx.KVStore(k.storeKey)
-	return sdk.KVStorePrefixIterator(store, []byte(types.PendingClientKeyPrefix))
+	return sdk.KVStorePrefixIterator(store, types.PendingClientPrefix())
 }
 
 // IteratePendingClientInfo iterates over the pending client info in order and creates the consumer client if the spawn time has passed,
@@ -310,7 +310,7 @@ func (k Keeper) DeletePendingStopProposals(ctx sdk.Context, proposals ...types.S
 
 func (k Keeper) PendingStopProposalIterator(ctx sdk.Context) sdk.Iterator {
 	store := ctx.KVStore(k.storeKey)
-	return sdk.KVStorePrefixIterator(store, []byte(types.PendingStopProposalKeyPrefix))
+	return sdk.KVStorePrefixIterator(store, types.PendingStopProposalPrefix())
 }
 
 // IteratePendingStopProposal iterates over the pending stop proposals in order and stop the chain if the stop time has passed,

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -234,7 +234,7 @@ func (k Keeper) GetPendingCreateProposal(ctx sdk.Context, timestamp time.Time, c
 
 func (k Keeper) PendingCreateProposalIterator(ctx sdk.Context) sdk.Iterator {
 	store := ctx.KVStore(k.storeKey)
-	return sdk.KVStorePrefixIterator(store, types.PendingCreateProposalPrefix())
+	return sdk.KVStorePrefixIterator(store, []byte{types.PendingCreateProposalBytePrefix})
 }
 
 // IteratePendingCreateProposal iterates over the pending proposals to create consumer chain clients in order
@@ -310,7 +310,7 @@ func (k Keeper) DeletePendingStopProposals(ctx sdk.Context, proposals ...types.S
 
 func (k Keeper) PendingStopProposalIterator(ctx sdk.Context) sdk.Iterator {
 	store := ctx.KVStore(k.storeKey)
-	return sdk.KVStorePrefixIterator(store, types.PendingStopProposalPrefix())
+	return sdk.KVStorePrefixIterator(store, []byte{types.PendingStopProposalBytePrefix})
 }
 
 // IteratePendingStopProposal iterates over the pending stop proposals in order and stop the chain if the stop time has passed,

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -27,7 +27,7 @@ func (k Keeper) CreateConsumerChainProposal(ctx sdk.Context, p *types.CreateCons
 		return k.CreateConsumerClient(ctx, p.ChainId, p.InitialHeight, p.LockUnbondingOnTimeout)
 	}
 
-	err := k.SetPendingClientInfo(ctx, p)
+	err := k.SetPendingCreateProposal(ctx, p)
 	if err != nil {
 		return err
 	}
@@ -207,22 +207,22 @@ func (k Keeper) MakeConsumerGenesis(ctx sdk.Context) (gen consumertypes.GenesisS
 	return gen, nil
 }
 
-// SetPendingClientInfo sets the initial height for the given timestamp and chain ID
-func (k Keeper) SetPendingClientInfo(ctx sdk.Context, clientInfo *types.CreateConsumerChainProposal) error {
+// SetPendingCreateProposal stores a pending proposal to create a consumer chain client
+func (k Keeper) SetPendingCreateProposal(ctx sdk.Context, clientInfo *types.CreateConsumerChainProposal) error {
 	store := ctx.KVStore(k.storeKey)
 	bz, err := k.cdc.Marshal(clientInfo)
 	if err != nil {
 		return err
 	}
 
-	store.Set(types.PendingClientKey(clientInfo.SpawnTime, clientInfo.ChainId), bz)
+	store.Set(types.PendingCreateProposalKey(clientInfo.SpawnTime, clientInfo.ChainId), bz)
 	return nil
 }
 
-// GetPendingClient gets the client pending info for the given timestamp and chain ID
-func (k Keeper) GetPendingClientInfo(ctx sdk.Context, timestamp time.Time, chainID string) types.CreateConsumerChainProposal {
+// GetPendingCreateProposal retrieves a pending proposal to create a consumer chain client (by spawn time and chain id)
+func (k Keeper) GetPendingCreateProposal(ctx sdk.Context, timestamp time.Time, chainID string) types.CreateConsumerChainProposal {
 	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.PendingClientKey(timestamp, chainID))
+	bz := store.Get(types.PendingCreateProposalKey(timestamp, chainID))
 	if len(bz) == 0 {
 		return types.CreateConsumerChainProposal{}
 	}
@@ -232,16 +232,16 @@ func (k Keeper) GetPendingClientInfo(ctx sdk.Context, timestamp time.Time, chain
 	return clientInfo
 }
 
-func (k Keeper) PendingClientIterator(ctx sdk.Context) sdk.Iterator {
+func (k Keeper) PendingCreateProposalIterator(ctx sdk.Context) sdk.Iterator {
 	store := ctx.KVStore(k.storeKey)
-	return sdk.KVStorePrefixIterator(store, types.PendingClientPrefix())
+	return sdk.KVStorePrefixIterator(store, types.PendingCreateProposalPrefix())
 }
 
-// IteratePendingClientInfo iterates over the pending client info in order and creates the consumer client if the spawn time has passed,
-// otherwise it will break out of loop and return.
-func (k Keeper) IteratePendingClientInfo(ctx sdk.Context) {
+// IteratePendingCreateProposal iterates over the pending proposals to create consumer chain clients in order
+// and creates the consumer client if the spawn time has passed, otherwise it will break out of loop and return.
+func (k Keeper) IteratePendingCreateProposal(ctx sdk.Context) {
 
-	iterator := k.PendingClientIterator(ctx)
+	iterator := k.PendingCreateProposalIterator(ctx)
 	defer iterator.Close()
 
 	if !iterator.Valid() {
@@ -252,7 +252,7 @@ func (k Keeper) IteratePendingClientInfo(ctx sdk.Context) {
 
 	for ; iterator.Valid(); iterator.Next() {
 		key := iterator.Key()
-		spawnTime, chainID, err := types.ParsePendingClientKey(key)
+		spawnTime, chainID, err := types.ParsePendingCreateProposalKey(key)
 		if err != nil {
 			panic(fmt.Errorf("failed to parse pending client key: %w", err))
 		}
@@ -273,15 +273,15 @@ func (k Keeper) IteratePendingClientInfo(ctx sdk.Context) {
 	}
 
 	// delete the proposals executed
-	k.DeletePendingClientInfo(ctx, execProposals...)
+	k.DeletePendingCreateProposal(ctx, execProposals...)
 }
 
-// DeletePendingClientInfo deletes the given create consumer proposals
-func (k Keeper) DeletePendingClientInfo(ctx sdk.Context, proposals ...types.CreateConsumerChainProposal) {
+// DeletePendingCreateProposal deletes the given create consumer proposals
+func (k Keeper) DeletePendingCreateProposal(ctx sdk.Context, proposals ...types.CreateConsumerChainProposal) {
 	store := ctx.KVStore(k.storeKey)
 
 	for _, p := range proposals {
-		store.Delete(types.PendingClientKey(p.SpawnTime, p.ChainId))
+		store.Delete(types.PendingCreateProposalKey(p.SpawnTime, p.ChainId))
 	}
 }
 

--- a/x/ccv/provider/keeper/proposal_test.go
+++ b/x/ccv/provider/keeper/proposal_test.go
@@ -103,7 +103,7 @@ func (suite *KeeperTestSuite) TestCreateConsumerChainProposal() {
 					suite.Require().Equal(expectedGenesis, consumerGenesis)
 					suite.Require().NotEqual("", clientId, "consumer client was not created after spawn time reached")
 				} else {
-					gotClient := suite.providerChain.App.(*appProvider.App).ProviderKeeper.GetPendingCreateProposalInfo(ctx, proposal.SpawnTime, chainID)
+					gotClient := suite.providerChain.App.(*appProvider.App).ProviderKeeper.GetPendingCreateProposal(ctx, proposal.SpawnTime, chainID)
 					suite.Require().Equal(initialHeight, gotClient.InitialHeight, "pending client not equal to clientstate in proposal")
 					suite.Require().Equal(lockUbdOnTimeout, gotClient.LockUnbondingOnTimeout, "pending client not equal to clientstate in proposal")
 				}
@@ -165,17 +165,17 @@ func (suite *KeeperTestSuite) TestIteratePendingClientInfo() {
 	}
 
 	for _, tc := range testCases {
-		err := suite.providerChain.App.(*appProvider.App).ProviderKeeper.SetPendingCreateProposalInfo(
+		err := suite.providerChain.App.(*appProvider.App).ProviderKeeper.SetPendingCreateProposal(
 			suite.providerChain.GetContext(), &tc.CreateConsumerChainProposal)
 		suite.Require().NoError(err)
 	}
 
 	ctx := suite.providerChain.GetContext().WithBlockTime(testCases[0].SpawnTime)
 
-	suite.providerChain.App.(*appProvider.App).ProviderKeeper.IteratePendingCreateProposalInfo(ctx)
+	suite.providerChain.App.(*appProvider.App).ProviderKeeper.IteratePendingCreateProposal(ctx)
 
 	for _, tc := range testCases {
-		res := suite.providerChain.App.(*appProvider.App).ProviderKeeper.GetPendingCreateProposalInfo(ctx, tc.SpawnTime, tc.ChainId)
+		res := suite.providerChain.App.(*appProvider.App).ProviderKeeper.GetPendingCreateProposal(ctx, tc.SpawnTime, tc.ChainId)
 		if !tc.ExpDeleted {
 			suite.Require().NotEmpty(res, "stop proposal was not deleted: %s %s", tc.ChainId, tc.SpawnTime.String())
 			continue

--- a/x/ccv/provider/keeper/proposal_test.go
+++ b/x/ccv/provider/keeper/proposal_test.go
@@ -103,7 +103,7 @@ func (suite *KeeperTestSuite) TestCreateConsumerChainProposal() {
 					suite.Require().Equal(expectedGenesis, consumerGenesis)
 					suite.Require().NotEqual("", clientId, "consumer client was not created after spawn time reached")
 				} else {
-					gotClient := suite.providerChain.App.(*appProvider.App).ProviderKeeper.GetPendingClientInfo(ctx, proposal.SpawnTime, chainID)
+					gotClient := suite.providerChain.App.(*appProvider.App).ProviderKeeper.GetPendingCreateProposalInfo(ctx, proposal.SpawnTime, chainID)
 					suite.Require().Equal(initialHeight, gotClient.InitialHeight, "pending client not equal to clientstate in proposal")
 					suite.Require().Equal(lockUbdOnTimeout, gotClient.LockUnbondingOnTimeout, "pending client not equal to clientstate in proposal")
 				}
@@ -165,17 +165,17 @@ func (suite *KeeperTestSuite) TestIteratePendingClientInfo() {
 	}
 
 	for _, tc := range testCases {
-		err := suite.providerChain.App.(*appProvider.App).ProviderKeeper.SetPendingClientInfo(
+		err := suite.providerChain.App.(*appProvider.App).ProviderKeeper.SetPendingCreateProposalInfo(
 			suite.providerChain.GetContext(), &tc.CreateConsumerChainProposal)
 		suite.Require().NoError(err)
 	}
 
 	ctx := suite.providerChain.GetContext().WithBlockTime(testCases[0].SpawnTime)
 
-	suite.providerChain.App.(*appProvider.App).ProviderKeeper.IteratePendingClientInfo(ctx)
+	suite.providerChain.App.(*appProvider.App).ProviderKeeper.IteratePendingCreateProposalInfo(ctx)
 
 	for _, tc := range testCases {
-		res := suite.providerChain.App.(*appProvider.App).ProviderKeeper.GetPendingClientInfo(ctx, tc.SpawnTime, tc.ChainId)
+		res := suite.providerChain.App.(*appProvider.App).ProviderKeeper.GetPendingCreateProposalInfo(ctx, tc.SpawnTime, tc.ChainId)
 		if !tc.ExpDeleted {
 			suite.Require().NotEmpty(res, "stop proposal was not deleted: %s %s", tc.ChainId, tc.SpawnTime.String())
 			continue

--- a/x/ccv/provider/module.go
+++ b/x/ccv/provider/module.go
@@ -159,7 +159,7 @@ func (AppModule) ConsensusVersion() uint64 { return 1 }
 // BeginBlock implements the AppModule interface
 func (am AppModule) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {
 	// Check if there are any consumer chains that are due to be started
-	am.keeper.IteratePendingClientInfo(ctx)
+	am.keeper.IteratePendingCreateProposal(ctx)
 	// Check if there are any consumer chains that are due to be stopped
 	am.keeper.IteratePendingStopProposal(ctx)
 }

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -91,7 +91,7 @@ const (
 	LockUnbondingOnTimeoutBytePrefix
 )
 
-// Returns the key to the port ID in the store
+// PortKey returns the key to the port ID in the store
 func PortKey() []byte {
 	return []byte{PortByteKey}
 }
@@ -264,13 +264,15 @@ func ParsePendingStopProposalKey(bz []byte) (time.Time, string, error) {
 	return timestamp, chainID, nil
 }
 
-// chainId is hashed to a fixed length sequence of bytes here to prevent injection attack between chainIDs.
+// UnbondingOpIndexKey returns an unbonding op index key
+// Note: chainId is hashed to a fixed length sequence of bytes here to prevent
+// injection attack between chainIDs.
 func UnbondingOpIndexKey(chainID string, valsetUpdateID uint64) []byte {
 	return AppendMany(UnbondingOpIndexPrefix(), HashString(chainID), []byte("/"),
 		sdk.Uint64ToBigEndian(valsetUpdateID))
 }
 
-// Parses an unbonding op index key for VSC ID
+// ParseUnbondingOpIndexKey parses an unbonding op index key for VSC ID
 func ParseUnbondingOpIndexKey(key []byte) (vscID []byte, err error) {
 	keySplit := bytes.Split(key, []byte("/"))
 	if len(keySplit) != 2 {
@@ -281,7 +283,7 @@ func ParseUnbondingOpIndexKey(key []byte) (vscID []byte, err error) {
 	return keySplit[1], nil
 }
 
-// Returns the key that stores a record of all the ids of consumer chains that
+// UnbondingOpKey returns the key that stores a record of all the ids of consumer chains that
 // need to unbond before a given delegation can unbond on this chain
 func UnbondingOpKey(id uint64) []byte {
 	bz := make([]byte, 8)
@@ -289,14 +291,14 @@ func UnbondingOpKey(id uint64) []byte {
 	return append(UnbondingOpPrefix(), bz...)
 }
 
-// Returns the key that storing the mapping from valset update ID to block height
+// ValsetUpdateBlockHeightKey returns the key that storing the mapping from valset update ID to block height
 func ValsetUpdateBlockHeightKey(valsetUpdateId uint64) []byte {
 	vuidBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(vuidBytes, valsetUpdateId)
 	return append(ValsetUpdateBlockHeightPrefix(), vuidBytes...)
 }
 
-// Returns the key corresponding to consumer genesis state material
+// ConsumerGenesisKey returns the key corresponding to consumer genesis state material
 // (consensus state and client state) indexed by consumer chain id
 func ConsumerGenesisKey(chainID string) []byte {
 	return append(ConsumerGenesisPrefix(), []byte("/"+chainID)...)
@@ -318,13 +320,13 @@ func PendingVSCsKey(chainID string) []byte {
 	return append(PendingVSCsPrefix(), []byte("/"+chainID)...)
 }
 
-// Returns the key that will store the consumer chain id which unbonding operations are locked
+// LockUnbondingOnTimeoutKey returns the key that will store the consumer chain id which unbonding operations are locked
 // on CCV channel timeout
 func LockUnbondingOnTimeoutKey(chainID string) []byte {
 	return append(LockUnbondingOnTimeoutPrefix(), []byte("/"+chainID)...)
 }
 
-// Appends a variable number of byte slices together
+// AppendMany appends a variable number of byte slices together
 func AppendMany(byteses ...[]byte) (out []byte) {
 	for _, bytes := range byteses {
 		out = append(out, bytes...)
@@ -332,7 +334,7 @@ func AppendMany(byteses ...[]byte) (out []byte) {
 	return out
 }
 
-// Outputs a fixed length 32 byte hash for any string
+// HashString outputs a fixed length 32 byte hash for any string
 func HashString(x string) []byte {
 	hash := sha256.Sum256([]byte(x))
 	return hash[:]

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"time"
@@ -241,8 +242,9 @@ func ParsePendingStopProposalKey(bz []byte) (time.Time, string, error) {
 	return timestamp, chainID, nil
 }
 
+// chainId is hashed to a fixed length sequence of bytes here to prevent injection attack between chainIDs.
 func UnbondingOpIndexKey(chainID string, valsetUpdateID uint64) []byte {
-	return AppendMany(UnbondingOpIndexPrefix(), []byte(chainID), []byte("/"),
+	return AppendMany(UnbondingOpIndexPrefix(), HashString(chainID), []byte("/"),
 		sdk.Uint64ToBigEndian(valsetUpdateID))
 }
 
@@ -298,4 +300,10 @@ func AppendMany(byteses ...[]byte) (out []byte) {
 		out = append(out, bytes...)
 	}
 	return out
+}
+
+// Outputs a fixed length 32 byte hash for any string
+func HashString(x string) []byte {
+	hash := sha256.Sum256([]byte(x))
+	return hash[:]
 }

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -181,17 +181,17 @@ func LockUnbondingOnTimeoutPrefix() []byte {
 
 // ChainToChannelKey returns the key under which the CCV channel ID will be stored for the given consumer chain.
 func ChainToChannelKey(chainID string) []byte {
-	return append(ChainToChannelPrefix(), []byte("/"+chainID)...)
+	return append(ChainToChannelPrefix(), []byte(chainID)...)
 }
 
 // ChannelToChainKey returns the key under which the consumer chain ID will be stored for the given channelID.
 func ChannelToChainKey(channelID string) []byte {
-	return append(ChannelToChainPrefix(), []byte("/"+channelID)...)
+	return append(ChannelToChainPrefix(), []byte(channelID)...)
 }
 
 // ChainToClientKey returns the key under which the clientID for the given chainID is stored.
 func ChainToClientKey(chainID string) []byte {
-	return append(ChainToClientPrefix(), []byte("/"+chainID)...)
+	return append(ChainToClientPrefix(), []byte(chainID)...)
 }
 
 // PendingClientKey returns the key under which a pending identified client is stored
@@ -268,19 +268,20 @@ func ParsePendingStopProposalKey(bz []byte) (time.Time, string, error) {
 // Note: chainId is hashed to a fixed length sequence of bytes here to prevent
 // injection attack between chainIDs.
 func UnbondingOpIndexKey(chainID string, valsetUpdateID uint64) []byte {
-	return AppendMany(UnbondingOpIndexPrefix(), HashString(chainID), []byte("/"),
+	return AppendMany(UnbondingOpIndexPrefix(), HashString(chainID),
 		sdk.Uint64ToBigEndian(valsetUpdateID))
 }
 
 // ParseUnbondingOpIndexKey parses an unbonding op index key for VSC ID
 func ParseUnbondingOpIndexKey(key []byte) (vscID []byte, err error) {
-	keySplit := bytes.Split(key, []byte("/"))
-	if len(keySplit) != 2 {
+	// This key should be of set length: prefix + hashed chain ID + uint64
+	expectedBytes := 1 + 32 + 8
+	if len(key) != expectedBytes {
 		return nil, sdkerrors.Wrapf(
-			sdkerrors.ErrLogic, "key provided is incorrect: the key split has incorrect length, expected %d, got %d", 2, len(keySplit),
+			sdkerrors.ErrLogic, "key provided is incorrect: the key has incorrect length, expected %d, got %d", expectedBytes, len(key),
 		)
 	}
-	return keySplit[1], nil
+	return key[1+32:], nil
 }
 
 // UnbondingOpKey returns the key that stores a record of all the ids of consumer chains that
@@ -301,29 +302,29 @@ func ValsetUpdateBlockHeightKey(valsetUpdateId uint64) []byte {
 // ConsumerGenesisKey returns the key corresponding to consumer genesis state material
 // (consensus state and client state) indexed by consumer chain id
 func ConsumerGenesisKey(chainID string) []byte {
-	return append(ConsumerGenesisPrefix(), []byte("/"+chainID)...)
+	return append(ConsumerGenesisPrefix(), []byte(chainID)...)
 }
 
 // SlashAcksKey returns the key under which slashing acks are stored for a given chain ID
 func SlashAcksKey(chainID string) []byte {
-	return append(SlashAcksPrefix(), []byte("/"+chainID)...)
+	return append(SlashAcksPrefix(), []byte(chainID)...)
 }
 
 // InitChainHeightKey returns the key under which the block height for a given chain ID is stored
 func InitChainHeightKey(chainID string) []byte {
-	return append(InitChainHeightPrefix(), []byte("/"+chainID)...)
+	return append(InitChainHeightPrefix(), []byte(chainID)...)
 }
 
 // PendingVSCsKey returns the key under which
 // pending ValidatorSetChangePacket data is stored for a given chain ID
 func PendingVSCsKey(chainID string) []byte {
-	return append(PendingVSCsPrefix(), []byte("/"+chainID)...)
+	return append(PendingVSCsPrefix(), []byte(chainID)...)
 }
 
 // LockUnbondingOnTimeoutKey returns the key that will store the consumer chain id which unbonding operations are locked
 // on CCV channel timeout
 func LockUnbondingOnTimeoutKey(chainID string) []byte {
-	return append(LockUnbondingOnTimeoutPrefix(), []byte("/"+chainID)...)
+	return append(LockUnbondingOnTimeoutPrefix(), []byte(chainID)...)
 }
 
 // AppendMany appends a variable number of byte slices together

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -292,12 +292,6 @@ func LockUnbondingOnTimeoutKey(chainID string) []byte {
 	return append(LockUnbondingOnTimeoutPrefix(), []byte("/"+chainID)...)
 }
 
-// // Outputs a fixed length 32 byte hash for any string
-// func HashString(x string) []byte {
-// 	hash := sha256.Sum256([]byte(x))
-// 	return hash[:]
-// }
-
 // Appends a variable number of byte slices together
 func AppendMany(byteses ...[]byte) (out []byte) {
 	for _, bytes := range byteses {

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -55,9 +55,9 @@ const (
 	// ChainToClientBytePrefix is the byte prefix for storing the consumer chainID for a given consumer clientid.
 	ChainToClientBytePrefix
 
-	// PendingClientBytePrefix is the byte prefix for storing the pending identified consumer chain client before the spawn time occurs.
+	// PendingCreateProposalBytePrefix is the byte prefix for storing the pending identified consumer chain client before the spawn time occurs.
 	// The key includes the BigEndian timestamp to allow for efficient chronological iteration
-	PendingClientBytePrefix
+	PendingCreateProposalBytePrefix
 
 	// PendingStopProposalBytePrefix is the byte prefix for storing the pending identified consumer chain before the stop time occurs.
 	// The key includes the BigEndian timestamp to allow for efficient chronological iteration
@@ -123,10 +123,10 @@ func ChainToClientPrefix() []byte {
 	return []byte{ChainToClientBytePrefix}
 }
 
-// PendingClientPrefix is the key prefix for storing the pending identified consumer chain client before the spawn time occurs.
+// PendingCreateProposalPrefix is the key prefix for storing the pending identified consumer chain client before the spawn time occurs.
 // The key includes the BigEndian timestamp to allow for efficient chronological iteration
-func PendingClientPrefix() []byte {
-	return []byte{PendingClientBytePrefix}
+func PendingCreateProposalPrefix() []byte {
+	return []byte{PendingCreateProposalBytePrefix}
 }
 
 // PendingStopProposalPrefix is the key prefix for storing the pending identified consumer chain before the stop time occurs.
@@ -194,15 +194,15 @@ func ChainToClientKey(chainID string) []byte {
 	return append(ChainToClientPrefix(), []byte(chainID)...)
 }
 
-// PendingClientKey returns the key under which a pending identified client is stored
-func PendingClientKey(timestamp time.Time, chainID string) []byte {
+// PendingCreateProposalKey returns the key under which a pending identified client is stored
+func PendingCreateProposalKey(timestamp time.Time, chainID string) []byte {
 	timeBz := sdk.FormatTimeBytes(timestamp)
 	timeBzL := len(timeBz)
-	prefixL := len(PendingClientPrefix())
+	prefixL := len(PendingCreateProposalPrefix())
 
 	bz := make([]byte, prefixL+8+timeBzL+len(chainID))
 	// copy the prefix
-	copy(bz[:prefixL], PendingClientPrefix())
+	copy(bz[:prefixL], PendingCreateProposalPrefix())
 	// copy the time length
 	copy(bz[prefixL:prefixL+8], sdk.Uint64ToBigEndian(uint64(timeBzL)))
 	// copy the time bytes
@@ -212,11 +212,11 @@ func PendingClientKey(timestamp time.Time, chainID string) []byte {
 	return bz
 }
 
-// ParsePendingClientKey returns the time and chain ID for a pending client key or an error if unparseable
-func ParsePendingClientKey(bz []byte) (time.Time, string, error) {
-	prefixL := len(PendingClientPrefix())
-	if prefix := bz[:prefixL]; !bytes.Equal(prefix, PendingClientPrefix()) {
-		return time.Time{}, "", fmt.Errorf("invalid prefix; expected: %X, got: %X", PendingClientPrefix(), prefix)
+// ParsePendingCreateProposalKey returns the time and chain ID for a pending client key or an error if unparseable
+func ParsePendingCreateProposalKey(bz []byte) (time.Time, string, error) {
+	prefixL := len(PendingCreateProposalPrefix())
+	if prefix := bz[:prefixL]; !bytes.Equal(prefix, PendingCreateProposalPrefix()) {
+		return time.Time{}, "", fmt.Errorf("invalid prefix; expected: %X, got: %X", PendingCreateProposalPrefix(), prefix)
 	}
 
 	timeBzL := sdk.BigEndianToUint64(bz[prefixL : prefixL+8])

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -299,7 +299,7 @@ func ValsetUpdateBlockHeightKey(valsetUpdateId uint64) []byte {
 // Returns the key corresponding to consumer genesis state material
 // (consensus state and client state) indexed by consumer chain id
 func ConsumerGenesisKey(chainID string) []byte {
-	return append(ConsumerGenesisPrefix(), []byte(chainID)...)
+	return append(ConsumerGenesisPrefix(), []byte("/"+chainID)...)
 }
 
 // SlashAcksKey returns the key under which slashing acks are stored for a given chain ID

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -101,58 +101,80 @@ func MaturedUnbondingOpsKey() []byte {
 	return []byte{MaturedUnbondingOpsByteKey}
 }
 
+// ValidatorSetUpdateIdKey is the key that stores the current validator set update id
 func ValidatorSetUpdateIdKey() []byte {
 	return []byte{ValidatorSetUpdateIdByteKey}
 }
 
+// ChainToChannelPrefix is the key prefix for storing mapping
+// from chainID to the channel ID that is used to send over validator set changes.
 func ChainToChannelPrefix() []byte {
 	return []byte{ChainToChannelBytePrefix}
 }
 
+// ChannelToChainPrefix is the key prefix for storing mapping
+// from the CCV channel ID to the consumer chain ID.
 func ChannelToChainPrefix() []byte {
 	return []byte{ChannelToChainBytePrefix}
 }
 
+// ChainToClientPrefix is the key prefix for storing the consumer chainID for a given consumer clientid.
 func ChainToClientPrefix() []byte {
 	return []byte{ChainToClientBytePrefix}
 }
 
+// PendingClientPrefix is the key prefix for storing the pending identified consumer chain client before the spawn time occurs.
+// The key includes the BigEndian timestamp to allow for efficient chronological iteration
 func PendingClientPrefix() []byte {
 	return []byte{PendingClientBytePrefix}
 }
 
+// PendingStopProposalPrefix is the key prefix for storing the pending identified consumer chain before the stop time occurs.
+// The key includes the BigEndian timestamp to allow for efficient chronological iteration
 func PendingStopProposalPrefix() []byte {
 	return []byte{PendingStopProposalBytePrefix}
 }
 
+// UnbondingOpPrefix is the key prefix that stores a record of all the ids of consumer chains that
+// need to unbond before a given delegation can unbond on this chain.
 func UnbondingOpPrefix() []byte {
 	return []byte{UnbondingOpBytePrefix}
 }
 
+// UnbondingOpIndexPrefix is key prefix of the index for looking up which unbonding
+// delegation entries are waiting for a given consumer chain to unbond
 func UnbondingOpIndexPrefix() []byte {
 	return []byte{UnbondingOpIndexBytePrefix}
 }
 
+// ValsetUpdateBlockHeightPrefix is the key prefix that will store the mapping from valset update ID to block height
 func ValsetUpdateBlockHeightPrefix() []byte {
 	return []byte{ValsetUpdateBlockHeightBytePrefix}
 }
 
+// ConsumerGenesisPrefix is the key corresponding to consumer genesis state material
+// (consensus state and client state) indexed by consumer chain id
 func ConsumerGenesisPrefix() []byte {
 	return []byte{ConsumerGenesisBytePrefix}
 }
 
+// SlashAcksPrefix is the key prefix that will store consensus address of consumer chain validators successfully slashed on the provider chain
 func SlashAcksPrefix() []byte {
 	return []byte{SlashAcksBytePrefix}
 }
 
+// InitChainHeightPrefix is the key prefix that will store the mapping from a chain id to the corresponding block height on the provider
+// this consumer chain was initialized
 func InitChainHeightPrefix() []byte {
 	return []byte{InitChainHeightBytePrefix}
 }
 
+// PendingVSCsPrefix is the key prefix that will store pending ValidatorSetChangePacket data
 func PendingVSCsPrefix() []byte {
 	return []byte{PendingVSCsBytePrefix}
 }
 
+// LockUnbondingOnTimeoutPrefix is the key prefix that will store the consumer chain id which unbonding operations are locked on CCV channel timeout
 func LockUnbondingOnTimeoutPrefix() []byte {
 	return []byte{LockUnbondingOnTimeoutBytePrefix}
 }
@@ -248,6 +270,7 @@ func UnbondingOpIndexKey(chainID string, valsetUpdateID uint64) []byte {
 		sdk.Uint64ToBigEndian(valsetUpdateID))
 }
 
+// Parses an unbonding op index key for VSC ID
 func ParseUnbondingOpIndexKey(key []byte) (vscID []byte, err error) {
 	keySplit := bytes.Split(key, []byte("/"))
 	if len(keySplit) != 2 {
@@ -258,20 +281,25 @@ func ParseUnbondingOpIndexKey(key []byte) (vscID []byte, err error) {
 	return keySplit[1], nil
 }
 
+// Returns the key that stores a record of all the ids of consumer chains that
+// need to unbond before a given delegation can unbond on this chain
 func UnbondingOpKey(id uint64) []byte {
 	bz := make([]byte, 8)
 	binary.BigEndian.PutUint64(bz, id)
 	return append(UnbondingOpPrefix(), bz...)
 }
 
+// Returns the key that storing the mapping from valset update ID to block height
 func ValsetUpdateBlockHeightKey(valsetUpdateId uint64) []byte {
 	vuidBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(vuidBytes, valsetUpdateId)
 	return append(ValsetUpdateBlockHeightPrefix(), vuidBytes...)
 }
 
+// Returns the key corresponding to consumer genesis state material
+// (consensus state and client state) indexed by consumer chain id
 func ConsumerGenesisKey(chainID string) []byte {
-	return append(ConsumerGenesisPrefix(), []byte("/"+chainID)...)
+	return append(ConsumerGenesisPrefix(), []byte(chainID)...)
 }
 
 // SlashAcksKey returns the key under which slashing acks are stored for a given chain ID
@@ -290,6 +318,8 @@ func PendingVSCsKey(chainID string) []byte {
 	return append(PendingVSCsPrefix(), []byte("/"+chainID)...)
 }
 
+// Returns the key that will store the consumer chain id which unbonding operations are locked
+// on CCV channel timeout
 func LockUnbondingOnTimeoutKey(chainID string) []byte {
 	return append(LockUnbondingOnTimeoutPrefix(), []byte("/"+chainID)...)
 }

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -106,103 +106,30 @@ func ValidatorSetUpdateIdKey() []byte {
 	return []byte{ValidatorSetUpdateIdByteKey}
 }
 
-// ChainToChannelPrefix is the key prefix for storing mapping
-// from chainID to the channel ID that is used to send over validator set changes.
-func ChainToChannelPrefix() []byte {
-	return []byte{ChainToChannelBytePrefix}
-}
-
-// ChannelToChainPrefix is the key prefix for storing mapping
-// from the CCV channel ID to the consumer chain ID.
-func ChannelToChainPrefix() []byte {
-	return []byte{ChannelToChainBytePrefix}
-}
-
-// ChainToClientPrefix is the key prefix for storing the consumer chainID for a given consumer clientid.
-func ChainToClientPrefix() []byte {
-	return []byte{ChainToClientBytePrefix}
-}
-
-// PendingCreateProposalPrefix is the key prefix for storing the pending identified consumer chain client before the spawn time occurs.
-// The key includes the BigEndian timestamp to allow for efficient chronological iteration
-func PendingCreateProposalPrefix() []byte {
-	return []byte{PendingCreateProposalBytePrefix}
-}
-
-// PendingStopProposalPrefix is the key prefix for storing the pending identified consumer chain before the stop time occurs.
-// The key includes the BigEndian timestamp to allow for efficient chronological iteration
-func PendingStopProposalPrefix() []byte {
-	return []byte{PendingStopProposalBytePrefix}
-}
-
-// UnbondingOpPrefix is the key prefix that stores a record of all the ids of consumer chains that
-// need to unbond before a given delegation can unbond on this chain.
-func UnbondingOpPrefix() []byte {
-	return []byte{UnbondingOpBytePrefix}
-}
-
-// UnbondingOpIndexPrefix is key prefix of the index for looking up which unbonding
-// delegation entries are waiting for a given consumer chain to unbond
-func UnbondingOpIndexPrefix() []byte {
-	return []byte{UnbondingOpIndexBytePrefix}
-}
-
-// ValsetUpdateBlockHeightPrefix is the key prefix that will store the mapping from valset update ID to block height
-func ValsetUpdateBlockHeightPrefix() []byte {
-	return []byte{ValsetUpdateBlockHeightBytePrefix}
-}
-
-// ConsumerGenesisPrefix is the key corresponding to consumer genesis state material
-// (consensus state and client state) indexed by consumer chain id
-func ConsumerGenesisPrefix() []byte {
-	return []byte{ConsumerGenesisBytePrefix}
-}
-
-// SlashAcksPrefix is the key prefix that will store consensus address of consumer chain validators successfully slashed on the provider chain
-func SlashAcksPrefix() []byte {
-	return []byte{SlashAcksBytePrefix}
-}
-
-// InitChainHeightPrefix is the key prefix that will store the mapping from a chain id to the corresponding block height on the provider
-// this consumer chain was initialized
-func InitChainHeightPrefix() []byte {
-	return []byte{InitChainHeightBytePrefix}
-}
-
-// PendingVSCsPrefix is the key prefix that will store pending ValidatorSetChangePacket data
-func PendingVSCsPrefix() []byte {
-	return []byte{PendingVSCsBytePrefix}
-}
-
-// LockUnbondingOnTimeoutPrefix is the key prefix that will store the consumer chain id which unbonding operations are locked on CCV channel timeout
-func LockUnbondingOnTimeoutPrefix() []byte {
-	return []byte{LockUnbondingOnTimeoutBytePrefix}
-}
-
 // ChainToChannelKey returns the key under which the CCV channel ID will be stored for the given consumer chain.
 func ChainToChannelKey(chainID string) []byte {
-	return append(ChainToChannelPrefix(), []byte(chainID)...)
+	return append([]byte{ChainToChannelBytePrefix}, []byte(chainID)...)
 }
 
 // ChannelToChainKey returns the key under which the consumer chain ID will be stored for the given channelID.
 func ChannelToChainKey(channelID string) []byte {
-	return append(ChannelToChainPrefix(), []byte(channelID)...)
+	return append([]byte{ChannelToChainBytePrefix}, []byte(channelID)...)
 }
 
 // ChainToClientKey returns the key under which the clientID for the given chainID is stored.
 func ChainToClientKey(chainID string) []byte {
-	return append(ChainToClientPrefix(), []byte(chainID)...)
+	return append([]byte{ChainToClientBytePrefix}, []byte(chainID)...)
 }
 
 // PendingCreateProposalKey returns the key under which a pending identified client is stored
 func PendingCreateProposalKey(timestamp time.Time, chainID string) []byte {
 	timeBz := sdk.FormatTimeBytes(timestamp)
 	timeBzL := len(timeBz)
-	prefixL := len(PendingCreateProposalPrefix())
+	prefixL := len([]byte{PendingCreateProposalBytePrefix})
 
 	bz := make([]byte, prefixL+8+timeBzL+len(chainID))
 	// copy the prefix
-	copy(bz[:prefixL], PendingCreateProposalPrefix())
+	copy(bz[:prefixL], []byte{PendingCreateProposalBytePrefix})
 	// copy the time length
 	copy(bz[prefixL:prefixL+8], sdk.Uint64ToBigEndian(uint64(timeBzL)))
 	// copy the time bytes
@@ -214,9 +141,10 @@ func PendingCreateProposalKey(timestamp time.Time, chainID string) []byte {
 
 // ParsePendingCreateProposalKey returns the time and chain ID for a pending client key or an error if unparseable
 func ParsePendingCreateProposalKey(bz []byte) (time.Time, string, error) {
-	prefixL := len(PendingCreateProposalPrefix())
-	if prefix := bz[:prefixL]; !bytes.Equal(prefix, PendingCreateProposalPrefix()) {
-		return time.Time{}, "", fmt.Errorf("invalid prefix; expected: %X, got: %X", PendingCreateProposalPrefix(), prefix)
+	expectedPrefix := []byte{PendingCreateProposalBytePrefix}
+	prefixL := len(expectedPrefix)
+	if prefix := bz[:prefixL]; !bytes.Equal(prefix, expectedPrefix) {
+		return time.Time{}, "", fmt.Errorf("invalid prefix; expected: %X, got: %X", expectedPrefix, prefix)
 	}
 
 	timeBzL := sdk.BigEndianToUint64(bz[prefixL : prefixL+8])
@@ -233,11 +161,11 @@ func ParsePendingCreateProposalKey(bz []byte) (time.Time, string, error) {
 func PendingStopProposalKey(timestamp time.Time, chainID string) []byte {
 	timeBz := sdk.FormatTimeBytes(timestamp)
 	timeBzL := len(timeBz)
-	prefixL := len(PendingStopProposalPrefix())
+	prefixL := len([]byte{PendingStopProposalBytePrefix})
 
 	bz := make([]byte, prefixL+8+timeBzL+len(chainID))
 	// copy the prefix
-	copy(bz[:prefixL], PendingStopProposalPrefix())
+	copy(bz[:prefixL], []byte{PendingStopProposalBytePrefix})
 	// copy the time length
 	copy(bz[prefixL:prefixL+8], sdk.Uint64ToBigEndian(uint64(timeBzL)))
 	// copy the time bytes
@@ -249,9 +177,10 @@ func PendingStopProposalKey(timestamp time.Time, chainID string) []byte {
 
 // ParsePendingStopProposalKey returns the time and chain ID for a pending consumer chain stop proposal key or an error if unparseable
 func ParsePendingStopProposalKey(bz []byte) (time.Time, string, error) {
-	prefixL := len(PendingStopProposalPrefix())
-	if prefix := bz[:prefixL]; !bytes.Equal(prefix, PendingStopProposalPrefix()) {
-		return time.Time{}, "", fmt.Errorf("invalid prefix; expected: %X, got: %X", PendingStopProposalPrefix(), prefix)
+	expectedPrefix := []byte{PendingStopProposalBytePrefix}
+	prefixL := len(expectedPrefix)
+	if prefix := bz[:prefixL]; !bytes.Equal(prefix, expectedPrefix) {
+		return time.Time{}, "", fmt.Errorf("invalid prefix; expected: %X, got: %X", expectedPrefix, prefix)
 	}
 
 	timeBzL := sdk.BigEndianToUint64(bz[prefixL : prefixL+8])
@@ -268,7 +197,7 @@ func ParsePendingStopProposalKey(bz []byte) (time.Time, string, error) {
 // Note: chainId is hashed to a fixed length sequence of bytes here to prevent
 // injection attack between chainIDs.
 func UnbondingOpIndexKey(chainID string, valsetUpdateID uint64) []byte {
-	return AppendMany(UnbondingOpIndexPrefix(), HashString(chainID),
+	return AppendMany([]byte{UnbondingOpIndexBytePrefix}, HashString(chainID),
 		sdk.Uint64ToBigEndian(valsetUpdateID))
 }
 
@@ -289,42 +218,42 @@ func ParseUnbondingOpIndexKey(key []byte) (vscID []byte, err error) {
 func UnbondingOpKey(id uint64) []byte {
 	bz := make([]byte, 8)
 	binary.BigEndian.PutUint64(bz, id)
-	return append(UnbondingOpPrefix(), bz...)
+	return append([]byte{UnbondingOpBytePrefix}, bz...)
 }
 
 // ValsetUpdateBlockHeightKey returns the key that storing the mapping from valset update ID to block height
 func ValsetUpdateBlockHeightKey(valsetUpdateId uint64) []byte {
 	vuidBytes := make([]byte, 8)
 	binary.BigEndian.PutUint64(vuidBytes, valsetUpdateId)
-	return append(ValsetUpdateBlockHeightPrefix(), vuidBytes...)
+	return append([]byte{ValsetUpdateBlockHeightBytePrefix}, vuidBytes...)
 }
 
 // ConsumerGenesisKey returns the key corresponding to consumer genesis state material
 // (consensus state and client state) indexed by consumer chain id
 func ConsumerGenesisKey(chainID string) []byte {
-	return append(ConsumerGenesisPrefix(), []byte(chainID)...)
+	return append([]byte{ConsumerGenesisBytePrefix}, []byte(chainID)...)
 }
 
 // SlashAcksKey returns the key under which slashing acks are stored for a given chain ID
 func SlashAcksKey(chainID string) []byte {
-	return append(SlashAcksPrefix(), []byte(chainID)...)
+	return append([]byte{SlashAcksBytePrefix}, []byte(chainID)...)
 }
 
 // InitChainHeightKey returns the key under which the block height for a given chain ID is stored
 func InitChainHeightKey(chainID string) []byte {
-	return append(InitChainHeightPrefix(), []byte(chainID)...)
+	return append([]byte{InitChainHeightBytePrefix}, []byte(chainID)...)
 }
 
 // PendingVSCsKey returns the key under which
 // pending ValidatorSetChangePacket data is stored for a given chain ID
 func PendingVSCsKey(chainID string) []byte {
-	return append(PendingVSCsPrefix(), []byte(chainID)...)
+	return append([]byte{PendingVSCsBytePrefix}, []byte(chainID)...)
 }
 
 // LockUnbondingOnTimeoutKey returns the key that will store the consumer chain id which unbonding operations are locked
 // on CCV channel timeout
 func LockUnbondingOnTimeoutKey(chainID string) []byte {
-	return append(LockUnbondingOnTimeoutPrefix(), []byte(chainID)...)
+	return append([]byte{LockUnbondingOnTimeoutBytePrefix}, []byte(chainID)...)
 }
 
 // AppendMany appends a variable number of byte slices together

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"time"
@@ -28,113 +27,159 @@ const (
 
 	// QuerierRoute is the querier route for IBC transfer
 	QuerierRoute = ModuleName
+)
 
-	// ChainToChannelKeyPrefix is the key prefix for storing mapping
-	// from chainID to the channel ID that is used to send over validator set changes.
-	ChainToChannelKeyPrefix = "chaintochannel"
+// Iota generated keys/byte prefixes (as a byte), supports 256 possible values
+const (
 
-	// ChannelToChainKeyPrefix is the key prefix for storing mapping
-	// from the CCV channel ID to the consumer chain ID.
-	ChannelToChainKeyPrefix = "channeltochain"
+	// PortKey defines the key to store the port ID in store
+	PortByteKey byte = iota
 
-	// ChainToClientKeyPrefix is the key prefix for storing the consumer chainID for a given consumer clientid.
-	ChainToClientKeyPrefix = "chaintoclient"
-
-	// PendingClientKeyPrefix is the key prefix for storing the pending identified consumer chain client before the spawn time occurs.
-	// The key includes the BigEndian timestamp to allow for efficient chronological iteration
-	PendingClientKeyPrefix = "pendingclient"
-
-	//PendingStopProposalKeyPrefix is the key prefix for storing the pending identified consumer chain before the stop time occurs.
-	// The key includes the BigEndian timestamp to allow for efficient chronological iteration
-	PendingStopProposalKeyPrefix = "pendingstopproposal"
-
-	// UnbondingOpPrefix is the key prefix that stores a record of all the ids of consumer chains that
-	// need to unbond before a given delegation can unbond on this chain.
-	UnbondingOpPrefix = "unbondingops"
-
-	// MaturedUnbondingOpPrefix is the key prefix that stores the list of all unbonding operations ids
+	// MaturedUnbondingOpsByteKey is the byte key that stores the list of all unbonding operations ids
 	// that have matured from a consumer chain perspective,
 	// i.e., no longer waiting on the unbonding period to elapse on any consumer chain
-	MaturedUnbondingOpsPrefix = "maturedunbondingops"
+	MaturedUnbondingOpsByteKey
 
-	// ValidatorSetUpdateIdPrefix is the key prefix that stores the current validator set update id
-	ValidatorSetUpdateIdPrefix = "valsetupdateid"
+	// ValidatorSetUpdateIdByteKey is the byte key that stores the current validator set update id
+	ValidatorSetUpdateIdByteKey
 
-	// UnbondingOpIndexPrefix is for the index for looking up which unbonding delegation entries are waiting for a given
-	// consumer chain to unbond
-	UnbondingOpIndexPrefix = "consumerchaintounbondingops"
+	// ChainToChannelBytePrefix is the byte prefix for storing mapping
+	// from chainID to the channel ID that is used to send over validator set changes.
+	ChainToChannelBytePrefix
 
-	//ValsetUpdateBlockHeightPrefix is the key prefix that will store the mapping from valset update ID to block height
-	ValsetUpdateBlockHeightPrefix = "valsetupdateblockheight"
+	// ChannelToChainBytePrefix is the byte prefix for storing mapping
+	// from the CCV channel ID to the consumer chain ID.
+	ChannelToChainBytePrefix
 
-	// ConsumerGenesisStatePrefix stores consumer genesis state material (consensus state and client state) indexed by consumer chain id
-	ConsumerGenesisPrefix = "consumergenesisstate"
+	// ChainToClientBytePrefix is the byte prefix for storing the consumer chainID for a given consumer clientid.
+	ChainToClientBytePrefix
 
-	// SlashAcksPrefix is the key prefix that will store consensus address of consumer chain validators successfully slashed on the provider chain
-	SlashAcksPrefix = "slashacks"
+	// PendingClientBytePrefix is the byte prefix for storing the pending identified consumer chain client before the spawn time occurs.
+	// The key includes the BigEndian timestamp to allow for efficient chronological iteration
+	PendingClientBytePrefix
 
-	// InitChainHeightPrefix is the key prefix that will store the mapping from a chain id to the corresponding block height on the provider
+	// PendingStopProposalBytePrefix is the byte prefix for storing the pending identified consumer chain before the stop time occurs.
+	// The key includes the BigEndian timestamp to allow for efficient chronological iteration
+	PendingStopProposalBytePrefix
+
+	// UnbondingOpBytePrefix is the byte prefix that stores a record of all the ids of consumer chains that
+	// need to unbond before a given delegation can unbond on this chain.
+	UnbondingOpBytePrefix
+
+	// UnbondingOpIndexBytePrefix is byte prefix of the index for looking up which unbonding
+	// delegation entries are waiting for a given consumer chain to unbond
+	UnbondingOpIndexBytePrefix
+
+	// ValsetUpdateBlockHeightBytePrefix is the byte prefix that will store the mapping from valset update ID to block height
+	ValsetUpdateBlockHeightBytePrefix
+
+	// ConsumerGenesisBytePrefix stores consumer genesis state material (consensus state and client state) indexed by consumer chain id
+	ConsumerGenesisBytePrefix
+
+	// SlashAcksBytePrefix is the byte prefix that will store consensus address of consumer chain validators successfully slashed on the provider chain
+	SlashAcksBytePrefix
+
+	// InitChainHeightBytePrefix is the byte prefix that will store the mapping from a chain id to the corresponding block height on the provider
 	// this consumer chain was initialized
-	InitChainHeightPrefix = "initchainheight"
+	InitChainHeightBytePrefix
 
-	// PendingVSCsPrefix is the key prefix that will store pending ValidatorSetChangePacket data
-	PendingVSCsPrefix = "pendingvscs"
+	// PendingVSCsBytePrefix is the byte prefix that will store pending ValidatorSetChangePacket data
+	PendingVSCsBytePrefix
 
-	// LockUnbondingOnTimeout is the key prefix that will store the consumer chain id which unbonding operations are locked on CCV channel timeout
-	LockUnbondingOnTimeoutPrefix = "LockUnbondingOnTimeout"
+	// LockUnbondingOnTimeoutBytePrefix is the byte prefix that will store the consumer chain id which unbonding operations are locked on CCV channel timeout
+	LockUnbondingOnTimeoutBytePrefix
 )
 
-var (
-	// PortKey defines the key to store the port ID in store
-	PortKey = []byte{0x01}
-)
-
-// Ouputs a fixed length 32 byte hash for any string
-func HashString(x string) []byte {
-	hash := sha256.Sum256([]byte(x))
-	return hash[:]
+// Returns the key to the port ID in the store
+func PortKey() []byte {
+	return []byte{PortByteKey}
 }
 
-// Appends a variable number of byte slices together
-func AppendMany(byteses ...[]byte) (out []byte) {
-	for _, bytes := range byteses {
-		out = append(out, bytes...)
-	}
-
-	return out
+// MaturedUnbondingOpsKey returns the key for storing the list of matured unbonding operations.
+func MaturedUnbondingOpsKey() []byte {
+	return []byte{MaturedUnbondingOpsByteKey}
 }
 
-// Turns a uint64 to bytes
-func Uint64ToBytes(x uint64) []byte {
-	bz := make([]byte, 8)
-	binary.BigEndian.PutUint64(bz, x)
-	return bz
+func ValidatorSetUpdateIdKey() []byte {
+	return []byte{ValidatorSetUpdateIdByteKey}
+}
+
+func ChainToChannelPrefix() []byte {
+	return []byte{ChainToChannelBytePrefix}
+}
+
+func ChannelToChainPrefix() []byte {
+	return []byte{ChannelToChainBytePrefix}
+}
+
+func ChainToClientPrefix() []byte {
+	return []byte{ChainToClientBytePrefix}
+}
+
+func PendingClientPrefix() []byte {
+	return []byte{PendingClientBytePrefix}
+}
+
+func PendingStopProposalPrefix() []byte {
+	return []byte{PendingStopProposalBytePrefix}
+}
+
+func UnbondingOpPrefix() []byte {
+	return []byte{UnbondingOpBytePrefix}
+}
+
+func UnbondingOpIndexPrefix() []byte {
+	return []byte{UnbondingOpIndexBytePrefix}
+}
+
+func ValsetUpdateBlockHeightPrefix() []byte {
+	return []byte{ValsetUpdateBlockHeightBytePrefix}
+}
+
+func ConsumerGenesisPrefix() []byte {
+	return []byte{ConsumerGenesisBytePrefix}
+}
+
+func SlashAcksPrefix() []byte {
+	return []byte{SlashAcksBytePrefix}
+}
+
+func InitChainHeightPrefix() []byte {
+	return []byte{InitChainHeightBytePrefix}
+}
+
+func PendingVSCsPrefix() []byte {
+	return []byte{PendingVSCsBytePrefix}
+}
+
+func LockUnbondingOnTimeoutPrefix() []byte {
+	return []byte{LockUnbondingOnTimeoutBytePrefix}
 }
 
 // ChainToChannelKey returns the key under which the CCV channel ID will be stored for the given consumer chain.
 func ChainToChannelKey(chainID string) []byte {
-	return []byte(ChainToChannelKeyPrefix + "/" + chainID)
+	return append(ChainToChannelPrefix(), []byte("/"+chainID)...)
 }
 
 // ChannelToChainKey returns the key under which the consumer chain ID will be stored for the given channelID.
 func ChannelToChainKey(channelID string) []byte {
-	return []byte(ChannelToChainKeyPrefix + "/" + channelID)
+	return append(ChannelToChainPrefix(), []byte("/"+channelID)...)
 }
 
 // ChainToClientKey returns the key under which the clientID for the given chainID is stored.
 func ChainToClientKey(chainID string) []byte {
-	return []byte(fmt.Sprintf("%s/%s", ChainToClientKeyPrefix, chainID))
+	return append(ChainToClientPrefix(), []byte("/"+chainID)...)
 }
 
 // PendingClientKey returns the key under which a pending identified client is stored
 func PendingClientKey(timestamp time.Time, chainID string) []byte {
 	timeBz := sdk.FormatTimeBytes(timestamp)
 	timeBzL := len(timeBz)
-	prefixL := len(PendingClientKeyPrefix)
+	prefixL := len(PendingClientPrefix())
 
 	bz := make([]byte, prefixL+8+timeBzL+len(chainID))
 	// copy the prefix
-	copy(bz[:prefixL], PendingClientKeyPrefix)
+	copy(bz[:prefixL], PendingClientPrefix())
 	// copy the time length
 	copy(bz[prefixL:prefixL+8], sdk.Uint64ToBigEndian(uint64(timeBzL)))
 	// copy the time bytes
@@ -146,9 +191,9 @@ func PendingClientKey(timestamp time.Time, chainID string) []byte {
 
 // ParsePendingClientKey returns the time and chain ID for a pending client key or an error if unparseable
 func ParsePendingClientKey(bz []byte) (time.Time, string, error) {
-	prefixL := len(PendingClientKeyPrefix)
-	if prefix := bz[:prefixL]; string(prefix) != PendingClientKeyPrefix {
-		return time.Time{}, "", fmt.Errorf("invalid prefix; expected: %X, got: %X", PendingClientKeyPrefix, prefix)
+	prefixL := len(PendingClientPrefix())
+	if prefix := bz[:prefixL]; !bytes.Equal(prefix, PendingClientPrefix()) {
+		return time.Time{}, "", fmt.Errorf("invalid prefix; expected: %X, got: %X", PendingClientPrefix(), prefix)
 	}
 
 	timeBzL := sdk.BigEndianToUint64(bz[prefixL : prefixL+8])
@@ -165,11 +210,11 @@ func ParsePendingClientKey(bz []byte) (time.Time, string, error) {
 func PendingStopProposalKey(timestamp time.Time, chainID string) []byte {
 	timeBz := sdk.FormatTimeBytes(timestamp)
 	timeBzL := len(timeBz)
-	prefixL := len([]byte(PendingStopProposalKeyPrefix))
+	prefixL := len(PendingStopProposalPrefix())
 
 	bz := make([]byte, prefixL+8+timeBzL+len(chainID))
 	// copy the prefix
-	copy(bz[:prefixL], []byte(PendingStopProposalKeyPrefix))
+	copy(bz[:prefixL], PendingStopProposalPrefix())
 	// copy the time length
 	copy(bz[prefixL:prefixL+8], sdk.Uint64ToBigEndian(uint64(timeBzL)))
 	// copy the time bytes
@@ -181,9 +226,9 @@ func PendingStopProposalKey(timestamp time.Time, chainID string) []byte {
 
 // ParsePendingStopProposalKey returns the time and chain ID for a pending consumer chain stop proposal key or an error if unparseable
 func ParsePendingStopProposalKey(bz []byte) (time.Time, string, error) {
-	prefixL := len(PendingStopProposalKeyPrefix)
-	if prefix := bz[:prefixL]; string(prefix) != PendingStopProposalKeyPrefix {
-		return time.Time{}, "", fmt.Errorf("invalid prefix; expected: %X, got: %X", PendingStopProposalKeyPrefix, prefix)
+	prefixL := len(PendingStopProposalPrefix())
+	if prefix := bz[:prefixL]; !bytes.Equal(prefix, PendingStopProposalPrefix()) {
+		return time.Time{}, "", fmt.Errorf("invalid prefix; expected: %X, got: %X", PendingStopProposalPrefix(), prefix)
 	}
 
 	timeBzL := sdk.BigEndianToUint64(bz[prefixL : prefixL+8])
@@ -197,58 +242,66 @@ func ParsePendingStopProposalKey(bz []byte) (time.Time, string, error) {
 }
 
 func UnbondingOpIndexKey(chainID string, valsetUpdateID uint64) []byte {
-	return AppendMany(HashString(UnbondingOpIndexPrefix), HashString(chainID), HashString("/"), Uint64ToBytes(valsetUpdateID))
-}
-
-func UnbondingOpKey(id uint64) []byte {
-	bz := make([]byte, 8)
-	binary.BigEndian.PutUint64(bz, id)
-
-	return append([]byte(UnbondingOpPrefix), bz...)
-}
-
-// MaturedUnbondingOpsKey returns the key for storing the list of matured unbonding operations.
-func MaturedUnbondingOpsKey() []byte {
-	return []byte(MaturedUnbondingOpsPrefix)
-}
-
-func ValsetUpdateBlockHeightKey(valsetUpdateId uint64) []byte {
-	vuidBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(vuidBytes, valsetUpdateId)
-	return append([]byte(ValsetUpdateBlockHeightPrefix), vuidBytes...)
-}
-
-func ConsumerGenesisKey(chainID string) []byte {
-	return append(HashString(ConsumerGenesisPrefix), []byte(chainID)...)
-}
-
-// SlashAcksKey returns the key under which slashing acks are stored for a given chain ID
-func SlashAcksKey(chainID string) []byte {
-	return []byte(fmt.Sprintf("%s/%s", SlashAcksPrefix, chainID))
-}
-
-// InitChainHeightKey returns the key under which the block height for a given chain ID is stored
-func InitChainHeightKey(chainID string) []byte {
-	return []byte(fmt.Sprintf("%s/%s", InitChainHeightPrefix, chainID))
-}
-
-// PendingVSCsKey returns the key under which
-// pending ValidatorSetChangePacket data is stored for a given chain ID
-func PendingVSCsKey(chainID string) []byte {
-	return []byte(fmt.Sprintf("%s/%s", PendingVSCsPrefix, chainID))
-}
-
-func LockUnbondingOnTimeoutKey(chainID string) []byte {
-	return []byte(fmt.Sprintf("%s/%s", LockUnbondingOnTimeoutPrefix, chainID))
+	return AppendMany(UnbondingOpIndexPrefix(), []byte(chainID), []byte("/"),
+		sdk.Uint64ToBigEndian(valsetUpdateID))
 }
 
 func ParseUnbondingOpIndexKey(key []byte) (vscID []byte, err error) {
-	keySplit := bytes.Split(key, HashString("/"))
+	keySplit := bytes.Split(key, []byte("/"))
 	if len(keySplit) != 2 {
 		return nil, sdkerrors.Wrapf(
 			sdkerrors.ErrLogic, "key provided is incorrect: the key split has incorrect length, expected %d, got %d", 2, len(keySplit),
 		)
 	}
-
 	return keySplit[1], nil
+}
+
+func UnbondingOpKey(id uint64) []byte {
+	bz := make([]byte, 8)
+	binary.BigEndian.PutUint64(bz, id)
+	return append(UnbondingOpPrefix(), bz...)
+}
+
+func ValsetUpdateBlockHeightKey(valsetUpdateId uint64) []byte {
+	vuidBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(vuidBytes, valsetUpdateId)
+	return append(ValsetUpdateBlockHeightPrefix(), vuidBytes...)
+}
+
+func ConsumerGenesisKey(chainID string) []byte {
+	return append(ConsumerGenesisPrefix(), []byte("/"+chainID)...)
+}
+
+// SlashAcksKey returns the key under which slashing acks are stored for a given chain ID
+func SlashAcksKey(chainID string) []byte {
+	return append(SlashAcksPrefix(), []byte("/"+chainID)...)
+}
+
+// InitChainHeightKey returns the key under which the block height for a given chain ID is stored
+func InitChainHeightKey(chainID string) []byte {
+	return append(InitChainHeightPrefix(), []byte("/"+chainID)...)
+}
+
+// PendingVSCsKey returns the key under which
+// pending ValidatorSetChangePacket data is stored for a given chain ID
+func PendingVSCsKey(chainID string) []byte {
+	return append(PendingVSCsPrefix(), []byte("/"+chainID)...)
+}
+
+func LockUnbondingOnTimeoutKey(chainID string) []byte {
+	return append(LockUnbondingOnTimeoutPrefix(), []byte("/"+chainID)...)
+}
+
+// // Outputs a fixed length 32 byte hash for any string
+// func HashString(x string) []byte {
+// 	hash := sha256.Sum256([]byte(x))
+// 	return hash[:]
+// }
+
+// Appends a variable number of byte slices together
+func AppendMany(byteses ...[]byte) (out []byte) {
+	for _, bytes := range byteses {
+		out = append(out, bytes...)
+	}
+	return out
 }

--- a/x/ccv/provider/types/keys_test.go
+++ b/x/ccv/provider/types/keys_test.go
@@ -1,0 +1,56 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Tests that all singular keys, or prefixes to fully resolves keys are a single byte long,
+// preventing injection attacks into restricted parts of a full store.
+func TestSameLength(t *testing.T) {
+
+	keys := getSingleByteKeys()
+
+	for _, keyByteArray := range keys {
+		require.Equal(t, 1, len(keyByteArray))
+	}
+}
+
+// Tests that all singular keys, or prefixes to fully resolves keys are non duplicate byte values.
+func TestNoDuplicates(t *testing.T) {
+
+	keys := getSingleByteKeys()
+
+	for i, keyByteArray := range keys {
+		keys[i] = nil
+		require.NotContains(t, keys, keyByteArray)
+	}
+}
+
+// Returns all singular keys, or prefixes to fully resolved keys,
+// any of which should be a single byte.
+func getSingleByteKeys() [][]byte {
+
+	keys := make([][]byte, 16)
+	i := 0
+
+	keys[i], i = PortKey(), i+1
+	keys[i], i = MaturedUnbondingOpsKey(), i+1
+	keys[i], i = ValidatorSetUpdateIdKey(), i+1
+	keys[i], i = ChainToChannelPrefix(), i+1
+	keys[i], i = ChannelToChainPrefix(), i+1
+	keys[i], i = ChainToClientPrefix(), i+1
+	keys[i], i = PendingClientPrefix(), i+1
+	keys[i], i = PendingStopProposalPrefix(), i+1
+	keys[i], i = UnbondingOpPrefix(), i+1
+	keys[i], i = UnbondingOpIndexPrefix(), i+1
+	keys[i], i = ValsetUpdateBlockHeightPrefix(), i+1
+	keys[i], i = ConsumerGenesisPrefix(), i+1
+	keys[i], i = SlashAcksPrefix(), i+1
+	keys[i], i = InitChainHeightPrefix(), i+1
+	keys[i], i = PendingVSCsPrefix(), i+1
+	keys[i] = LockUnbondingOnTimeoutPrefix()
+
+	return keys
+}

--- a/x/ccv/provider/types/keys_test.go
+++ b/x/ccv/provider/types/keys_test.go
@@ -119,8 +119,8 @@ func TestUnbondingOpIndexKeyAndParse(t *testing.T) {
 	for _, test := range tests {
 		key := UnbondingOpIndexKey(test.chainID, test.valsetUpdateID)
 		require.NotEmpty(t, key)
-		// This key should be of set length: prefix + hashed chain ID + separator + uint64
-		require.Equal(t, 1+32+1+8, len(key))
+		// This key should be of set length: prefix + hashed chain ID + uint64
+		require.Equal(t, 1+32+8, len(key))
 		parsedVSCID, err := ParseUnbondingOpIndexKey(key)
 		require.NotEmpty(t, parsedVSCID)
 		asUint64 := sdk.BigEndianToUint64(parsedVSCID)
@@ -129,8 +129,8 @@ func TestUnbondingOpIndexKeyAndParse(t *testing.T) {
 	}
 }
 
-// Test key packing functions with the format <prefix><separator><stringID>
-func TestKeysWithSeparator(t *testing.T) {
+// Test key packing functions with the format <prefix><stringID>
+func TestKeysWithPrefixAndId(t *testing.T) {
 
 	funcs := []func(string) []byte{
 		ChainToChannelKey,
@@ -166,8 +166,7 @@ func TestKeysWithSeparator(t *testing.T) {
 		for funcIdx, function := range funcs {
 			key := function(test.stringID)
 			require.Equal(t, expectedPrefixes[funcIdx], key[0])
-			require.Equal(t, byte('/'), key[1])
-			require.Equal(t, []byte(test.stringID), key[2:])
+			require.Equal(t, []byte(test.stringID), key[1:])
 		}
 	}
 }

--- a/x/ccv/provider/types/keys_test.go
+++ b/x/ccv/provider/types/keys_test.go
@@ -43,7 +43,7 @@ func getSingleByteKeys() [][]byte {
 	keys[i], i = ChainToChannelPrefix(), i+1
 	keys[i], i = ChannelToChainPrefix(), i+1
 	keys[i], i = ChainToClientPrefix(), i+1
-	keys[i], i = PendingClientPrefix(), i+1
+	keys[i], i = PendingCreateProposalPrefix(), i+1
 	keys[i], i = PendingStopProposalPrefix(), i+1
 	keys[i], i = UnbondingOpPrefix(), i+1
 	keys[i], i = UnbondingOpIndexPrefix(), i+1
@@ -69,12 +69,12 @@ func TestPendingClientKeyAndParse(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		key := PendingClientKey(test.timestamp, test.chainID)
+		key := PendingCreateProposalKey(test.timestamp, test.chainID)
 		require.NotEmpty(t, key)
 		// Expected bytes = prefix + time length + time bytes + length of chainID
 		expectedBytes := 1 + 8 + len(sdk.FormatTimeBytes(time.Time{})) + len(test.chainID)
 		require.Equal(t, expectedBytes, len(key))
-		parsedTime, parsedID, err := ParsePendingClientKey(key)
+		parsedTime, parsedID, err := ParsePendingCreateProposalKey(key)
 		require.Equal(t, test.timestamp.UTC(), parsedTime.UTC())
 		require.Equal(t, test.chainID, parsedID)
 		require.NoError(t, err)

--- a/x/ccv/provider/types/keys_test.go
+++ b/x/ccv/provider/types/keys_test.go
@@ -31,7 +31,7 @@ func TestNoDuplicates(t *testing.T) {
 }
 
 // Returns all singular keys, or prefixes to fully resolved keys,
-// any of which should be a single byte.
+// any of which should be a single, unique byte.
 func getSingleByteKeys() [][]byte {
 
 	keys := make([][]byte, 16)
@@ -40,19 +40,19 @@ func getSingleByteKeys() [][]byte {
 	keys[i], i = PortKey(), i+1
 	keys[i], i = MaturedUnbondingOpsKey(), i+1
 	keys[i], i = ValidatorSetUpdateIdKey(), i+1
-	keys[i], i = ChainToChannelPrefix(), i+1
-	keys[i], i = ChannelToChainPrefix(), i+1
-	keys[i], i = ChainToClientPrefix(), i+1
-	keys[i], i = PendingCreateProposalPrefix(), i+1
-	keys[i], i = PendingStopProposalPrefix(), i+1
-	keys[i], i = UnbondingOpPrefix(), i+1
-	keys[i], i = UnbondingOpIndexPrefix(), i+1
-	keys[i], i = ValsetUpdateBlockHeightPrefix(), i+1
-	keys[i], i = ConsumerGenesisPrefix(), i+1
-	keys[i], i = SlashAcksPrefix(), i+1
-	keys[i], i = InitChainHeightPrefix(), i+1
-	keys[i], i = PendingVSCsPrefix(), i+1
-	keys[i] = LockUnbondingOnTimeoutPrefix()
+	keys[i], i = []byte{ChainToChannelBytePrefix}, i+1
+	keys[i], i = []byte{ChannelToChainBytePrefix}, i+1
+	keys[i], i = []byte{ChainToClientBytePrefix}, i+1
+	keys[i], i = []byte{PendingCreateProposalBytePrefix}, i+1
+	keys[i], i = []byte{PendingStopProposalBytePrefix}, i+1
+	keys[i], i = []byte{UnbondingOpBytePrefix}, i+1
+	keys[i], i = []byte{UnbondingOpIndexBytePrefix}, i+1
+	keys[i], i = []byte{ValsetUpdateBlockHeightBytePrefix}, i+1
+	keys[i], i = []byte{ConsumerGenesisBytePrefix}, i+1
+	keys[i], i = []byte{SlashAcksBytePrefix}, i+1
+	keys[i], i = []byte{InitChainHeightBytePrefix}, i+1
+	keys[i], i = []byte{PendingVSCsBytePrefix}, i+1
+	keys[i] = []byte{LockUnbondingOnTimeoutBytePrefix}
 
 	return keys
 }
@@ -143,7 +143,7 @@ func TestKeysWithPrefixAndId(t *testing.T) {
 		LockUnbondingOnTimeoutKey,
 	}
 
-	expectedPrefixes := []byte{
+	expectedBytePrefixes := []byte{
 		ChainToChannelBytePrefix,
 		ChannelToChainBytePrefix,
 		ChainToClientBytePrefix,
@@ -165,7 +165,7 @@ func TestKeysWithPrefixAndId(t *testing.T) {
 	for _, test := range tests {
 		for funcIdx, function := range funcs {
 			key := function(test.stringID)
-			require.Equal(t, expectedPrefixes[funcIdx], key[0])
+			require.Equal(t, expectedBytePrefixes[funcIdx], key[0])
 			require.Equal(t, []byte(test.stringID), key[1:])
 		}
 	}
@@ -178,7 +178,7 @@ func TestKeysWithUint64Payload(t *testing.T) {
 		ValsetUpdateBlockHeightKey,
 	}
 
-	expectedPrefixes := []byte{
+	expectedBytePrefixes := []byte{
 		UnbondingOpBytePrefix,
 		ValsetUpdateBlockHeightBytePrefix,
 	}
@@ -195,7 +195,7 @@ func TestKeysWithUint64Payload(t *testing.T) {
 	for _, test := range tests {
 		for funcIdx, function := range funcs {
 			key := function(test.integer)
-			require.Equal(t, expectedPrefixes[funcIdx], key[0])
+			require.Equal(t, expectedBytePrefixes[funcIdx], key[0])
 			require.Equal(t, sdk.Uint64ToBigEndian(test.integer), key[1:])
 		}
 	}

--- a/x/ccv/types/keys.go
+++ b/x/ccv/types/keys.go
@@ -10,18 +10,3 @@ const (
 
 	RouterKey = ModuleName
 )
-
-// Iota generated keys/byte prefixes (as a byte), supports 256 possible values
-const (
-	// ChannelStatusKeyPrefix is the byte prefix for storing the validation status of the CCV channel
-	ChannelStatusBytePrefix byte = iota
-)
-
-func ChannelStatusPrefix() []byte {
-	return []byte{ChannelStatusBytePrefix}
-}
-
-// ChannelStatusKey returns the key under which the Status of a consumer chain is stored.
-func ChannelStatusKey(channelID string) []byte {
-	return append(ChannelStatusPrefix(), []byte("/"+channelID)...)
-}

--- a/x/ccv/types/keys.go
+++ b/x/ccv/types/keys.go
@@ -8,13 +8,20 @@ const (
 	// module supports
 	Version = "1"
 
-	// ChannelStatusKeyPrefix is the key prefix for storing the validation status of the CCV channel
-	ChannelStatusKeyPrefix = "channelstatus"
-
 	RouterKey = ModuleName
 )
 
+// Iota generated keys/byte prefixes (as a byte), supports 256 possible values
+const (
+	// ChannelStatusKeyPrefix is the byte prefix for storing the validation status of the CCV channel
+	ChannelStatusBytePrefix byte = iota
+)
+
+func ChannelStatusPrefix() []byte {
+	return []byte{ChannelStatusBytePrefix}
+}
+
 // ChannelStatusKey returns the key under which the Status of a consumer chain is stored.
 func ChannelStatusKey(channelID string) []byte {
-	return []byte(ChannelStatusKeyPrefix + "/" + channelID)
+	return append(ChannelStatusPrefix(), []byte("/"+channelID)...)
 }


### PR DESCRIPTION
Closes https://github.com/cosmos/interchain-security/issues/18

Prefixes and singular keys are now defined as byte constants, assigned with iota. Corresponding helpers returning ```[]byte``` are defined in the same file as the byte constants. 

Comments: 

1. This PR enforces the semantics of a "key"/"singular key" and a "key prefix" in some places. The former being a key associated to a single value (or a single sequence of values marshaled/unmarshaled together), while the latter is a prefix where further bytes are appended to the key to retrieve values.

2. It may be worth standardizing on where/if we use separators at all. **Update after discussions** - Separators (```"/"```) were removed wherever possible from existing key functions.