### PR TITLE
Check counterparty port id during the channel handshake

### DIFF
--- a/x/ccv/consumer/keeper/genesis.go
+++ b/x/ccv/consumer/keeper/genesis.go
@@ -6,7 +6,8 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	ibctmtypes "github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types"
-	"github.com/cosmos/interchain-security/x/ccv/consumer/types"
+	consumertypes "github.com/cosmos/interchain-security/x/ccv/consumer/types"
+	ccv "github.com/cosmos/interchain-security/x/ccv/types"
 	utils "github.com/cosmos/interchain-security/x/ccv/utils"
 
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -14,20 +15,20 @@ import (
 )
 
 // InitGenesis initializes the CCV consumer state and binds to PortID.
-func (k Keeper) InitGenesis(ctx sdk.Context, state *types.GenesisState) []abci.ValidatorUpdate {
+func (k Keeper) InitGenesis(ctx sdk.Context, state *consumertypes.GenesisState) []abci.ValidatorUpdate {
 	k.SetParams(ctx, state.Params)
 	if !state.Params.Enabled {
 		return nil
 	}
 
-	k.SetPort(ctx, types.PortID)
+	k.SetPort(ctx, ccv.ConsumerPortID)
 
 	// Only try to bind to port if it is not already bound, since we may already own
 	// port capability from capability InitGenesis
-	if !k.IsBound(ctx, types.PortID) {
+	if !k.IsBound(ctx, ccv.ConsumerPortID) {
 		// transfer module binds to the transfer port on InitChain
 		// and claims the returned capability
-		err := k.BindPort(ctx, types.PortID)
+		err := k.BindPort(ctx, ccv.ConsumerPortID)
 		if err != nil {
 			panic(fmt.Sprintf("could not claim port capability: %v", err))
 		}
@@ -103,10 +104,10 @@ func (k Keeper) InitGenesis(ctx sdk.Context, state *types.GenesisState) []abci.V
 
 // ExportGenesis exports the CCV consumer state. If the channel has already been established, then we export
 // provider chain. Otherwise, this is still considered a new chain and we export latest client state.
-func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
+func (k Keeper) ExportGenesis(ctx sdk.Context) *consumertypes.GenesisState {
 	params := k.GetParams(ctx)
 	if !params.Enabled {
-		return types.DefaultGenesisState()
+		return consumertypes.DefaultGenesisState()
 	}
 
 	if channelID, ok := k.GetProviderChannel(ctx); ok {
@@ -115,11 +116,11 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 			panic("provider client does not exist")
 		}
 		// ValUpdates must be filled in off-line
-		gs := types.NewRestartGenesisState(clientID, channelID, nil, nil, params)
+		gs := consumertypes.NewRestartGenesisState(clientID, channelID, nil, nil, params)
 
-		maturingPackets := []types.MaturingVSCPacket{}
+		maturingPackets := []consumertypes.MaturingVSCPacket{}
 		cb := func(vscId, timeNs uint64) bool {
-			mat := types.MaturingVSCPacket{
+			mat := consumertypes.MaturingVSCPacket{
 				VscId:        vscId,
 				MaturityTime: timeNs,
 			}
@@ -135,7 +136,7 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	// if provider clientID and channelID don't exist on the consumer chain, then CCV protocol is disabled for this chain
 	// return a disabled genesis state
 	if !ok {
-		return types.DefaultGenesisState()
+		return consumertypes.DefaultGenesisState()
 	}
 	cs, ok := k.clientKeeper.GetClientState(ctx, clientID)
 	if !ok {
@@ -154,5 +155,5 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 		panic("provider consensus state is not tendermint consensus state")
 	}
 	// ValUpdates must be filled in off-line
-	return types.NewInitialGenesisState(tmCs, tmConsState, nil, params)
+	return consumertypes.NewInitialGenesisState(tmCs, tmConsState, nil, params)
 }

--- a/x/ccv/consumer/keeper/genesis_test.go
+++ b/x/ccv/consumer/keeper/genesis_test.go
@@ -9,7 +9,6 @@ import (
 
 	app "github.com/cosmos/interchain-security/app/consumer"
 	appConsumer "github.com/cosmos/interchain-security/app/consumer"
-	consumertypes "github.com/cosmos/interchain-security/x/ccv/consumer/types"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
 
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -30,7 +29,7 @@ func (suite *KeeperTestSuite) TestGenesis() {
 
 	ctx := suite.consumerChain.GetContext()
 	portId := suite.consumerChain.App.(*app.App).ConsumerKeeper.GetPort(ctx)
-	suite.Require().Equal(consumertypes.PortID, portId)
+	suite.Require().Equal(ccv.ConsumerPortID, portId)
 
 	clientId, ok := suite.consumerChain.App.(*app.App).ConsumerKeeper.GetProviderClient(ctx)
 	suite.Require().True(ok)
@@ -60,7 +59,7 @@ func (suite *KeeperTestSuite) TestGenesis() {
 		1,
 		nil,
 	)
-	packet := channeltypes.NewPacket(pd.GetBytes(), 1, ccv.ProviderPortID, suite.path.EndpointB.ChannelID, consumertypes.PortID, suite.path.EndpointA.ChannelID,
+	packet := channeltypes.NewPacket(pd.GetBytes(), 1, ccv.ProviderPortID, suite.path.EndpointB.ChannelID, ccv.ConsumerPortID, suite.path.EndpointA.ChannelID,
 		clienttypes.NewHeight(1, 0), 0)
 	suite.consumerChain.App.(*app.App).ConsumerKeeper.OnRecvVSCPacket(suite.consumerChain.GetContext(), packet, pd)
 

--- a/x/ccv/consumer/keeper/genesis_test.go
+++ b/x/ccv/consumer/keeper/genesis_test.go
@@ -10,8 +10,7 @@ import (
 	app "github.com/cosmos/interchain-security/app/consumer"
 	appConsumer "github.com/cosmos/interchain-security/app/consumer"
 	consumertypes "github.com/cosmos/interchain-security/x/ccv/consumer/types"
-	providertypes "github.com/cosmos/interchain-security/x/ccv/provider/types"
-	"github.com/cosmos/interchain-security/x/ccv/types"
+	ccv "github.com/cosmos/interchain-security/x/ccv/types"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmtypes "github.com/tendermint/tendermint/types"
@@ -47,7 +46,7 @@ func (suite *KeeperTestSuite) TestGenesis() {
 	suite.Require().NoError(err)
 	pk2, err := cryptocodec.ToTmProtoPublicKey(ed25519.GenPrivKey().PubKey())
 	suite.Require().NoError(err)
-	pd := types.NewValidatorSetChangePacketData(
+	pd := ccv.NewValidatorSetChangePacketData(
 		[]abci.ValidatorUpdate{
 			{
 				PubKey: pk1,
@@ -61,7 +60,7 @@ func (suite *KeeperTestSuite) TestGenesis() {
 		1,
 		nil,
 	)
-	packet := channeltypes.NewPacket(pd.GetBytes(), 1, providertypes.PortID, suite.path.EndpointB.ChannelID, consumertypes.PortID, suite.path.EndpointA.ChannelID,
+	packet := channeltypes.NewPacket(pd.GetBytes(), 1, ccv.ProviderPortID, suite.path.EndpointB.ChannelID, consumertypes.PortID, suite.path.EndpointA.ChannelID,
 		clienttypes.NewHeight(1, 0), 0)
 	suite.consumerChain.App.(*app.App).ConsumerKeeper.OnRecvVSCPacket(suite.consumerChain.GetContext(), packet, pd)
 

--- a/x/ccv/consumer/keeper/keeper_test.go
+++ b/x/ccv/consumer/keeper/keeper_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cosmos/interchain-security/testutil/simapp"
 	"github.com/cosmos/interchain-security/x/ccv/consumer/types"
 	consumertypes "github.com/cosmos/interchain-security/x/ccv/consumer/types"
-	providertypes "github.com/cosmos/interchain-security/x/ccv/provider/types"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
 	utils "github.com/cosmos/interchain-security/x/ccv/utils"
 	"github.com/stretchr/testify/require"
@@ -111,7 +110,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.path.EndpointA.ClientConfig.(*ibctesting.TendermintConfig).TrustingPeriod = consumerUnbondingPeriod / utils.TrustingPeriodFraction
 	// - channel config
 	suite.path.EndpointA.ChannelConfig.PortID = consumertypes.PortID
-	suite.path.EndpointB.ChannelConfig.PortID = providertypes.PortID
+	suite.path.EndpointB.ChannelConfig.PortID = ccv.ProviderPortID
 	suite.path.EndpointA.ChannelConfig.Version = ccv.Version
 	suite.path.EndpointB.ChannelConfig.Version = ccv.Version
 	suite.path.EndpointA.ChannelConfig.Order = channeltypes.ORDERED
@@ -661,10 +660,10 @@ func (suite *KeeperTestSuite) SendEmptyVSCPacket() {
 	)
 
 	seq, ok := suite.providerChain.App.(*appProvider.App).GetIBCKeeper().ChannelKeeper.GetNextSequenceSend(
-		suite.providerChain.GetContext(), providertypes.PortID, suite.path.EndpointB.ChannelID)
+		suite.providerChain.GetContext(), ccv.ProviderPortID, suite.path.EndpointB.ChannelID)
 	suite.Require().True(ok)
 
-	packet := channeltypes.NewPacket(pd.GetBytes(), seq, providertypes.PortID, suite.path.EndpointB.ChannelID,
+	packet := channeltypes.NewPacket(pd.GetBytes(), seq, ccv.ProviderPortID, suite.path.EndpointB.ChannelID,
 		consumertypes.PortID, suite.path.EndpointA.ChannelID, clienttypes.Height{}, timeout)
 
 	err := suite.path.EndpointB.SendPacket(packet)
@@ -684,7 +683,7 @@ func (suite *KeeperTestSuite) commitSlashPacket(ctx sdk.Context, packetData ccv.
 	timeout := uint64(ccv.GetTimeoutTimestamp(oldBlockTime).UnixNano())
 
 	packet := channeltypes.NewPacket(packetData.GetBytes(), 1, consumertypes.PortID, suite.path.EndpointA.ChannelID,
-		providertypes.PortID, suite.path.EndpointB.ChannelID, clienttypes.Height{}, timeout)
+		ccv.ProviderPortID, suite.path.EndpointB.ChannelID, clienttypes.Height{}, timeout)
 
 	return channeltypes.CommitPacket(suite.consumerChain.App.AppCodec(), packet)
 }

--- a/x/ccv/consumer/module.go
+++ b/x/ccv/consumer/module.go
@@ -226,13 +226,12 @@ func (am AppModule) WeightedOperations(_ module.SimulationState) []simtypes.Weig
 	return nil
 }
 
-// ValidateCCVChannelParams validates a ccv channel
-func ValidateCCVChannelParams(
+// validateCCVChannelParams validates a ccv channel
+func validateCCVChannelParams(
 	ctx sdk.Context,
 	keeper keeper.Keeper,
 	order channeltypes.Order,
 	portID string,
-	channelID string,
 	version string,
 ) error {
 	// only ordered channels allowed
@@ -272,8 +271,8 @@ func (am AppModule) OnChanOpenInit(
 	}
 
 	// validate parameters
-	if err := ValidateCCVChannelParams(
-		ctx, am.keeper, order, portID, channelID, version,
+	if err := validateCCVChannelParams(
+		ctx, am.keeper, order, portID, version,
 	); err != nil {
 		return err
 	}

--- a/x/ccv/consumer/module_test.go
+++ b/x/ccv/consumer/module_test.go
@@ -105,7 +105,7 @@ func (suite *ConsumerTestSuite) SetupTest() {
 	suite.path.EndpointA.ClientConfig.(*ibctesting.TendermintConfig).TrustingPeriod = consumerUnbondingPeriod / utils.TrustingPeriodFraction
 	// - channel config
 	suite.path.EndpointA.ChannelConfig.PortID = consumertypes.PortID
-	suite.path.EndpointB.ChannelConfig.PortID = providertypes.PortID
+	suite.path.EndpointB.ChannelConfig.PortID = ccv.ProviderPortID
 	suite.path.EndpointA.ChannelConfig.Version = ccv.Version
 	suite.path.EndpointB.ChannelConfig.Version = ccv.Version
 	suite.path.EndpointA.ChannelConfig.Order = channeltypes.ORDERED
@@ -136,7 +136,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 				// Set INIT channel on consumer chain
 				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
 					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(providertypes.PortID, ""),
+						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
 				)
 				suite.path.EndpointA.ChannelID = channelID
@@ -150,7 +150,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 				// Set INIT channel on consumer chain
 				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
 					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(providertypes.PortID, ""),
+						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
 				)
 				suite.path.EndpointA.ChannelID = channelID
@@ -165,7 +165,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 				// Set INIT channel on consumer chain
 				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
 					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.UNORDERED, channeltypes.NewCounterparty(providertypes.PortID, ""),
+						channeltypes.INIT, channeltypes.UNORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
 				)
 				suite.path.EndpointA.ChannelID = channelID
@@ -180,7 +180,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 				// Set INIT channel on consumer chain
 				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
 					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.UNORDERED, channeltypes.NewCounterparty(providertypes.PortID, ""),
+						channeltypes.INIT, channeltypes.UNORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
 				)
 				suite.path.EndpointA.ChannelID = channelID
@@ -195,7 +195,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 				// Set INIT channel on consumer chain
 				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
 					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.UNORDERED, channeltypes.NewCounterparty(providertypes.PortID, ""),
+						channeltypes.INIT, channeltypes.UNORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
 				)
 				suite.path.EndpointA.ChannelID = channelID
@@ -216,7 +216,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 				path.EndpointA.ClientConfig.(*ibctesting.TendermintConfig).TrustingPeriod = consumerUnbondingPeriod / utils.TrustingPeriodFraction
 				// - channel config
 				path.EndpointA.ChannelConfig.PortID = consumertypes.PortID
-				path.EndpointB.ChannelConfig.PortID = providertypes.PortID
+				path.EndpointB.ChannelConfig.PortID = ccv.ProviderPortID
 				path.EndpointA.ChannelConfig.Version = ccv.Version
 				path.EndpointB.ChannelConfig.Version = ccv.Version
 				path.EndpointA.ChannelConfig.Order = channeltypes.ORDERED
@@ -234,7 +234,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 				// Set INIT channel on consumer chain
 				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
 					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(providertypes.PortID, ""),
+						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
 				)
 				suite.path.EndpointA.ChannelID = channelID
@@ -254,7 +254,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 			suite.Require().NoError(err)
 
 			err = consumerModule.OnChanOpenInit(suite.ctx, suite.path.EndpointA.ChannelConfig.Order, []string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.PortID,
-				suite.path.EndpointA.ChannelID, chanCap, channeltypes.NewCounterparty(providertypes.PortID, ""), suite.path.EndpointA.ChannelConfig.Version)
+				suite.path.EndpointA.ChannelID, chanCap, channeltypes.NewCounterparty(ccv.ProviderPortID, ""), suite.path.EndpointA.ChannelConfig.Version)
 
 			if tc.expError {
 				suite.Require().Error(err)
@@ -310,7 +310,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenTry() {
 	chanCap, err := suite.consumerChain.App.GetScopedIBCKeeper().NewCapability(suite.ctx, host.ChannelCapabilityPath(consumertypes.PortID, suite.path.EndpointA.ChannelID))
 	suite.Require().NoError(err)
 
-	_, err = consumerModule.OnChanOpenTry(suite.ctx, channeltypes.ORDERED, []string{"connection-1"}, consumertypes.PortID, "channel-1", chanCap, channeltypes.NewCounterparty(providertypes.PortID, "channel-1"), ccv.Version)
+	_, err = consumerModule.OnChanOpenTry(suite.ctx, channeltypes.ORDERED, []string{"connection-1"}, consumertypes.PortID, "channel-1", chanCap, channeltypes.NewCounterparty(ccv.ProviderPortID, "channel-1"), ccv.Version)
 	suite.Require().Error(err, "OnChanOpenTry callback must error on consumer chain")
 }
 
@@ -328,7 +328,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenAck() {
 				// Set INIT channel on consumer chain
 				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
 					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(providertypes.PortID, ""),
+						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
 				)
 				suite.path.EndpointA.ChannelID = channelID
@@ -342,7 +342,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenAck() {
 				// Set INIT channel on consumer chain
 				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
 					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(providertypes.PortID, ""),
+						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
 				)
 				suite.path.EndpointA.ChannelID = channelID
@@ -355,7 +355,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenAck() {
 				// Set INIT channel on consumer chain
 				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
 					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(providertypes.PortID, ""),
+						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
 				)
 				suite.path.EndpointA.ChannelID = channelID
@@ -394,7 +394,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenAck() {
 func (suite *ConsumerTestSuite) TestOnChanOpenConfirm() {
 	suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, "channel-1",
 		channeltypes.NewChannel(
-			channeltypes.TRYOPEN, channeltypes.ORDERED, channeltypes.NewCounterparty(providertypes.PortID, "channel-1"),
+			channeltypes.TRYOPEN, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, "channel-1"),
 			[]string{"connection-1"}, ccv.Version,
 		))
 
@@ -417,7 +417,7 @@ func (suite *ConsumerTestSuite) TestOnChanCloseInit() {
 				// Set INIT channel on consumer chain
 				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
 					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(providertypes.PortID, ""),
+						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
 				)
 				suite.path.EndpointA.ChannelID = channelID
@@ -440,7 +440,7 @@ func (suite *ConsumerTestSuite) TestOnChanCloseInit() {
 				// Set INIT channel on consumer chain
 				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
 					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(providertypes.PortID, ""),
+						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
 				)
 				suite.path.EndpointA.ChannelID = channelID

--- a/x/ccv/consumer/module_test.go
+++ b/x/ccv/consumer/module_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cosmos/interchain-security/testutil/simapp"
 	"github.com/cosmos/interchain-security/x/ccv/consumer"
 	providertypes "github.com/cosmos/interchain-security/x/ccv/provider/types"
+	"github.com/cosmos/interchain-security/x/ccv/types"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
 	"github.com/cosmos/interchain-security/x/ccv/utils"
 
@@ -123,96 +124,49 @@ func (suite *ConsumerTestSuite) SetupTest() {
 }
 
 func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
-	channelID := "channel-1"
+	var (
+		channel *channeltypes.Channel
+		// chanCap *capabilitytypes.Capability
+	)
+
 	testCases := []struct {
 		name     string
-		setup    func(suite *ConsumerTestSuite)
-		expError bool
+		malleate func()
+		expPass  bool
 	}{
+
 		{
-			name: "success",
-			setup: func(suite *ConsumerTestSuite) {
-				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
-					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
-						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
-				)
-				suite.path.EndpointA.ChannelID = channelID
-			},
-			expError: false,
+			"success", func() {}, true,
 		},
 		{
-			name: "invalid: provider channel already established",
-			setup: func(suite *ConsumerTestSuite) {
+			"invalid: provider channel already established", func() {
 				suite.consumerChain.App.(*appConsumer.App).ConsumerKeeper.SetProviderChannel(suite.ctx, "channel-2")
-				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
-					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
-						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
-				)
-				suite.path.EndpointA.ChannelID = channelID
-			},
-			expError: true,
+			}, false,
 		},
 		{
-			name: "invalid: UNORDERED channel",
-			setup: func(suite *ConsumerTestSuite) {
-				// set path ORDER to UNORDERED
-				suite.path.EndpointA.ChannelConfig.Order = channeltypes.UNORDERED
-				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
-					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.UNORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
-						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
-				)
-				suite.path.EndpointA.ChannelID = channelID
-			},
-			expError: true,
+			"invalid: UNORDERED channel", func() {
+				channel.Ordering = channeltypes.UNORDERED
+			}, false,
 		},
 		{
-			name: "invalid: incorrect port",
-			setup: func(suite *ConsumerTestSuite) {
-				// set path port to invalid portID
-				suite.path.EndpointA.ChannelConfig.PortID = "invalidPort"
-				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
-					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.UNORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
-						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
-				)
-				suite.path.EndpointA.ChannelID = channelID
-			},
-			expError: true,
+			"invalid port ID", func() {
+				suite.path.EndpointA.ChannelConfig.PortID = ibctesting.MockPort
+			}, false,
 		},
 		{
-			name: "invalid: incorrect version",
-			setup: func(suite *ConsumerTestSuite) {
-				// set path port to invalid version
-				suite.path.EndpointA.ChannelConfig.Version = "invalidVersion"
-				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
-					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.UNORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
-						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
-				)
-				suite.path.EndpointA.ChannelID = channelID
-			},
-			expError: true,
+			"invalid version", func() {
+				channel.Version = "version"
+			}, false,
 		},
 		{
-			name: "invalid: verify provider chain failed",
-			setup: func(suite *ConsumerTestSuite) {
+			"invalid counter party port ID", func() {
+				channel.Counterparty.PortId = ibctesting.MockPort
+			}, false,
+		},
+		{
+			"invalid: verify provider chain failed", func() {
 				// setup a new path with provider client on consumer chain being different from genesis client
 				path := ibctesting.NewPath(suite.consumerChain, suite.providerChain)
-				// - client config
-				providerUnbondingPeriod := suite.providerChain.App.(*appProvider.App).GetStakingKeeper().UnbondingTime(suite.providerChain.GetContext())
-				path.EndpointB.ClientConfig.(*ibctesting.TendermintConfig).UnbondingPeriod = providerUnbondingPeriod
-				path.EndpointB.ClientConfig.(*ibctesting.TendermintConfig).TrustingPeriod = providerUnbondingPeriod / utils.TrustingPeriodFraction
-				consumerUnbondingPeriod := utils.ComputeConsumerUnbondingPeriod(providerUnbondingPeriod)
-				path.EndpointA.ClientConfig.(*ibctesting.TendermintConfig).UnbondingPeriod = consumerUnbondingPeriod
-				path.EndpointA.ClientConfig.(*ibctesting.TendermintConfig).TrustingPeriod = consumerUnbondingPeriod / utils.TrustingPeriodFraction
 				// - channel config
 				path.EndpointA.ChannelConfig.PortID = ccv.ConsumerPortID
 				path.EndpointB.ChannelConfig.PortID = ccv.ProviderPortID
@@ -222,53 +176,75 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 				path.EndpointB.ChannelConfig.Order = channeltypes.ORDERED
 
 				// create consumer client on provider chain, and provider client on consumer chain
-				err := suite.CreateCustomClient(path.EndpointB, consumerUnbondingPeriod)
+				providerUnbondingPeriod := suite.providerChain.App.(*appProvider.App).GetStakingKeeper().UnbondingTime(suite.providerChain.GetContext())
+				consumerUnbondingPeriod := utils.ComputeConsumerUnbondingPeriod(providerUnbondingPeriod)
+				err := suite.createCustomClient(path.EndpointB, consumerUnbondingPeriod)
 				suite.Require().NoError(err)
-				err = suite.CreateCustomClient(path.EndpointA, providerUnbondingPeriod)
+				err = suite.createCustomClient(path.EndpointA, providerUnbondingPeriod)
 				suite.Require().NoError(err)
 
 				suite.coordinator.CreateConnections(path)
 				suite.path = path
-
-				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
-					channeltypes.NewChannel(
-						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
-						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
-				)
-				suite.path.EndpointA.ChannelID = channelID
-			},
-			expError: true,
+				channel.ConnectionHops = []string{suite.path.EndpointA.ConnectionID}
+			}, false,
 		},
 	}
 
 	for _, tc := range testCases {
 		tc := tc
-		suite.Run(fmt.Sprintf("Case: %s", tc.name), func() {
-			suite.SetupTest() // reset suite
-			tc.setup(suite)
+
+		suite.Run(tc.name, func() {
+			suite.SetupTest() // reset
+
+			suite.path.EndpointA.ChannelID = ibctesting.FirstChannelID
+
+			counterparty := channeltypes.NewCounterparty(suite.path.EndpointB.ChannelConfig.PortID, "")
+			channel = &channeltypes.Channel{
+				State:          channeltypes.INIT,
+				Ordering:       channeltypes.ORDERED,
+				Counterparty:   counterparty,
+				ConnectionHops: []string{suite.path.EndpointA.ConnectionID},
+				Version:        types.Version,
+			}
 
 			consumerModule := consumer.NewAppModule(suite.consumerChain.App.(*appConsumer.App).ConsumerKeeper)
-			chanCap, err := suite.consumerChain.App.GetScopedIBCKeeper().NewCapability(suite.ctx, host.ChannelCapabilityPath(ccv.ConsumerPortID, suite.path.EndpointA.ChannelID))
+			chanCap, err := suite.consumerChain.App.GetScopedIBCKeeper().NewCapability(
+				suite.ctx,
+				host.ChannelCapabilityPath(
+					ccv.ConsumerPortID,
+					suite.path.EndpointA.ChannelID,
+				),
+			)
 			suite.Require().NoError(err)
 
-			err = consumerModule.OnChanOpenInit(suite.ctx, suite.path.EndpointA.ChannelConfig.Order, []string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.PortID,
-				suite.path.EndpointA.ChannelID, chanCap, channeltypes.NewCounterparty(ccv.ProviderPortID, ""), suite.path.EndpointA.ChannelConfig.Version)
+			tc.malleate() // explicitly change fields in channel and testChannel
 
-			if tc.expError {
-				suite.Require().Error(err)
-			} else {
+			err = consumerModule.OnChanOpenInit(
+				suite.ctx,
+				channel.Ordering,
+				channel.GetConnectionHops(),
+				suite.path.EndpointA.ChannelConfig.PortID,
+				suite.path.EndpointA.ChannelID,
+				chanCap,
+				channel.Counterparty,
+				channel.GetVersion(),
+			)
+
+			if tc.expPass {
 				suite.Require().NoError(err)
+			} else {
+				suite.Require().Error(err)
 			}
+
 		})
 	}
 }
 
-// CreateCustomClient creates an IBC client on the endpoint
+// createCustomClient creates an IBC client on the endpoint
 // using the given unbonding period.
 // It will update the clientID for the endpoint if the message
 // is successfully executed.
-func (suite *ConsumerTestSuite) CreateCustomClient(endpoint *ibctesting.Endpoint, unbondingPeriod time.Duration) (err error) {
+func (suite *ConsumerTestSuite) createCustomClient(endpoint *ibctesting.Endpoint, unbondingPeriod time.Duration) (err error) {
 	// ensure counterparty has committed state
 	endpoint.Chain.Coordinator.CommitBlock(endpoint.Counterparty.Chain)
 
@@ -306,10 +282,16 @@ func (suite *ConsumerTestSuite) CreateCustomClient(endpoint *ibctesting.Endpoint
 func (suite *ConsumerTestSuite) TestOnChanOpenTry() {
 	// OnOpenTry must error even with correct arguments
 	consumerModule := consumer.NewAppModule(suite.consumerChain.App.(*appConsumer.App).ConsumerKeeper)
-	chanCap, err := suite.consumerChain.App.GetScopedIBCKeeper().NewCapability(suite.ctx, host.ChannelCapabilityPath(ccv.ConsumerPortID, suite.path.EndpointA.ChannelID))
-	suite.Require().NoError(err)
-
-	_, err = consumerModule.OnChanOpenTry(suite.ctx, channeltypes.ORDERED, []string{"connection-1"}, ccv.ConsumerPortID, "channel-1", chanCap, channeltypes.NewCounterparty(ccv.ProviderPortID, "channel-1"), ccv.Version)
+	_, err := consumerModule.OnChanOpenTry(
+		suite.ctx,
+		channeltypes.ORDERED,
+		[]string{"connection-1"},
+		ccv.ConsumerPortID,
+		"channel-1",
+		nil,
+		channeltypes.NewCounterparty(ccv.ProviderPortID, "channel-1"),
+		ccv.Version,
+	)
 	suite.Require().Error(err, "OnChanOpenTry callback must error on consumer chain")
 }
 
@@ -391,16 +373,9 @@ func (suite *ConsumerTestSuite) TestOnChanOpenAck() {
 }
 
 func (suite *ConsumerTestSuite) TestOnChanOpenConfirm() {
-	suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, "channel-1",
-		channeltypes.NewChannel(
-			channeltypes.TRYOPEN, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, "channel-1"),
-			[]string{"connection-1"}, ccv.Version,
-		))
-
 	consumerModule := consumer.NewAppModule(suite.consumerChain.App.(*appConsumer.App).ConsumerKeeper)
-
 	err := consumerModule.OnChanOpenConfirm(suite.ctx, ccv.ConsumerPortID, "channel-1")
-	suite.Require().Error(err, "OnChanOpenConfirm must always fail")
+	suite.Require().Error(err, "OnChanOpenConfirm callback must error on consumer chain")
 }
 
 func (suite *ConsumerTestSuite) TestOnChanCloseInit() {

--- a/x/ccv/consumer/module_test.go
+++ b/x/ccv/consumer/module_test.go
@@ -20,7 +20,6 @@ import (
 	appProvider "github.com/cosmos/interchain-security/app/provider"
 	"github.com/cosmos/interchain-security/testutil/simapp"
 	"github.com/cosmos/interchain-security/x/ccv/consumer"
-	consumertypes "github.com/cosmos/interchain-security/x/ccv/consumer/types"
 	providertypes "github.com/cosmos/interchain-security/x/ccv/provider/types"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
 	"github.com/cosmos/interchain-security/x/ccv/utils"
@@ -104,7 +103,7 @@ func (suite *ConsumerTestSuite) SetupTest() {
 	suite.path.EndpointA.ClientConfig.(*ibctesting.TendermintConfig).UnbondingPeriod = consumerUnbondingPeriod
 	suite.path.EndpointA.ClientConfig.(*ibctesting.TendermintConfig).TrustingPeriod = consumerUnbondingPeriod / utils.TrustingPeriodFraction
 	// - channel config
-	suite.path.EndpointA.ChannelConfig.PortID = consumertypes.PortID
+	suite.path.EndpointA.ChannelConfig.PortID = ccv.ConsumerPortID
 	suite.path.EndpointB.ChannelConfig.PortID = ccv.ProviderPortID
 	suite.path.EndpointA.ChannelConfig.Version = ccv.Version
 	suite.path.EndpointB.ChannelConfig.Version = ccv.Version
@@ -134,7 +133,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 			name: "success",
 			setup: func(suite *ConsumerTestSuite) {
 				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
+				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
 					channeltypes.NewChannel(
 						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
@@ -148,7 +147,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 			setup: func(suite *ConsumerTestSuite) {
 				suite.consumerChain.App.(*appConsumer.App).ConsumerKeeper.SetProviderChannel(suite.ctx, "channel-2")
 				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
+				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
 					channeltypes.NewChannel(
 						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
@@ -163,7 +162,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 				// set path ORDER to UNORDERED
 				suite.path.EndpointA.ChannelConfig.Order = channeltypes.UNORDERED
 				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
+				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
 					channeltypes.NewChannel(
 						channeltypes.INIT, channeltypes.UNORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
@@ -178,7 +177,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 				// set path port to invalid portID
 				suite.path.EndpointA.ChannelConfig.PortID = "invalidPort"
 				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
+				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
 					channeltypes.NewChannel(
 						channeltypes.INIT, channeltypes.UNORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
@@ -193,7 +192,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 				// set path port to invalid version
 				suite.path.EndpointA.ChannelConfig.Version = "invalidVersion"
 				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
+				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
 					channeltypes.NewChannel(
 						channeltypes.INIT, channeltypes.UNORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
@@ -215,7 +214,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 				path.EndpointA.ClientConfig.(*ibctesting.TendermintConfig).UnbondingPeriod = consumerUnbondingPeriod
 				path.EndpointA.ClientConfig.(*ibctesting.TendermintConfig).TrustingPeriod = consumerUnbondingPeriod / utils.TrustingPeriodFraction
 				// - channel config
-				path.EndpointA.ChannelConfig.PortID = consumertypes.PortID
+				path.EndpointA.ChannelConfig.PortID = ccv.ConsumerPortID
 				path.EndpointB.ChannelConfig.PortID = ccv.ProviderPortID
 				path.EndpointA.ChannelConfig.Version = ccv.Version
 				path.EndpointB.ChannelConfig.Version = ccv.Version
@@ -232,7 +231,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 				suite.path = path
 
 				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
+				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
 					channeltypes.NewChannel(
 						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
@@ -250,7 +249,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenInit() {
 			tc.setup(suite)
 
 			consumerModule := consumer.NewAppModule(suite.consumerChain.App.(*appConsumer.App).ConsumerKeeper)
-			chanCap, err := suite.consumerChain.App.GetScopedIBCKeeper().NewCapability(suite.ctx, host.ChannelCapabilityPath(consumertypes.PortID, suite.path.EndpointA.ChannelID))
+			chanCap, err := suite.consumerChain.App.GetScopedIBCKeeper().NewCapability(suite.ctx, host.ChannelCapabilityPath(ccv.ConsumerPortID, suite.path.EndpointA.ChannelID))
 			suite.Require().NoError(err)
 
 			err = consumerModule.OnChanOpenInit(suite.ctx, suite.path.EndpointA.ChannelConfig.Order, []string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.PortID,
@@ -307,10 +306,10 @@ func (suite *ConsumerTestSuite) CreateCustomClient(endpoint *ibctesting.Endpoint
 func (suite *ConsumerTestSuite) TestOnChanOpenTry() {
 	// OnOpenTry must error even with correct arguments
 	consumerModule := consumer.NewAppModule(suite.consumerChain.App.(*appConsumer.App).ConsumerKeeper)
-	chanCap, err := suite.consumerChain.App.GetScopedIBCKeeper().NewCapability(suite.ctx, host.ChannelCapabilityPath(consumertypes.PortID, suite.path.EndpointA.ChannelID))
+	chanCap, err := suite.consumerChain.App.GetScopedIBCKeeper().NewCapability(suite.ctx, host.ChannelCapabilityPath(ccv.ConsumerPortID, suite.path.EndpointA.ChannelID))
 	suite.Require().NoError(err)
 
-	_, err = consumerModule.OnChanOpenTry(suite.ctx, channeltypes.ORDERED, []string{"connection-1"}, consumertypes.PortID, "channel-1", chanCap, channeltypes.NewCounterparty(ccv.ProviderPortID, "channel-1"), ccv.Version)
+	_, err = consumerModule.OnChanOpenTry(suite.ctx, channeltypes.ORDERED, []string{"connection-1"}, ccv.ConsumerPortID, "channel-1", chanCap, channeltypes.NewCounterparty(ccv.ProviderPortID, "channel-1"), ccv.Version)
 	suite.Require().Error(err, "OnChanOpenTry callback must error on consumer chain")
 }
 
@@ -326,7 +325,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenAck() {
 			name: "success",
 			setup: func(suite *ConsumerTestSuite) {
 				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
+				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
 					channeltypes.NewChannel(
 						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
@@ -340,7 +339,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenAck() {
 			setup: func(suite *ConsumerTestSuite) {
 				suite.consumerChain.App.(*appConsumer.App).ConsumerKeeper.SetProviderChannel(suite.ctx, "channel-2")
 				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
+				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
 					channeltypes.NewChannel(
 						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
@@ -353,7 +352,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenAck() {
 			name: "invalid: mismatched versions",
 			setup: func(suite *ConsumerTestSuite) {
 				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
+				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
 					channeltypes.NewChannel(
 						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
@@ -381,7 +380,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenAck() {
 			mdBz, err := (&md).Marshal()
 			suite.Require().NoError(err)
 
-			err = consumerModule.OnChanOpenAck(suite.ctx, consumertypes.PortID, channelID, counterChannelID, string(mdBz))
+			err = consumerModule.OnChanOpenAck(suite.ctx, ccv.ConsumerPortID, channelID, counterChannelID, string(mdBz))
 			if tc.expError {
 				suite.Require().Error(err)
 			} else {
@@ -392,7 +391,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenAck() {
 }
 
 func (suite *ConsumerTestSuite) TestOnChanOpenConfirm() {
-	suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, "channel-1",
+	suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, "channel-1",
 		channeltypes.NewChannel(
 			channeltypes.TRYOPEN, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, "channel-1"),
 			[]string{"connection-1"}, ccv.Version,
@@ -400,7 +399,7 @@ func (suite *ConsumerTestSuite) TestOnChanOpenConfirm() {
 
 	consumerModule := consumer.NewAppModule(suite.consumerChain.App.(*appConsumer.App).ConsumerKeeper)
 
-	err := consumerModule.OnChanOpenConfirm(suite.ctx, consumertypes.PortID, "channel-1")
+	err := consumerModule.OnChanOpenConfirm(suite.ctx, ccv.ConsumerPortID, "channel-1")
 	suite.Require().Error(err, "OnChanOpenConfirm must always fail")
 }
 
@@ -415,7 +414,7 @@ func (suite *ConsumerTestSuite) TestOnChanCloseInit() {
 			name: "can close duplicate in-progress channel once provider channel is established",
 			setup: func(suite *ConsumerTestSuite) {
 				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
+				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
 					channeltypes.NewChannel(
 						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
@@ -438,7 +437,7 @@ func (suite *ConsumerTestSuite) TestOnChanCloseInit() {
 			name: "cannot close in-progress channel, no established channel yet",
 			setup: func(suite *ConsumerTestSuite) {
 				// Set INIT channel on consumer chain
-				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, consumertypes.PortID, channelID,
+				suite.consumerChain.App.GetIBCKeeper().ChannelKeeper.SetChannel(suite.ctx, ccv.ConsumerPortID, channelID,
 					channeltypes.NewChannel(
 						channeltypes.INIT, channeltypes.ORDERED, channeltypes.NewCounterparty(ccv.ProviderPortID, ""),
 						[]string{suite.path.EndpointA.ConnectionID}, suite.path.EndpointA.ChannelConfig.Version),
@@ -466,7 +465,7 @@ func (suite *ConsumerTestSuite) TestOnChanCloseInit() {
 
 			consumerModule := consumer.NewAppModule(suite.consumerChain.App.(*appConsumer.App).ConsumerKeeper)
 
-			err := consumerModule.OnChanCloseInit(suite.ctx, consumertypes.PortID, suite.path.EndpointA.ChannelID)
+			err := consumerModule.OnChanCloseInit(suite.ctx, ccv.ConsumerPortID, suite.path.EndpointA.ChannelID)
 
 			if tc.expError {
 				suite.Require().Error(err)

--- a/x/ccv/consumer/types/keys.go
+++ b/x/ccv/consumer/types/keys.go
@@ -11,9 +11,6 @@ const (
 	// ModuleName defines the CCV consumer module name
 	ModuleName = "ccvconsumer"
 
-	// PortID is the default port id that consumer module binds to
-	PortID = "consumer"
-
 	// StoreKey is the store key string for IBC consumer
 	StoreKey = ModuleName
 

--- a/x/ccv/provider/keeper/genesis.go
+++ b/x/ccv/provider/keeper/genesis.go
@@ -5,18 +5,18 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/interchain-security/x/ccv/provider/types"
-	providertypes "github.com/cosmos/interchain-security/x/ccv/provider/types"
+	ccv "github.com/cosmos/interchain-security/x/ccv/types"
 )
 
 func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
-	k.SetPort(ctx, providertypes.PortID)
+	k.SetPort(ctx, ccv.ProviderPortID)
 
 	// Only try to bind to port if it is not already bound, since we may already own
 	// port capability from capability InitGenesis
-	if !k.IsBound(ctx, providertypes.PortID) {
+	if !k.IsBound(ctx, ccv.ProviderPortID) {
 		// transfer module binds to the transfer port on InitChain
 		// and claims the returned capability
-		err := k.BindPort(ctx, providertypes.PortID)
+		err := k.BindPort(ctx, ccv.ProviderPortID)
 		if err != nil {
 			panic(fmt.Sprintf("could not claim port capability: %v", err))
 		}

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -259,7 +259,7 @@ func (k Keeper) VerifyConsumerChain(ctx sdk.Context, channelID string, connectio
 // and set the channel status to validating.
 // If there is already a ccv channel between the provider and consumer chain then close the channel, so that another channel can be made.
 func (k Keeper) SetConsumerChain(ctx sdk.Context, channelID string) error {
-	channel, ok := k.channelKeeper.GetChannel(ctx, types.PortID, channelID)
+	channel, ok := k.channelKeeper.GetChannel(ctx, ccv.ProviderPortID, channelID)
 	if !ok {
 		return sdkerrors.Wrapf(channeltypes.ErrChannelNotFound, "channel not found for channel ID: %s", channelID)
 	}
@@ -463,12 +463,12 @@ func (k Keeper) getUnderlyingClient(ctx sdk.Context, connectionID string) (strin
 
 // chanCloseInit defines a wrapper function for the channel Keeper's function
 func (k Keeper) chanCloseInit(ctx sdk.Context, channelID string) error {
-	capName := host.ChannelCapabilityPath(types.PortID, channelID)
+	capName := host.ChannelCapabilityPath(ccv.ProviderPortID, channelID)
 	chanCap, ok := k.scopedKeeper.GetCapability(ctx, capName)
 	if !ok {
 		return sdkerrors.Wrapf(channeltypes.ErrChannelCapabilityNotFound, "could not retrieve channel capability at: %s", capName)
 	}
-	return k.channelKeeper.ChanCloseInit(ctx, types.PortID, channelID, chanCap)
+	return k.channelKeeper.ChanCloseInit(ctx, ccv.ProviderPortID, channelID, chanCap)
 }
 
 func (k Keeper) IncrementValidatorSetUpdateId(ctx sdk.Context) {

--- a/x/ccv/provider/keeper/keeper_test.go
+++ b/x/ccv/provider/keeper/keeper_test.go
@@ -26,7 +26,6 @@ import (
 	testkeeper "github.com/cosmos/interchain-security/testutil/keeper"
 	"github.com/cosmos/interchain-security/testutil/simapp"
 	consumertypes "github.com/cosmos/interchain-security/x/ccv/consumer/types"
-	providertypes "github.com/cosmos/interchain-security/x/ccv/provider/types"
 	"github.com/cosmos/interchain-security/x/ccv/types"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
 	utils "github.com/cosmos/interchain-security/x/ccv/utils"
@@ -109,7 +108,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.path.EndpointA.ClientConfig.(*ibctesting.TendermintConfig).TrustingPeriod = consumerUnbondingPeriod / utils.TrustingPeriodFraction
 	// - channel config
 	suite.path.EndpointA.ChannelConfig.PortID = consumertypes.PortID
-	suite.path.EndpointB.ChannelConfig.PortID = providertypes.PortID
+	suite.path.EndpointB.ChannelConfig.PortID = ccv.ProviderPortID
 	suite.path.EndpointA.ChannelConfig.Version = types.Version
 	suite.path.EndpointB.ChannelConfig.Version = types.Version
 	suite.path.EndpointA.ChannelConfig.Order = channeltypes.ORDERED

--- a/x/ccv/provider/keeper/keeper_test.go
+++ b/x/ccv/provider/keeper/keeper_test.go
@@ -25,8 +25,6 @@ import (
 	appProvider "github.com/cosmos/interchain-security/app/provider"
 	testkeeper "github.com/cosmos/interchain-security/testutil/keeper"
 	"github.com/cosmos/interchain-security/testutil/simapp"
-	consumertypes "github.com/cosmos/interchain-security/x/ccv/consumer/types"
-	"github.com/cosmos/interchain-security/x/ccv/types"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
 	utils "github.com/cosmos/interchain-security/x/ccv/utils"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -107,10 +105,10 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.path.EndpointA.ClientConfig.(*ibctesting.TendermintConfig).UnbondingPeriod = consumerUnbondingPeriod
 	suite.path.EndpointA.ClientConfig.(*ibctesting.TendermintConfig).TrustingPeriod = consumerUnbondingPeriod / utils.TrustingPeriodFraction
 	// - channel config
-	suite.path.EndpointA.ChannelConfig.PortID = consumertypes.PortID
+	suite.path.EndpointA.ChannelConfig.PortID = ccv.ConsumerPortID
 	suite.path.EndpointB.ChannelConfig.PortID = ccv.ProviderPortID
-	suite.path.EndpointA.ChannelConfig.Version = types.Version
-	suite.path.EndpointB.ChannelConfig.Version = types.Version
+	suite.path.EndpointA.ChannelConfig.Version = ccv.Version
+	suite.path.EndpointB.ChannelConfig.Version = ccv.Version
 	suite.path.EndpointA.ChannelConfig.Order = channeltypes.ORDERED
 	suite.path.EndpointB.ChannelConfig.Order = channeltypes.ORDERED
 

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -17,6 +17,8 @@ import (
 	abci "github.com/tendermint/tendermint/abci/types"
 
 	consumertypes "github.com/cosmos/interchain-security/x/ccv/consumer/types"
+
+	ccv "github.com/cosmos/interchain-security/x/ccv/types"
 )
 
 // CreateConsumerChainProposal will receive the consumer chain's client state from the proposal.
@@ -389,7 +391,7 @@ func (k Keeper) StopProposalsToExecute(ctx sdk.Context) []types.StopConsumerChai
 // CloseChannel closes the channel for the given channel ID on the condition
 // that the channel exists and isn't already in the CLOSED state
 func (k Keeper) CloseChannel(ctx sdk.Context, channelID string) {
-	channel, found := k.channelKeeper.GetChannel(ctx, types.PortID, channelID)
+	channel, found := k.channelKeeper.GetChannel(ctx, ccv.ProviderPortID, channelID)
 	if found && channel.State != channeltypes.CLOSED {
 		err := k.chanCloseInit(ctx, channelID)
 		if err != nil {

--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -145,8 +145,8 @@ func (k Keeper) SendValidatorUpdates(ctx sdk.Context) {
 					ctx,
 					k.scopedKeeper,
 					k.channelKeeper,
-					channelID,    // source channel id
-					types.PortID, // source port id
+					channelID,          // source channel id
+					ccv.ProviderPortID, // source port id
 					packetData.GetBytes(),
 				)
 				if err != nil {
@@ -172,8 +172,8 @@ func (k Keeper) SendPendingVSCPackets(ctx sdk.Context, chainID, channelID string
 			ctx,
 			k.scopedKeeper,
 			k.channelKeeper,
-			channelID,    // source channel id
-			types.PortID, // source port id
+			channelID,          // source channel id
+			ccv.ProviderPortID, // source port id
 			data.GetBytes(),
 		)
 		if err != nil {

--- a/x/ccv/provider/stop_consumer_test.go
+++ b/x/ccv/provider/stop_consumer_test.go
@@ -285,10 +285,10 @@ func (s *ProviderTestSuite) SendEmptyVSCPacket() {
 	)
 
 	seq, ok := s.providerChain.App.(*appProvider.App).GetIBCKeeper().ChannelKeeper.GetNextSequenceSend(
-		s.providerChain.GetContext(), providertypes.PortID, s.path.EndpointB.ChannelID)
+		s.providerChain.GetContext(), ccv.ProviderPortID, s.path.EndpointB.ChannelID)
 	s.Require().True(ok)
 
-	packet := channeltypes.NewPacket(pd.GetBytes(), seq, providertypes.PortID, s.path.EndpointB.ChannelID,
+	packet := channeltypes.NewPacket(pd.GetBytes(), seq, ccv.ProviderPortID, s.path.EndpointB.ChannelID,
 		consumertypes.PortID, s.path.EndpointA.ChannelID, clienttypes.Height{}, timeout)
 
 	err := s.path.EndpointB.SendPacket(packet)

--- a/x/ccv/provider/stop_consumer_test.go
+++ b/x/ccv/provider/stop_consumer_test.go
@@ -8,7 +8,6 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 	channeltypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	appProvider "github.com/cosmos/interchain-security/app/provider"
-	consumertypes "github.com/cosmos/interchain-security/x/ccv/consumer/types"
 	providertypes "github.com/cosmos/interchain-security/x/ccv/provider/types"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -289,7 +288,7 @@ func (s *ProviderTestSuite) SendEmptyVSCPacket() {
 	s.Require().True(ok)
 
 	packet := channeltypes.NewPacket(pd.GetBytes(), seq, ccv.ProviderPortID, s.path.EndpointB.ChannelID,
-		consumertypes.PortID, s.path.EndpointA.ChannelID, clienttypes.Height{}, timeout)
+		ccv.ConsumerPortID, s.path.EndpointA.ChannelID, clienttypes.Height{}, timeout)
 
 	err := s.path.EndpointB.SendPacket(packet)
 	s.Require().NoError(err)

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -17,9 +17,6 @@ const (
 	// ModuleName defines the CCV provider module name
 	ModuleName = "provider"
 
-	// PortID is the default port id that transfer module binds to
-	PortID = "provider"
-
 	// StoreKey is the store key string for IBC transfer
 	StoreKey = ModuleName
 

--- a/x/ccv/provider/unbonding_test.go
+++ b/x/ccv/provider/unbonding_test.go
@@ -7,7 +7,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	consumertypes "github.com/cosmos/interchain-security/x/ccv/consumer/types"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
 	"github.com/cosmos/interchain-security/x/ccv/utils"
 
@@ -49,7 +48,7 @@ func (s *ProviderTestSuite) TestUndelegationProviderFirst() {
 	incrementTimeByUnbondingPeriod(s, Consumer)
 
 	// relay 1 VSCMatured packet from consumer to provider
-	relayAllCommittedPackets(s, s.consumerChain, s.path, consumertypes.PortID, s.path.EndpointA.ChannelID, 1)
+	relayAllCommittedPackets(s, s.consumerChain, s.path, ccv.ConsumerPortID, s.path.EndpointA.ChannelID, 1)
 
 	// check that the unbonding operation completed
 	// - check that ccv unbonding op has been deleted
@@ -84,7 +83,7 @@ func (s *ProviderTestSuite) TestUndelegationConsumerFirst() {
 	incrementTimeByUnbondingPeriod(s, Consumer)
 
 	// relay 1 VSCMatured packet from consumer to provider
-	relayAllCommittedPackets(s, s.consumerChain, s.path, consumertypes.PortID, s.path.EndpointA.ChannelID, 1)
+	relayAllCommittedPackets(s, s.consumerChain, s.path, ccv.ConsumerPortID, s.path.EndpointA.ChannelID, 1)
 
 	// check that the unbonding is not complete
 	s.Require().True(getBalance(s, s.providerCtx(), delAddr).Equal(initBalance.Sub(bondAmt)))
@@ -128,7 +127,7 @@ func (s *ProviderTestSuite) TestUndelegationNoValsetChange() {
 	incrementTimeByUnbondingPeriod(s, Consumer)
 
 	// relay 1 VSCMatured packet from consumer to provider
-	relayAllCommittedPackets(s, s.consumerChain, s.path, consumertypes.PortID, s.path.EndpointA.ChannelID, 1)
+	relayAllCommittedPackets(s, s.consumerChain, s.path, ccv.ConsumerPortID, s.path.EndpointA.ChannelID, 1)
 
 	// increment time so that the unbonding period ends on the provider
 	incrementTimeByUnbondingPeriod(s, Provider)
@@ -191,7 +190,7 @@ func (s *ProviderTestSuite) TestUndelegationDuringInit() {
 	incrementTimeByUnbondingPeriod(s, Consumer)
 
 	// relay VSCMatured packets from consumer to provider
-	relayAllCommittedPackets(s, s.consumerChain, s.path, consumertypes.PortID, s.path.EndpointA.ChannelID, 2)
+	relayAllCommittedPackets(s, s.consumerChain, s.path, ccv.ConsumerPortID, s.path.EndpointA.ChannelID, 2)
 
 	// check that the unbonding operation completed
 	// - check that ccv unbonding op has been deleted

--- a/x/ccv/provider/unbonding_test.go
+++ b/x/ccv/provider/unbonding_test.go
@@ -8,7 +8,7 @@ import (
 	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	consumertypes "github.com/cosmos/interchain-security/x/ccv/consumer/types"
-	providertypes "github.com/cosmos/interchain-security/x/ccv/provider/types"
+	ccv "github.com/cosmos/interchain-security/x/ccv/types"
 	"github.com/cosmos/interchain-security/x/ccv/utils"
 
 	ibctesting "github.com/cosmos/ibc-go/v3/testing"
@@ -35,7 +35,7 @@ func (s *ProviderTestSuite) TestUndelegationProviderFirst() {
 	s.providerChain.NextBlock()
 
 	// relay 1 VSC packet from provider to consumer
-	relayAllCommittedPackets(s, s.providerChain, s.path, providertypes.PortID, s.path.EndpointB.ChannelID, 1)
+	relayAllCommittedPackets(s, s.providerChain, s.path, ccv.ProviderPortID, s.path.EndpointB.ChannelID, 1)
 
 	// increment time so that the unbonding period ends on the provider
 	incrementTimeByUnbondingPeriod(s, Provider)
@@ -78,7 +78,7 @@ func (s *ProviderTestSuite) TestUndelegationConsumerFirst() {
 	s.providerChain.NextBlock()
 
 	// relay 1 VSC packet from provider to consumer
-	relayAllCommittedPackets(s, s.providerChain, s.path, providertypes.PortID, s.path.EndpointB.ChannelID, 1)
+	relayAllCommittedPackets(s, s.providerChain, s.path, ccv.ProviderPortID, s.path.EndpointB.ChannelID, 1)
 
 	// increment time so that the unbonding period ends on the consumer
 	incrementTimeByUnbondingPeriod(s, Consumer)
@@ -119,7 +119,7 @@ func (s *ProviderTestSuite) TestUndelegationNoValsetChange() {
 	s.providerChain.NextBlock()
 
 	// relay 1 VSC packet from provider to consumer
-	relayAllCommittedPackets(s, s.providerChain, s.path, providertypes.PortID, s.path.EndpointB.ChannelID, 1)
+	relayAllCommittedPackets(s, s.providerChain, s.path, ccv.ProviderPortID, s.path.EndpointB.ChannelID, 1)
 
 	// check that the unbonding is not complete
 	s.Require().True(getBalance(s, s.providerCtx(), delAddr).Equal(initBalance.Sub(bondAmt)))
@@ -185,7 +185,7 @@ func (s *ProviderTestSuite) TestUndelegationDuringInit() {
 	s.SetupCCVChannel()
 
 	// relay VSC packets from provider to consumer
-	relayAllCommittedPackets(s, s.providerChain, s.path, providertypes.PortID, s.path.EndpointB.ChannelID, 2)
+	relayAllCommittedPackets(s, s.providerChain, s.path, ccv.ProviderPortID, s.path.EndpointB.ChannelID, 2)
 
 	// increment time so that the unbonding period ends on the consumer
 	incrementTimeByUnbondingPeriod(s, Consumer)

--- a/x/ccv/types/keys.go
+++ b/x/ccv/types/keys.go
@@ -8,8 +8,11 @@ const (
 	// module supports
 	Version = "1"
 
-	// ProviderPortID is the default port id that provider CCV module binds to
+	// ProviderPortID is the default port id the provider CCV module binds to
 	ProviderPortID = "provider"
+
+	// ConsumerPortID is the default port id the consumer CCV module binds to
+	ConsumerPortID = "consumer"
 
 	RouterKey = ModuleName
 

--- a/x/ccv/types/keys.go
+++ b/x/ccv/types/keys.go
@@ -8,6 +8,9 @@ const (
 	// module supports
 	Version = "1"
 
+	// ProviderPortID is the default port id that provider CCV module binds to
+	ProviderPortID = "provider"
+
 	RouterKey = ModuleName
 
 	// StoreKey defines the primary module store key


### PR DESCRIPTION
Closes https://github.com/cosmos/interchain-security/issues/281

Before merging: 
- [x] add UTs for the channel opening handshake on the provider
- [x] improve coverage of `ConsumerTestSuite.TestOnChanOpenAck`, see https://github.com/cosmos/interchain-security/blob/eaa7f6e7ef98fa16b38e6213a194506dc9d50f26/x/ccv/consumer/module.go#L305