### PR TITLE
(small change): Naming of UnbondMaturePackets

### DIFF
--- a/e2e-tests/valset_update_test.go
+++ b/e2e-tests/valset_update_test.go
@@ -34,8 +34,8 @@ func (s *ProviderTestSuite) TestPacketRoundtrip() {
 	relayAllCommittedPackets(s, s.consumerChain, s.path, ccv.ConsumerPortID, s.path.EndpointA.ChannelID, 1)
 }
 
-// TestWriteVSCMaturedPackets tests the behavior of WriteVSCMaturedPackets and related state checks
-func (suite *ConsumerKeeperTestSuite) TestWriteVSCMaturedPackets() {
+// TestSendVSCMaturedPackets tests the behavior of SendVSCMaturedPackets and related state checks
+func (suite *ConsumerKeeperTestSuite) TestSendVSCMaturedPackets() {
 	// setup CCV channel
 	suite.SetupCCVChannel()
 
@@ -101,7 +101,7 @@ func (suite *ConsumerKeeperTestSuite) TestWriteVSCMaturedPackets() {
 	// increase time
 	incrementTimeBy(suite, unbondingPeriod-time.Hour)
 
-	err = suite.consumerChain.App.(*appConsumer.App).ConsumerKeeper.WriteVSCMaturedPackets(suite.consumerChain.GetContext())
+	err = suite.consumerChain.App.(*appConsumer.App).ConsumerKeeper.SendVSCMaturedPackets(suite.consumerChain.GetContext())
 	suite.Require().NoError(err)
 
 	// ensure first two packets are unbonded and VSCMatured packets are sent

--- a/e2e-tests/valset_update_test.go
+++ b/e2e-tests/valset_update_test.go
@@ -34,8 +34,8 @@ func (s *ProviderTestSuite) TestPacketRoundtrip() {
 	relayAllCommittedPackets(s, s.consumerChain, s.path, ccv.ConsumerPortID, s.path.EndpointA.ChannelID, 1)
 }
 
-// TestUnbondMaturePackets tests the behavior of UnbondMaturePackets and related state checks
-func (suite *ConsumerKeeperTestSuite) TestUnbondMaturePackets() {
+// TestWriteVSCMaturedPackets tests the behavior of WriteVSCMaturedPackets and related state checks
+func (suite *ConsumerKeeperTestSuite) TestWriteVSCMaturedPackets() {
 	// setup CCV channel
 	suite.SetupCCVChannel()
 
@@ -101,7 +101,7 @@ func (suite *ConsumerKeeperTestSuite) TestUnbondMaturePackets() {
 	// increase time
 	incrementTimeBy(suite, unbondingPeriod-time.Hour)
 
-	err = suite.consumerChain.App.(*appConsumer.App).ConsumerKeeper.UnbondMaturePackets(suite.consumerChain.GetContext())
+	err = suite.consumerChain.App.(*appConsumer.App).ConsumerKeeper.WriteVSCMaturedPackets(suite.consumerChain.GetContext())
 	suite.Require().NoError(err)
 
 	// ensure first two packets are unbonded and VSCMatured packets are sent

--- a/x/ccv/consumer/keeper/relay.go
+++ b/x/ccv/consumer/keeper/relay.go
@@ -71,13 +71,13 @@ func (k Keeper) OnRecvVSCPacket(ctx sdk.Context, packet channeltypes.Packet, new
 	return ack
 }
 
-// WriteVSCMaturedPackets will iterate over the persisted maturity times of previously
+// SendVSCMaturedPackets will iterate over the persisted maturity times of previously
 // received VSC packets in order, and write acknowledgements for all matured VSC packets.
 //
 // Note: Per spec, a VSC reaching maturity on a consumer chain means that all the unbonding
 // operations that resulted in validator updates included in that VSC have matured on
 // the consumer chain.
-func (k Keeper) WriteVSCMaturedPackets(ctx sdk.Context) error {
+func (k Keeper) SendVSCMaturedPackets(ctx sdk.Context) error {
 
 	// This method is a no-op if there is no established channel to the provider.
 	channelID, ok := k.GetProviderChannel(ctx)

--- a/x/ccv/consumer/keeper/relay.go
+++ b/x/ccv/consumer/keeper/relay.go
@@ -18,6 +18,9 @@ import (
 // OnRecvVSCPacket sets the pending validator set changes that will be flushed to ABCI on Endblock
 // and set the maturity time for the packet. Once the maturity time elapses, a VSCMatured packet is
 // sent back to the provider chain.
+//
+// Note: CCV uses an ordered IBC channel, meaning VSC packet changes will be accumulated (and later
+// processed by ApplyCCValidatorChanges) s.t. more recent val power changes overwrite older ones.
 func (k Keeper) OnRecvVSCPacket(ctx sdk.Context, packet channeltypes.Packet, newChanges ccv.ValidatorSetChangePacketData) exported.Acknowledgement {
 	// get the provider channel
 	providerChannel, found := k.GetProviderChannel(ctx)
@@ -71,7 +74,7 @@ func (k Keeper) OnRecvVSCPacket(ctx sdk.Context, packet channeltypes.Packet, new
 // WriteVSCMaturedPackets will iterate over the persisted maturity times of previously
 // received VSC packets in order, and write acknowledgements for all matured VSC packets.
 //
-// Per spec, a VSC reaching maturity on a consumer chain means that all the unbonding
+// Note: Per spec, a VSC reaching maturity on a consumer chain means that all the unbonding
 // operations that resulted in validator updates included in that VSC have matured on
 // the consumer chain.
 func (k Keeper) WriteVSCMaturedPackets(ctx sdk.Context) error {

--- a/x/ccv/consumer/keeper/relay.go
+++ b/x/ccv/consumer/keeper/relay.go
@@ -68,9 +68,13 @@ func (k Keeper) OnRecvVSCPacket(ctx sdk.Context, packet channeltypes.Packet, new
 	return ack
 }
 
-// UnbondMaturePackets will iterate over the unbonding packets in order and write acknowledgements for all
-// packets that have finished unbonding.
-func (k Keeper) UnbondMaturePackets(ctx sdk.Context) error {
+// WriteVSCMaturedPackets will iterate over the persisted maturity times of previously
+// received VSC packets in order, and write acknowledgements for all matured VSC packets.
+//
+// Per spec, a VSC reaching maturity on a consumer chain means that all the unbonding
+// operations that resulted in validator updates included in that VSC have matured on
+// the consumer chain.
+func (k Keeper) WriteVSCMaturedPackets(ctx sdk.Context) error {
 
 	// This method is a no-op if there is no established channel to the provider.
 	channelID, ok := k.GetProviderChannel(ctx)

--- a/x/ccv/consumer/module.go
+++ b/x/ccv/consumer/module.go
@@ -174,7 +174,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.V
 		panic(err)
 	}
 
-	err = am.keeper.WriteVSCMaturedPackets(ctx)
+	err = am.keeper.SendVSCMaturedPackets(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/x/ccv/consumer/module.go
+++ b/x/ccv/consumer/module.go
@@ -174,7 +174,7 @@ func (am AppModule) EndBlock(ctx sdk.Context, req abci.RequestEndBlock) []abci.V
 		panic(err)
 	}
 
-	err = am.keeper.UnbondMaturePackets(ctx)
+	err = am.keeper.WriteVSCMaturedPackets(ctx)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The naming of ```UnbondMaturePackets``` did not make sense to me. This PR changes the name to help quick readers