### PR TITLE
Integration Test Addition - Unbonding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN echo fuk
 RUN dnf update -y
 RUN dnf install -y golang git make gcc gcc-c++ which iproute iputils procps-ng vim-minimal tmux net-tools htop tar jq npm openssl-devel perl rust cargo golang
 
-RUN PATH="$HOME/.cargo/bin:$PATH" && cargo install ibc-relayer-cli@0.15.0 --bin hermes --locked
+RUN PATH="$HOME/.cargo/bin:$PATH" && cargo install ibc-relayer-cli@1.0.0-rc.1 --bin hermes --locked
 
 # Copy in the repo under test
 ADD . /interchain-security

--- a/integration-tests/actions.go
+++ b/integration-tests/actions.go
@@ -107,7 +107,7 @@ func (s System) startChain(
 		"/testnet-scripts/start-chain.sh", chainConfig.binaryName, string(vals),
 		chainConfig.chainId, chainConfig.ipPrefix, genesisChanges,
 		fmt.Sprint(action.skipGentx),
-		`s/timeout_commit = "5s"/timeout_commit = "500ms"/;`+
+		`s/timeout_commit = "5s"/timeout_commit = "1s"/;`+
 			`s/peer_gossip_sleep_duration = "100ms"/peer_gossip_sleep_duration = "50ms"/;`,
 		// `s/flush_throttle_timeout = "100ms"/flush_throttle_timeout = "10ms"/`,
 	)

--- a/integration-tests/actions.go
+++ b/integration-tests/actions.go
@@ -548,7 +548,7 @@ func (s System) delegateTokens(
 	verbose bool,
 ) {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err := exec.Command("docker", "exec", s.containerConfig.instanceName, s.chainConfigs[action.chain].binaryName,
+	cmd := exec.Command("docker", "exec", s.containerConfig.instanceName, s.chainConfigs[action.chain].binaryName,
 
 		"tx", "staking", "delegate",
 		s.validatorConfigs[action.to].valoperAddress,
@@ -561,8 +561,12 @@ func (s System) delegateTokens(
 		`--keyring-backend`, `test`,
 		`-b`, `block`,
 		`-y`,
-	).CombinedOutput()
+	)
+	if verbose {
+		fmt.Println("delegate cmd:", cmd.String())
+	}
 
+	bz, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Fatal(err, "\n", string(bz))
 	}
@@ -580,7 +584,7 @@ func (s System) unbondTokens(
 	verbose bool,
 ) {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err := exec.Command("docker", "exec", s.containerConfig.instanceName, s.chainConfigs[action.chain].binaryName,
+	cmd := exec.Command("docker", "exec", s.containerConfig.instanceName, s.chainConfigs[action.chain].binaryName,
 
 		"tx", "staking", "unbond",
 		s.validatorConfigs[action.unbondFrom].valoperAddress,
@@ -593,8 +597,12 @@ func (s System) unbondTokens(
 		`--keyring-backend`, `test`,
 		`-b`, `block`,
 		`-y`,
-	).CombinedOutput()
+	)
+	if verbose {
+		fmt.Println("unbond cmd:", cmd.String())
+	}
 
+	bz, err := cmd.CombinedOutput()
 	if err != nil {
 		log.Fatal(err, "\n", string(bz))
 	}

--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -49,6 +49,8 @@ func (s System) runStep(step Step, verbose bool) {
 		s.relayPackets(action, verbose)
 	case DelegateTokensAction:
 		s.delegateTokens(action, verbose)
+	case UnbondTokensAction:
+		s.unbondTokens(action, verbose)
 	default:
 		log.Fatalf(fmt.Sprintf(`unknown action: %#v`, action))
 	}

--- a/integration-tests/steps.go
+++ b/integration-tests/steps.go
@@ -233,4 +233,47 @@ var happyPathSteps = []Step{
 			},
 		},
 	},
+	{
+		action: UnbondTokensAction{
+			chain:      0,
+			unbondFrom: 0,
+			sender:     0,
+			amount:     11111111,
+		},
+		state: State{
+			0: ChainState{
+				ValPowers: &map[uint]uint{
+					0: 500,
+					1: 500,
+					2: 500,
+				},
+			},
+			1: ChainState{
+				ValPowers: &map[uint]uint{
+					// Voting power on consumer should not be affected yet
+					0: 511,
+					1: 500,
+					2: 500,
+				},
+			},
+		},
+	},
+	// This final relay action seems to be failing non-deterministically :/
+	{
+		action: RelayPacketsAction{
+			chain:   0,
+			port:    "provider",
+			channel: 0,
+		},
+		state: State{
+			1: ChainState{
+				ValPowers: &map[uint]uint{
+					0: 500,
+					1: 500,
+					2: 500,
+				},
+			},
+		},
+	},
+	// TODO: Test full unbonding functionality, considering liquidity after unbonding period, etc.
 }

