### PR TITLE
Specify hermes version for integration tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN echo fuk
 RUN dnf update -y
 RUN dnf install -y golang git make gcc gcc-c++ which iproute iputils procps-ng vim-minimal tmux net-tools htop tar jq npm openssl-devel perl rust cargo golang
 
-RUN PATH="$HOME/.cargo/bin:$PATH" && cargo install ibc-relayer-cli --bin hermes --locked
+RUN PATH="$HOME/.cargo/bin:$PATH" && cargo install ibc-relayer-cli@1.0.0-rc.1 --bin hermes --locked
 
 # Copy in the repo under test
 ADD . /interchain-security

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN echo fuk
 RUN dnf update -y
 RUN dnf install -y golang git make gcc gcc-c++ which iproute iputils procps-ng vim-minimal tmux net-tools htop tar jq npm openssl-devel perl rust cargo golang
 
-RUN PATH="$HOME/.cargo/bin:$PATH" && cargo install ibc-relayer-cli@1.0.0-rc.1 --bin hermes --locked
+RUN PATH="$HOME/.cargo/bin:$PATH" && cargo install ibc-relayer-cli@0.15.0 --bin hermes --locked
 
 # Copy in the repo under test
 ADD . /interchain-security


### PR DESCRIPTION
Avoids future issues similar to what was solved in #248, where the newest version of hermes introduced breaking changes to integration test setup. This change specifies that the integration test docker container will always use [v0.15.0 (latest)](https://github.com/informalsystems/ibc-rs/releases/tag/v0.15.0)