### PR TITLE
update buf googleapis dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ $(BUILDDIR)/:
 ###                                Protobuf                                 ###
 ###############################################################################
 
-containerProtoVer=v0.7
-containerProtoImage=tendermintdev/sdk-proto-gen:$(containerProtoVer)
+containerProtoVer=0.9.0
+containerProtoImage=ghcr.io/cosmos/proto-builder:$(containerProtoVer)
 containerProtoGen=cosmos-sdk-proto-gen-$(containerProtoVer)
 containerProtoGenSwagger=cosmos-sdk-proto-gen-swagger-$(containerProtoVer)
 containerProtoFmt=cosmos-sdk-proto-fmt-$(containerProtoVer)

--- a/go.sum
+++ b/go.sum
@@ -232,8 +232,6 @@ github.com/cosmos/btcutil v1.0.4/go.mod h1:Ffqc8Hn6TJUdDgHBwIZLtrLQC1KdJ9jGJl/Tv
 github.com/cosmos/cosmos-sdk v0.44.2/go.mod h1:fwQJdw+aECatpTvQTo1tSfHEsxACdZYU80QCZUPnHr4=
 github.com/cosmos/cosmos-sdk v0.44.3/go.mod h1:bA3+VenaR/l/vDiYzaiwbWvRPWHMBX2jG0ygiFtiBp0=
 github.com/cosmos/cosmos-sdk v0.45.0/go.mod h1:XXS/asyCqWNWkx2rW6pSuen+EVcpAFxq6khrhnZgHaQ=
-github.com/cosmos/cosmos-sdk v0.45.2-0.20220811130336-846d0158765e h1:aKKTrqI9mNCQpLkul4S6BHdWYrdNrFNhiHfy2Oh2yhM=
-github.com/cosmos/cosmos-sdk v0.45.2-0.20220811130336-846d0158765e/go.mod h1:XXS/asyCqWNWkx2rW6pSuen+EVcpAFxq6khrhnZgHaQ=
 github.com/cosmos/cosmos-sdk v0.45.2-0.20220901181011-06d4a64bf808 h1:PW5p0/qt5iJZS7f4bDjo/OYhMhzlmCewh8PZrpBluxo=
 github.com/cosmos/cosmos-sdk v0.45.2-0.20220901181011-06d4a64bf808/go.mod h1:XXS/asyCqWNWkx2rW6pSuen+EVcpAFxq6khrhnZgHaQ=
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=

--- a/proto/buf.lock
+++ b/proto/buf.lock
@@ -4,14 +4,8 @@ deps:
   - remote: buf.build
     owner: cosmos
     repository: gogo-proto
-    branch: main
     commit: bee5511075b7499da6178d9e4aaa628b
-    digest: b1-rrBIustouD-S80cVoZ_rM0qJsmei9AgbXy9GPQu6vxg=
-    create_time: 2021-12-02T20:01:17.069307Z
   - remote: buf.build
     owner: googleapis
     repository: googleapis
-    branch: main
-    commit: 40f07f5b563941f2b20b991a7aedd53d
-    digest: b1-Iv8fTR4AKXwNW80Ey6K5tY8cP053y_95sB5fro9IWZo=
-    create_time: 2021-12-02T15:07:41.896892Z
+    commit: 62f35d8aed1149c291d606d958a7ce32

--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -19,4 +19,4 @@ cd ..
 cp -r github.com/cosmos/interchain-security/* ./
 rm -rf github.com
 
-go mod tidy -compat=1.17
+go mod tidy -compat=1.18

--- a/third_party/proto/cosmos/staking/v1beta1/staking.proto
+++ b/third_party/proto/cosmos/staking/v1beta1/staking.proto
@@ -9,6 +9,7 @@ import "google/protobuf/timestamp.proto";
 import "cosmos_proto/cosmos.proto";
 import "cosmos/base/v1beta1/coin.proto";
 import "tendermint/types/types.proto";
+import "tendermint/abci/types.proto";
 
 option go_package = "github.com/cosmos/cosmos-sdk/x/staking/types";
 
@@ -118,8 +119,11 @@ message Validator {
     (gogoproto.nullable)   = false
   ];
 
-  // True if this validator's unbonding has been stopped by an external module
-  bool unbonding_on_hold = 12;
+  // strictly positive if this validator's unbonding has been stopped by external modules
+  int64 unbonding_on_hold_ref_count = 12;
+
+  // list of unbonding ids, each uniquely identifing an unbonding of this validator
+  repeated uint64 unbonding_ids = 13;
 }
 
 // BondStatus is the status of a validator.
@@ -233,8 +237,8 @@ message UnbondingDelegationEntry {
   // Incrementing id that uniquely identifies this entry
   uint64 unbonding_id = 5;
 
-  // True if this entry's unbonding has been stopped by an external module
-  bool unbonding_on_hold = 6;
+  // Strictly positive if this entry's unbonding has been stopped by external modules
+  int64 unbonding_on_hold_ref_count = 6;
 }
 
 // RedelegationEntry defines a redelegation object with relevant metadata.
@@ -260,8 +264,8 @@ message RedelegationEntry {
   // Incrementing id that uniquely identifies this entry
   uint64 unbonding_id = 5;
 
-  // True if this entry's unbonding has been stopped by an external module
-  bool unbonding_on_hold = 6;
+  // Strictly positive if this entry's unbonding has been stopped by external modules
+  int64 unbonding_on_hold_ref_count = 6;
 }
 
 // Redelegation contains the list of a particular delegator's redelegating bonds
@@ -358,4 +362,9 @@ enum InfractionType {
   INFRACTION_TYPE_DOUBLE_SIGN = 1 [(gogoproto.enumvalue_customname) = "DoubleSign"];
   // DOWNTIME defines a validator that missed signing too many blocks.
   INFRACTION_TYPE_DOWNTIME = 2 [(gogoproto.enumvalue_customname) = "Downtime"];
+}
+
+// ValidatorUpdates defines an array of abci.ValidatorUpdate objects.
+message ValidatorUpdates {
+  repeated tendermint.abci.ValidatorUpdate updates = 1 [(gogoproto.nullable) = false];
 }


### PR DESCRIPTION
An issue manifested because buf dependencies were out of date.

Running `make proto-gen` would fail with err citing that googleapis depedency cannot be found.

Updated buf dependencies using
buf mod update --only buf.build/googleapis/googleapis

Changed tidy to be compatible to 1.18 only

Closes: #347