### PR TITLE
small test fix for #254

### DIFF
--- a/x/ccv/provider/keeper/proposal_test.go
+++ b/x/ccv/provider/keeper/proposal_test.go
@@ -148,18 +148,16 @@ func (suite *KeeperTestSuite) TestIteratePendingStopProposal() {
 
 func (suite *KeeperTestSuite) TestIteratePendingClientInfo() {
 
-	chainID := suite.consumerChain.ChainID
-
 	testCases := []struct {
 		types.CreateConsumerChainProposal
 		ExpDeleted bool
 	}{
 		{
-			CreateConsumerChainProposal: types.CreateConsumerChainProposal{ChainId: chainID, SpawnTime: time.Now().UTC()},
+			CreateConsumerChainProposal: types.CreateConsumerChainProposal{ChainId: "0", SpawnTime: time.Now().UTC()},
 			ExpDeleted:                  true,
 		},
 		{
-			CreateConsumerChainProposal: types.CreateConsumerChainProposal{ChainId: chainID, SpawnTime: time.Now().UTC().Add(time.Hour)},
+			CreateConsumerChainProposal: types.CreateConsumerChainProposal{ChainId: "1", SpawnTime: time.Now().UTC().Add(time.Hour)},
 			ExpDeleted:                  false,
 		},
 	}


### PR DESCRIPTION
@mpoke something like this should fix your branch. The changes in #254 will throw an error if two ```createConsumerProposal```s are set for a single chain id. Alternatively, we can allow multiple proposals to be submitted for a single chain id, and ignore duplicates without throwing error. 

Related to #160, have we come to an agreement on best design patterns for this issue?