### PR TITLE
Integration Test Readability - ChainIDs

### DIFF
--- a/integration-tests/actions.go
+++ b/integration-tests/actions.go
@@ -620,6 +620,7 @@ type ValidatorDowntimeAction struct {
 // Simulates validator downtime by moving the home folder of the node, making it's binary panic
 // TODO: Downtime needs to be implemented more elegantly to allow validators to come back online
 func (s System) InvokeValidatorDowntime(action ValidatorDowntimeAction, verbose bool) {
+	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	cmd := exec.Command("docker", "exec", s.containerConfig.instanceName, "mv",
 		"/"+action.chain+"/validator"+fmt.Sprint(action.validator)+"/", "//")
 

--- a/integration-tests/actions.go
+++ b/integration-tests/actions.go
@@ -15,7 +15,7 @@ import (
 )
 
 type SendTokensAction struct {
-	chain  uint
+	chain  string
 	from   uint
 	to     uint
 	amount uint
@@ -52,7 +52,7 @@ func (s System) sendTokens(
 }
 
 type StartChainAction struct {
-	chain          uint
+	chain          string
 	validators     []StartChainValidator
 	genesisChanges string
 	skipGentx      bool
@@ -144,7 +144,7 @@ func (s System) startChain(
 }
 
 type SubmitTextProposalAction struct {
-	chain       uint
+	chain       string
 	from        uint
 	deposit     uint
 	propType    string
@@ -180,10 +180,10 @@ func (s System) submitTextProposal(
 }
 
 type SubmitConsumerProposalAction struct {
-	chain         uint
+	chain         string
 	from          uint
 	deposit       uint
-	consumerChain uint
+	consumerChain string
 	spawnTime     uint
 	initialHeight clienttypes.Height
 }
@@ -249,7 +249,7 @@ func (s System) submitConsumerProposal(
 }
 
 type VoteGovProposalAction struct {
-	chain      uint
+	chain      string
 	from       []uint
 	vote       []string
 	propNumber uint
@@ -291,8 +291,8 @@ func (s System) voteGovProposal(
 }
 
 type StartConsumerChainAction struct {
-	consumerChain uint
-	providerChain uint
+	consumerChain string
+	providerChain string
 	validators    []StartChainValidator
 }
 
@@ -321,7 +321,7 @@ func (s System) startConsumerChain(
 	}
 
 	s.startChain(StartChainAction{
-		chain:          1,
+		chain:          consumerChainId,
 		validators:     action.validators,
 		genesisChanges: ".app_state.ccvconsumer = " + string(bz),
 		skipGentx:      true,
@@ -329,7 +329,7 @@ func (s System) startConsumerChain(
 }
 
 type AddChainToRelayerAction struct {
-	chain     uint
+	chain     string
 	validator uint
 }
 
@@ -410,8 +410,8 @@ func (s System) addChainToRelayer(
 }
 
 type AddIbcConnectionAction struct {
-	chainA  uint
-	chainB  uint
+	chainA  string
+	chainB  string
 	clientA uint
 	clientB uint
 	order   string
@@ -456,8 +456,8 @@ func (s System) addIbcConnection(
 }
 
 type AddIbcChannelAction struct {
-	chainA      uint
-	chainB      uint
+	chainA      string
+	chainB      string
 	connectionA uint
 	portA       string
 	portB       string
@@ -510,7 +510,7 @@ func (s System) addIbcChannel(
 }
 
 type RelayPacketsAction struct {
-	chain   uint
+	chain   string
 	port    string
 	channel uint
 }
@@ -537,7 +537,7 @@ func (s System) relayPackets(
 }
 
 type DelegateTokensAction struct {
-	chain  uint
+	chain  string
 	from   uint
 	to     uint
 	amount uint
@@ -573,7 +573,7 @@ func (s System) delegateTokens(
 }
 
 type UnbondTokensAction struct {
-	chain      uint
+	chain      string
 	sender     uint
 	unbondFrom uint
 	amount     uint
@@ -610,7 +610,7 @@ func (s System) unbondTokens(
 
 var queryValidatorRegex = regexp.MustCompile(`(\d+)`)
 
-func (s System) getValidatorNum(chain uint) uint {
+func (s System) getValidatorNum(chain string) uint {
 	// Get first subdirectory of the directory of this chain, which will be the home directory of one of the validators
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	bz, err := exec.Command("docker", "exec", s.containerConfig.instanceName, "bash", "-c", `cd /`+s.chainConfigs[chain].chainId+`; ls -d */ | awk '{print $1}' | head -n 1`).CombinedOutput()
@@ -627,10 +627,10 @@ func (s System) getValidatorNum(chain uint) uint {
 	return uint(validator)
 }
 
-func (s System) getValidatorNode(chain uint, validator uint) string {
+func (s System) getValidatorNode(chain string, validator uint) string {
 	return "tcp://" + s.chainConfigs[chain].ipPrefix + "." + fmt.Sprint(validator) + ":26658"
 }
 
-func (s System) getValidatorHome(chain uint, validator uint) string {
+func (s System) getValidatorHome(chain string, validator uint) string {
 	return `/` + s.chainConfigs[chain].chainId + `/validator` + fmt.Sprint(validator)
 }

--- a/integration-tests/config.go
+++ b/integration-tests/config.go
@@ -1,6 +1,13 @@
 package main
 
-import "time"
+import (
+	"time"
+)
+
+const (
+	providerChainId = "provider"
+	consumerChainId = "consumer"
+)
 
 // Attributes that are unique to a validator. Allows us to map (part of) the set of uints to
 // a set of viable validators
@@ -35,7 +42,7 @@ type ContainerConfig struct {
 type System struct {
 	containerConfig  ContainerConfig
 	validatorConfigs []ValidatorConfig
-	chainConfigs     []ChainConfig
+	chainConfigs     map[string]ChainConfig
 }
 
 func DefaultSystemConfig() System {
@@ -72,16 +79,16 @@ func DefaultSystemConfig() System {
 				nodeKey:          `{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"WLTcHEjbwB24Wp3z5oBSYTvtGQonz/7IQabOFw85BN0UkkyY5HDf38o8oHlFxVI26f+DFVeICuLbe9aXKGnUeg=="}}`,
 			},
 		},
-		chainConfigs: []ChainConfig{
-			{
-				chainId:        "provider",
+		chainConfigs: map[string]ChainConfig{
+			providerChainId: {
+				chainId:        providerChainId,
 				binaryName:     "interchain-security-pd",
 				ipPrefix:       "7.7.7",
 				votingWaitTime: 5,
 				genesisChanges: ".app_state.gov.voting_params.voting_period = \"5s\"",
 			},
-			{
-				chainId:        "consumer",
+			consumerChainId: {
+				chainId:        consumerChainId,
 				binaryName:     "interchain-security-cd",
 				ipPrefix:       "7.7.8",
 				votingWaitTime: 10,

--- a/integration-tests/main.go
+++ b/integration-tests/main.go
@@ -51,6 +51,8 @@ func (s System) runStep(step Step, verbose bool) {
 		s.delegateTokens(action, verbose)
 	case UnbondTokensAction:
 		s.unbondTokens(action, verbose)
+	case ValidatorDowntimeAction:
+		s.InvokeValidatorDowntime(action, verbose)
 	default:
 		log.Fatalf(fmt.Sprintf(`unknown action: %#v`, action))
 	}

--- a/integration-tests/state.go
+++ b/integration-tests/state.go
@@ -66,7 +66,7 @@ func (s System) getChainState(chain string, modelState ChainState) ChainState {
 	}
 
 	if modelState.ValPowers != nil {
-		s.waitBlocks(chain, 1)
+		s.waitBlocks(chain, 1, 10*time.Second)
 		powers := s.getValPowers(chain, *modelState.ValPowers)
 		chainState.ValPowers = &powers
 	}
@@ -97,12 +97,17 @@ func (s System) getBlockHeight(chain string) uint {
 	return uint(blockHeight)
 }
 
-func (s System) waitBlocks(chain string, blocks uint) {
+func (s System) waitBlocks(chain string, blocks uint, timeout time.Duration) {
 	startBlock := s.getBlockHeight(chain)
 
+	start := time.Now()
 	for {
 		thisBlock := s.getBlockHeight(chain)
 		if thisBlock >= startBlock+blocks {
+			return
+		}
+		if time.Since(start) > timeout {
+			fmt.Printf("\nwaitBlocks method has timed out after: %s\n", timeout)
 			return
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -279,7 +284,6 @@ func (s System) getValPower(chain string, validator uint) uint {
 		}
 	}
 
-	log.Fatalf("Validator %v not in tendermint validator set", validator)
-
+	// Validator not in set, it's validator power is zero.
 	return 0
 }

--- a/integration-tests/steps.go
+++ b/integration-tests/steps.go
@@ -12,7 +12,7 @@ type Step struct {
 var happyPathSteps = []Step{
 	{
 		action: StartChainAction{
-			chain: 0,
+			chain: providerChainId,
 			validators: []StartChainValidator{
 				{id: 1, stake: 500000000, allocation: 10000000000},
 				{id: 0, stake: 500000000, allocation: 10000000000},
@@ -20,7 +20,7 @@ var happyPathSteps = []Step{
 			},
 		},
 		state: State{
-			0: ChainState{
+			providerChainId: ChainState{
 				ValBalances: &map[uint]uint{
 					0: 9500000000,
 					1: 9500000000,
@@ -30,13 +30,13 @@ var happyPathSteps = []Step{
 	},
 	{
 		action: SendTokensAction{
-			chain:  0,
+			chain:  providerChainId,
 			from:   0,
 			to:     1,
 			amount: 2,
 		},
 		state: State{
-			0: ChainState{
+			providerChainId: ChainState{
 				ValBalances: &map[uint]uint{
 					0: 9499999998,
 					1: 9500000002,
@@ -46,15 +46,15 @@ var happyPathSteps = []Step{
 	},
 	{
 		action: SubmitConsumerProposalAction{
-			chain:         0,
+			chain:         providerChainId,
 			from:          0,
 			deposit:       10000001,
-			consumerChain: 1,
+			consumerChain: consumerChainId,
 			spawnTime:     0,
 			initialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
 		},
 		state: State{
-			0: ChainState{
+			providerChainId: ChainState{
 				ValBalances: &map[uint]uint{
 					0: 9489999997,
 					1: 9500000002,
@@ -62,7 +62,7 @@ var happyPathSteps = []Step{
 				Proposals: &map[uint]Proposal{
 					1: ConsumerProposal{
 						Deposit:       10000001,
-						Chain:         1,
+						Chain:         consumerChainId,
 						SpawnTime:     0,
 						InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
 						Status:        "PROPOSAL_STATUS_VOTING_PERIOD",
@@ -73,17 +73,17 @@ var happyPathSteps = []Step{
 	},
 	{
 		action: VoteGovProposalAction{
-			chain:      0,
+			chain:      providerChainId,
 			from:       []uint{0, 1, 2},
 			vote:       []string{"yes", "yes", "yes"},
 			propNumber: 1,
 		},
 		state: State{
-			0: ChainState{
+			providerChainId: ChainState{
 				Proposals: &map[uint]Proposal{
 					1: ConsumerProposal{
 						Deposit:       10000001,
-						Chain:         1,
+						Chain:         consumerChainId,
 						SpawnTime:     0,
 						InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
 						Status:        "PROPOSAL_STATUS_PASSED",
@@ -98,8 +98,8 @@ var happyPathSteps = []Step{
 	},
 	{
 		action: StartConsumerChainAction{
-			consumerChain: 1,
-			providerChain: 0,
+			consumerChain: consumerChainId,
+			providerChain: providerChainId,
 			validators: []StartChainValidator{
 				{id: 2, stake: 500000000, allocation: 10000000000},
 				{id: 0, stake: 500000000, allocation: 10000000000},
@@ -107,13 +107,13 @@ var happyPathSteps = []Step{
 			},
 		},
 		state: State{
-			0: ChainState{
+			providerChainId: ChainState{
 				ValBalances: &map[uint]uint{
 					0: 9499999998,
 					1: 9500000002,
 				},
 			},
-			1: ChainState{
+			consumerChainId: ChainState{
 				ValBalances: &map[uint]uint{
 					0: 10000000000,
 					1: 10000000000,
@@ -123,13 +123,13 @@ var happyPathSteps = []Step{
 	},
 	{
 		action: SendTokensAction{
-			chain:  1,
+			chain:  consumerChainId,
 			from:   0,
 			to:     1,
 			amount: 1,
 		},
 		state: State{
-			1: ChainState{
+			consumerChainId: ChainState{
 				// Tx on consumer chain should not go through before ICS channel is setup
 				ValBalances: &map[uint]uint{
 					0: 10000000000,
@@ -140,8 +140,8 @@ var happyPathSteps = []Step{
 	},
 	{
 		action: AddIbcConnectionAction{
-			chainA:  1,
-			chainB:  0,
+			chainA:  consumerChainId,
+			chainB:  providerChainId,
 			clientA: 0,
 			clientB: 0,
 			order:   "ordered",
@@ -150,8 +150,8 @@ var happyPathSteps = []Step{
 	},
 	{
 		action: AddIbcChannelAction{
-			chainA:      1,
-			chainB:      0,
+			chainA:      consumerChainId,
+			chainB:      providerChainId,
 			connectionA: 0,
 			portA:       "consumer",
 			portB:       "provider",
@@ -161,20 +161,20 @@ var happyPathSteps = []Step{
 	},
 	{
 		action: DelegateTokensAction{
-			chain:  0,
+			chain:  providerChainId,
 			from:   0,
 			to:     0,
 			amount: 11000000,
 		},
 		state: State{
-			0: ChainState{
+			providerChainId: ChainState{
 				ValPowers: &map[uint]uint{
 					0: 511,
 					1: 500,
 					2: 500,
 				},
 			},
-			1: ChainState{
+			consumerChainId: ChainState{
 				ValPowers: &map[uint]uint{
 					0: 500,
 					1: 500,
@@ -185,13 +185,13 @@ var happyPathSteps = []Step{
 	},
 	{
 		action: SendTokensAction{
-			chain:  1,
+			chain:  consumerChainId,
 			from:   0,
 			to:     1,
 			amount: 1,
 		},
 		state: State{
-			1: ChainState{
+			consumerChainId: ChainState{
 				// Tx should not go through, ICS channel is not setup until first VSC packet has been relayed to consumer
 				ValBalances: &map[uint]uint{
 					0: 10000000000,
@@ -202,12 +202,12 @@ var happyPathSteps = []Step{
 	},
 	{
 		action: RelayPacketsAction{
-			chain:   0,
+			chain:   providerChainId,
 			port:    "provider",
 			channel: 0,
 		},
 		state: State{
-			1: ChainState{
+			consumerChainId: ChainState{
 				ValPowers: &map[uint]uint{
 					0: 511,
 					1: 500,
@@ -218,13 +218,13 @@ var happyPathSteps = []Step{
 	},
 	{
 		action: SendTokensAction{
-			chain:  1,
+			chain:  consumerChainId,
 			from:   0,
 			to:     1,
 			amount: 1,
 		},
 		state: State{
-			1: ChainState{
+			consumerChainId: ChainState{
 				// Now tx should execute
 				ValBalances: &map[uint]uint{
 					0: 9999999999,
@@ -235,20 +235,20 @@ var happyPathSteps = []Step{
 	},
 	{
 		action: UnbondTokensAction{
-			chain:      0,
+			chain:      providerChainId,
 			unbondFrom: 0,
 			sender:     0,
 			amount:     11000000,
 		},
 		state: State{
-			0: ChainState{
+			providerChainId: ChainState{
 				ValPowers: &map[uint]uint{
 					0: 500,
 					1: 500,
 					2: 500,
 				},
 			},
-			1: ChainState{
+			consumerChainId: ChainState{
 				ValPowers: &map[uint]uint{
 					// Voting power on consumer should not be affected yet
 					0: 511,
@@ -260,12 +260,12 @@ var happyPathSteps = []Step{
 	},
 	{
 		action: RelayPacketsAction{
-			chain:   0,
+			chain:   providerChainId,
 			port:    "provider",
 			channel: 0,
 		},
 		state: State{
-			1: ChainState{
+			consumerChainId: ChainState{
 				ValPowers: &map[uint]uint{
 					0: 500,
 					1: 500,

--- a/integration-tests/steps.go
+++ b/integration-tests/steps.go
@@ -238,12 +238,12 @@ var happyPathSteps = []Step{
 			chain:      providerChainId,
 			unbondFrom: 0,
 			sender:     0,
-			amount:     11000000,
+			amount:     1000000,
 		},
 		state: State{
 			providerChainId: ChainState{
 				ValPowers: &map[uint]uint{
-					0: 500,
+					0: 510,
 					1: 500,
 					2: 500,
 				},
@@ -267,7 +267,7 @@ var happyPathSteps = []Step{
 		state: State{
 			consumerChainId: ChainState{
 				ValPowers: &map[uint]uint{
-					0: 500,
+					0: 510,
 					1: 500,
 					2: 500,
 				},
@@ -275,4 +275,68 @@ var happyPathSteps = []Step{
 		},
 	},
 	// TODO: Test full unbonding functionality, considering liquidity after unbonding period, etc.
+	{
+		action: ValidatorDowntimeAction{
+			chain:     consumerChainId,
+			validator: 1,
+		},
+		state: State{
+			// validator powers not affected on either chain yet
+			providerChainId: ChainState{
+				ValPowers: &map[uint]uint{
+					0: 510,
+					1: 500,
+					2: 500,
+				},
+			},
+			consumerChainId: ChainState{
+				ValPowers: &map[uint]uint{
+					0: 510,
+					1: 500,
+					2: 500,
+				},
+			},
+		},
+	},
+	{
+		action: RelayPacketsAction{
+			chain:   providerChainId,
+			port:    "provider",
+			channel: 0,
+		},
+		state: State{
+			providerChainId: ChainState{
+				ValPowers: &map[uint]uint{
+					0: 510,
+					// VSC now seen on provider
+					1: 0,
+					2: 500,
+				},
+			},
+			consumerChainId: ChainState{
+				ValPowers: &map[uint]uint{
+					0: 510,
+					1: 500,
+					2: 500,
+				},
+			},
+		},
+	},
+	{
+		action: RelayPacketsAction{
+			chain:   providerChainId,
+			port:    "provider",
+			channel: 0,
+		},
+		state: State{
+			consumerChainId: ChainState{
+				ValPowers: &map[uint]uint{
+					0: 510,
+					// VSC packet now relayed back to consumer
+					1: 0,
+					2: 500,
+				},
+			},
+		},
+	},
 }


### PR DESCRIPTION
Changes the ```uint```s used in integration tests to ```string```s for increased test readability, no functional changes. 

Main value addition is to help quick readers of ```integration-tests/steps.go```

Will be used by #257