### PR TITLE
Fix UnbondMaturePackets

### DIFF
--- a/x/ccv/consumer/keeper/relay.go
+++ b/x/ccv/consumer/keeper/relay.go
@@ -72,7 +72,7 @@ func (k Keeper) OnRecvVSCPacket(ctx sdk.Context, packet channeltypes.Packet, new
 // packets that have finished unbonding.
 func (k Keeper) UnbondMaturePackets(ctx sdk.Context) error {
 
-	// This method is a no-op if no established channel to the provider.
+	// This method is a no-op if there is no established channel to the provider.
 	channelID, ok := k.GetProviderChannel(ctx)
 	if !ok {
 		return nil

--- a/x/ccv/consumer/keeper/relay.go
+++ b/x/ccv/consumer/keeper/relay.go
@@ -72,16 +72,17 @@ func (k Keeper) OnRecvVSCPacket(ctx sdk.Context, packet channeltypes.Packet, new
 // packets that have finished unbonding.
 func (k Keeper) UnbondMaturePackets(ctx sdk.Context) error {
 
+	// This method is a no-op if no established channel to the provider.
+	channelID, ok := k.GetProviderChannel(ctx)
+	if !ok {
+		return nil
+	}
+
 	store := ctx.KVStore(k.storeKey)
 	maturityIterator := sdk.KVStorePrefixIterator(store, []byte(types.PacketMaturityTimePrefix))
 	defer maturityIterator.Close()
 
 	currentTime := uint64(ctx.BlockTime().UnixNano())
-
-	channelID, ok := k.GetProviderChannel(ctx)
-	if !ok {
-		return sdkerrors.Wrap(channeltypes.ErrChannelNotFound, "provider channel not set")
-	}
 
 	for maturityIterator.Valid() {
 		vscId := types.GetIdFromPacketMaturityTimeKey(maturityIterator.Key())

--- a/x/ccv/consumer/module.go
+++ b/x/ccv/consumer/module.go
@@ -182,13 +182,9 @@ func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.V
 		panic(err)
 	}
 
-	// Unbond mature packets only if provider channel has been set
-	_, ok := am.keeper.GetProviderChannel(ctx)
-	if ok {
-		err = am.keeper.UnbondMaturePackets(ctx)
-		if err != nil {
-			panic(err)
-		}
+	err = am.keeper.UnbondMaturePackets(ctx)
+	if err != nil {
+		panic(err)
 	}
 
 	data, ok := am.keeper.GetPendingChanges(ctx)


### PR DESCRIPTION
Closes https://github.com/cosmos/interchain-security/issues/244

There's not much to gain from accessing the provider channel both inside and outside the UnbondMaturePackets method