### PR TITLE
Disable messages on consumer chain

### DIFF
--- a/app/consumer/ante/disabled_modules_ante.go
+++ b/app/consumer/ante/disabled_modules_ante.go
@@ -1,0 +1,31 @@
+package ante
+
+import (
+	"fmt"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type DisabledModulesDecorator struct {
+	prefixes []string
+}
+
+func NewDisabledModulesDecorator(disabledModules ...string) DisabledModulesDecorator {
+	return DisabledModulesDecorator{prefixes: disabledModules}
+}
+
+func (dmd DisabledModulesDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	currHeight := ctx.BlockHeight()
+	for _, msg := range tx.GetMsgs() {
+		msgTypeURL := sdk.MsgTypeURL(msg)
+
+		for _, prefix := range dmd.prefixes {
+			if strings.HasPrefix(msgTypeURL, prefix) {
+				return ctx, fmt.Errorf("tx contains message types from unsupported modules at height %d", currHeight)
+			}
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}

--- a/app/consumer/ante/disabled_modules_ante_test.go
+++ b/app/consumer/ante/disabled_modules_ante_test.go
@@ -1,0 +1,78 @@
+package ante_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
+	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	ibcclienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
+	appconsumer "github.com/cosmos/interchain-security/app/consumer"
+	"github.com/cosmos/interchain-security/app/consumer/ante"
+	"github.com/stretchr/testify/require"
+	"github.com/tendermint/spm/cosmoscmd"
+)
+
+func TestDisabledModulesDecorator(t *testing.T) {
+	txCfg := cosmoscmd.MakeEncodingConfig(appconsumer.ModuleBasics).TxConfig
+
+	testCases := []struct {
+		name      string
+		ctx       sdk.Context
+		msgs      []sdk.Msg
+		expectErr bool
+	}{
+		{
+			name: "IBC module messages supported",
+			ctx:  sdk.Context{},
+			msgs: []sdk.Msg{
+				&ibcclienttypes.MsgUpdateClient{},
+			},
+			expectErr: false,
+		},
+		{
+			name: "bank module messages supported",
+			ctx:  sdk.Context{},
+			msgs: []sdk.Msg{
+				&banktypes.MsgSend{},
+			},
+			expectErr: false,
+		},
+		{
+			name: "evidence module messages not supported",
+			ctx:  sdk.Context{},
+			msgs: []sdk.Msg{
+				&evidencetypes.MsgSubmitEvidence{},
+			},
+			expectErr: true,
+		},
+		{
+			name: "slashing module messages not supported",
+			ctx:  sdk.Context{},
+			msgs: []sdk.Msg{
+				&slashingtypes.MsgUnjail{},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			handler := ante.NewDisabledModulesDecorator("/cosmos.evidence", "/cosmos.slashing")
+
+			txBuilder := txCfg.NewTxBuilder()
+			require.NoError(t, txBuilder.SetMsgs(tc.msgs...))
+
+			_, err := handler.AnteHandle(tc.ctx, txBuilder.GetTx(), false,
+				func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) { return ctx, nil })
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/app/consumer/ante_handler.go
+++ b/app/consumer/ante_handler.go
@@ -39,6 +39,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewSetUpContextDecorator(),
 		ante.NewRejectExtensionOptionsDecorator(),
 		consumerante.NewMsgFilterDecorator(options.ConsumerKeeper),
+		consumerante.NewDisabledModulesDecorator("/cosmos.evidence", "/cosmos.slashing"),
 		ante.NewMempoolFeeDecorator(),
 		ante.NewValidateBasicDecorator(),
 		ante.NewTxTimeoutHeightDecorator(),


### PR DESCRIPTION
This pull request fixes issue #115 by adding new ante decorator that disables messages from evidence and slashing modules.

Messages from staking, governance and distribution modules don't need to be filtered since those modules don't exist in minimal consumer chain. If someone sends any of those messages, the CheckTx() will fail because messages from this modules can not be deserialized from bytes to Go structs.

The fix addresses only minimal viable consumer chain. Enabling/disabling of governance, staking and distribution messages for consumer chains with the "democracy package" will be implemented through issue #141.