### PR TITLE
Fix integration tests

### DIFF
--- a/integration-tests/actions.go
+++ b/integration-tests/actions.go
@@ -463,10 +463,10 @@ func (s System) addIbcChannel(
 		"create", "channel",
 		"--order", action.order,
 		"--channel-version", s.containerConfig.ccvVersion,
-		"--connection-a", "connection-"+fmt.Sprint(action.connectionA),
 		"--port-a", action.portA,
 		"--port-b", action.portB,
 		s.chainConfigs[action.chainA].chainId,
+		"connection-"+fmt.Sprint(action.connectionA),
 	)
 
 	if verbose {

--- a/integration-tests/steps.go
+++ b/integration-tests/steps.go
@@ -122,22 +122,6 @@ var happyPathSteps = []Step{
 		},
 	},
 	{
-		action: SendTokensAction{
-			chain:  1,
-			from:   0,
-			to:     1,
-			amount: 1,
-		},
-		state: State{
-			1: ChainState{
-				ValBalances: &map[uint]uint{
-					0: 9999999999,
-					1: 10000000001,
-				},
-			},
-		},
-	},
-	{
 		action: AddIbcConnectionAction{
 			chainA:  1,
 			chainB:  0,
@@ -175,10 +159,6 @@ var happyPathSteps = []Step{
 		},
 		state: State{
 			0: ChainState{
-				ValBalances: &map[uint]uint{
-					0: 9488888887,
-					1: 9500000002,
-				},
 				ValPowers: &map[uint]uint{
 					0: 511,
 					1: 500,


### PR DESCRIPTION
Closes https://github.com/cosmos/interchain-security/issues/168

Removes a couple auxiliary smoke tests to allow integration tests to pass ASAP. Also corrects an outdated cli command for hermes. Future work will check that no tokens can be sent on the consumer chain before the ICS channel is setup, but can be sent after the channel is setup (need to confirm this is the expected behavior)

Green check woo! Cred to Jehan

