### PR TITLE
reduce usage of magic numbers and replace with constants

### DIFF
--- a/x/ccv/consumer/types/params.go
+++ b/x/ccv/consumer/types/params.go
@@ -6,6 +6,9 @@ import (
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
+// about 2 hr at 7.6 seconds per blocks
+const DefaultBlocksPerDistributionTransmission = 1000
+
 var (
 	KeyEnabled                           = []byte("Enabled")
 	KeyBlocksPerDistributionTransmission = []byte("BlocksPerDistributionTransmission")
@@ -33,7 +36,7 @@ func NewParams(enabled bool, blocksPerDistributionTransmission int64,
 func DefaultParams() Params {
 	return NewParams(
 		false,
-		1000, // about 2 hr at 7.6 seconds per blocks
+		DefaultBlocksPerDistributionTransmission,
 		"",
 		"",
 	)

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -88,6 +88,11 @@ const (
 	LockUnbondingOnTimeoutBytePrefix
 )
 
+const (
+	// UnbondingOpIndexKey should be of set length: prefix + hashed chain ID + uint64
+	UnbondingOpIndexKeySize = 1 + 32 + 8
+)
+
 // PortKey returns the key to the port ID in the store
 func PortKey() []byte {
 	return []byte{PortByteKey}
@@ -199,12 +204,12 @@ func UnbondingOpIndexKey(chainID string, valsetUpdateID uint64) []byte {
 }
 
 // ParseUnbondingOpIndexKey parses an unbonding op index key for VSC ID
+// Removes the prefix + chainID from index key and returns only the key part.
 func ParseUnbondingOpIndexKey(key []byte) (vscID []byte, err error) {
-	// This key should be of set length: prefix + hashed chain ID + uint64
-	expectedBytes := 1 + 32 + 8
-	if len(key) != expectedBytes {
+	if len(key) != UnbondingOpIndexKeySize {
 		return nil, sdkerrors.Wrapf(
-			sdkerrors.ErrLogic, "key provided is incorrect: the key has incorrect length, expected %d, got %d", expectedBytes, len(key),
+			sdkerrors.ErrLogic, "key provided is incorrect: the key has incorrect length, expected %d, got %d",
+			UnbondingOpIndexKeySize, len(key),
 		)
 	}
 	return key[1+32:], nil

--- a/x/ccv/provider/types/params.go
+++ b/x/ccv/provider/types/params.go
@@ -10,6 +10,18 @@ import (
 	ibctmtypes "github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types"
 )
 
+const (
+	// DefaultTrustingPeriod is duration of the period since
+	// the LastestTimestamp during which the submitted headers are valid for upgrade
+	DefaultTrustingPeriod = 3 * 7 * 24 * time.Hour
+
+	// DefaultUnbondingPeriod of the staking unbonding period
+	DefaultUnbondingPeriod = 4 * 7 * 24 * time.Hour
+
+	// DefaultMaxClockDrift defines how much new (untrusted) header's Time can drift into the future.
+	DefaultMaxClockDrift = 10 * time.Second
+)
+
 var (
 	KeyTemplateClient = []byte("TemplateClient")
 )
@@ -32,7 +44,7 @@ func DefaultParams() Params {
 	// these fields will be populated during proposal handler.
 	return NewParams(
 		ibctmtypes.NewClientState("", ibctmtypes.DefaultTrustLevel, 0, 0,
-			time.Second*10, clienttypes.Height{}, commitmenttypes.GetSDKSpecs(), []string{"upgrade", "upgradedIBCState"}, true, true),
+			DefaultMaxClockDrift, clienttypes.Height{}, commitmenttypes.GetSDKSpecs(), []string{"upgrade", "upgradedIBCState"}, true, true),
 	)
 }
 
@@ -62,8 +74,8 @@ func validateTemplateClient(i interface{}) error {
 
 	// populate zeroed fields with valid fields
 	copiedClient.ChainId = "chainid"
-	copiedClient.TrustingPeriod = 3 * 7 * 24 * time.Hour
-	copiedClient.UnbondingPeriod = 4 * 7 * 24 * time.Hour
+	copiedClient.TrustingPeriod = DefaultTrustingPeriod
+	copiedClient.UnbondingPeriod = DefaultUnbondingPeriod
 	copiedClient.LatestHeight = clienttypes.NewHeight(0, 1)
 
 	if err := copiedClient.Validate(); err != nil {


### PR DESCRIPTION
This PR addresses isue #280.

Usage of magic numbers is reduced and replaced with defined constants.
Magic numbers remain in tests and testutils.

`golangci-lint` was used to discover the magic numbers.

Linter configuration can be found [here](https://gist.github.com/MSalopek/191fc6e493286aab33448506d2fecebe).

Comprehensive configuration options can be found [here](https://github.com/golangci/golangci-lint/blob/master/.golangci.reference.yml)

It might be beneficial to setup `golangci-lint` to run as precommit hook in the future.