### PR TITLE
allow selecting test granularity using make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,25 @@ install: go.sum
 		go install $(BUILD_FLAGS) ./cmd/interchain-security-pd
 		go install $(BUILD_FLAGS) ./cmd/interchain-security-cd
 
+# run all tests: unit, e2e and diff
 test: 
 	go test ./...
+
+# run e2e and unit tests
+test-short:
+	go test ./tests/e2e/... ./x/... ./app/...
+
+# run difference tests
+test-diff:
+	go test ./tests/difference/...
+
+# run integration tests
+test-integration:
+	go run ./tests/integration/...
+
+# run all tests with caching disabled
+test-no-cache:
+	go test ./... -count=1
 
 BUILD_TARGETS := build
 

--- a/README.md
+++ b/README.md
@@ -64,12 +64,27 @@ Similar to e2e tests, but they compare the system state to an expected state gen
 [Integration tests](./tests/integration/) run true consumer and provider chain binaries within a docker container and are relevant to the highest level of functionality. Integration tests use queries/transactions invoked from CLI to drive and validate the code.
 
 ### Running Tests
+Tests can be run using `make`:
 
 ```bash
-# run all static analysis, unit, e2e, and integration tests using make
-TODO
-# run all unit and e2e tests using make
+# run all static analysis, unit, e2e, and integration tests
 make test
+
+# run unit and e2e tests - prefer this for local development
+make test-short
+
+# run difference tests
+make test-diff
+
+# run integration tests
+make test-integration
+
+# equivalent to make test with caching disabled
+make test-no-cache
+```
+
+Alternatively you can run tests using `go test`:
+```bash
 # run all unit and e2e tests using go
 go test ./...
 # run all unit and e2e tests with verbose output

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Similar to e2e tests, but they compare the system state to an expected state gen
 Tests can be run using `make`:
 
 ```bash
-# run all static analysis, unit, e2e, and integration tests
+# run unit, e2e, and integration tests
 make test
 
 # run unit and e2e tests - prefer this for local development


### PR DESCRIPTION
Adds new commands to makefile:
* make test-short (unit, e2e)
* make test-diff (difference tests only)
* make test-integration (integration tests only)
* make test-no-cache (equivalent to make test with caching disabled)

Closes: #345