--- a/integration-tests/steps.go
+++ b/integration-tests/steps.go
@@ -192,7 +192,7 @@ var happyPathSteps = []Step{
 		},
 		state: State{
 			1: ChainState{
-				// Tx should not go through, ICS channel is not setup until token delegation has been relayed to consumer
+				// Tx should not go through, ICS channel is not setup until first VSC packet has been relayed to consumer
 				ValBalances: &map[uint]uint{
 					0: 10000000000,
 					1: 10000000000,

--- a/integration-tests/steps.go
+++ b/integration-tests/steps.go
@@ -258,7 +258,6 @@ var happyPathSteps = []Step{
 			},
 		},
 	},
-	// This final relay action seems to be failing non-deterministically :/
 	{
 		action: RelayPacketsAction{
 			chain:   0,

--- a/integration-tests/steps.go
+++ b/integration-tests/steps.go
@@ -164,7 +164,7 @@ var happyPathSteps = []Step{
 			chain:  0,
 			from:   0,
 			to:     0,
-			amount: 11111111,
+			amount: 11000000,
 		},
 		state: State{
 			0: ChainState{
@@ -238,7 +238,7 @@ var happyPathSteps = []Step{
 			chain:      0,
 			unbondFrom: 0,
 			sender:     0,
-			amount:     11111111,
+			amount:     11000000,
 		},
 		state: State{
 			0: ChainState{

--- a/integration-tests/steps.go
+++ b/integration-tests/steps.go
@@ -122,6 +122,23 @@ var happyPathSteps = []Step{
 		},
 	},
 	{
+		action: SendTokensAction{
+			chain:  1,
+			from:   0,
+			to:     1,
+			amount: 1,
+		},
+		state: State{
+			1: ChainState{
+				// Tx on consumer chain should not go through before ICS channel is setup
+				ValBalances: &map[uint]uint{
+					0: 10000000000,
+					1: 10000000000,
+				},
+			},
+		},
+	},
+	{
 		action: AddIbcConnectionAction{
 			chainA:  1,
 			chainB:  0,
@@ -139,14 +156,6 @@ var happyPathSteps = []Step{
 			portA:       "consumer",
 			portB:       "provider",
 			order:       "ordered",
-		},
-		state: State{},
-	},
-	{
-		action: RelayPacketsAction{
-			chain:   0,
-			port:    "provider",
-			channel: 0,
 		},
 		state: State{},
 	},
@@ -175,6 +184,23 @@ var happyPathSteps = []Step{
 		},
 	},
 	{
+		action: SendTokensAction{
+			chain:  1,
+			from:   0,
+			to:     1,
+			amount: 1,
+		},
+		state: State{
+			1: ChainState{
+				// Tx should not go through, ICS channel is not setup until token delegation has been relayed to consumer
+				ValBalances: &map[uint]uint{
+					0: 10000000000,
+					1: 10000000000,
+				},
+			},
+		},
+	},
+	{
 		action: RelayPacketsAction{
 			chain:   0,
 			port:    "provider",
@@ -186,6 +212,23 @@ var happyPathSteps = []Step{
 					0: 511,
 					1: 500,
 					2: 500,
+				},
+			},
+		},
+	},
+	{
+		action: SendTokensAction{
+			chain:  1,
+			from:   0,
+			to:     1,
+			amount: 1,
+		},
+		state: State{
+			1: ChainState{
+				// Now tx should execute
+				ValBalances: &map[uint]uint{
+					0: 9999999999,
+					1: 10000000001,
 				},
 			},
 		},


### PR DESCRIPTION
Closes #94, Adds relevant action and state check to test basic unbonding functionality.

While implementing this PR, the error mentioned [here](https://github.com/informalsystems/ibc-rs/issues/2536) presented itself from hermes CLI. The solution was to adjust the non-default tendermint consensus parameters used in integration tests. Before finding that solution, I did the work to migrate the integration test driver from using hermes ```v0.15.0``` to ```v1.0.0-rc.1```. These changes are included in this PR since it doesn't hurt to use a newer version of hermes. More detail on the differences [here](https://github.com/informalsystems/ibc-rs/blob/v1.0.0-rc.1/UPGRADING.md).