### PR TITLE
Proposal naming refactors

### DIFF
--- a/docs/interchain-security/proto-docs.md
+++ b/docs/interchain-security/proto-docs.md
@@ -22,7 +22,7 @@
     - [UnbondingSequence](#interchain_security.ccv.consumer.v1.UnbondingSequence)
   
 - [interchain_security/ccv/provider/v1/provider.proto](#interchain_security/ccv/provider/v1/provider.proto)
-    - [CreateConsumerChainProposal](#interchain_security.ccv.provider.v1.CreateConsumerChainProposal)
+    - [ConsumerAdditionProposal](#interchain_security.ccv.provider.v1.ConsumerAdditionProposal)
     - [HandshakeMetadata](#interchain_security.ccv.provider.v1.HandshakeMetadata)
     - [Params](#interchain_security.ccv.provider.v1.Params)
   
@@ -278,10 +278,10 @@ UnbondingSequence defines the genesis information for each unbonding packet sequ
 
 
 
-<a name="interchain_security.ccv.provider.v1.CreateConsumerChainProposal"></a>
+<a name="interchain_security.ccv.provider.v1.ConsumerAdditionProposal"></a>
 
-### CreateConsumerChainProposal
-CreateConsumerChainProposal is a governance proposal on the provider chain to spawn a new consumer chain.
+### ConsumerAdditionProposal
+ConsumerAdditionProposal is a governance proposal on the provider chain to spawn a new consumer chain.
 If it passes, then all validators on the provider chain are expected to validate the consumer chain at spawn time
 or get slashed. It is recommended that spawn time occurs after the proposal end time.
 

--- a/docs/quality_assurance.md
+++ b/docs/quality_assurance.md
@@ -85,7 +85,7 @@ The main concern addressed in this section is the correctness of the provider ch
 | 4.10 | The provider chain's correctness is not affected by a consumer chain shutting down | `Scheduled` | `Future work` | `Future work` | `Scheduled` | `NA` |
 | 4.11 | The provider chain can graciously handle a CCV packet timing out (without shuting down) <br /> - expected outcome: consumer chain shuts down and its state in provider CCV module is removed | `Scheduled` | `Future work` | `Future work` | `Scheduled` | `NA` |
 | 4.12 | The provider chain can graciously handle a `StopConsumerChainProposal` <br /> - expected outcome: consumer chain shuts down and its state in provider CCV module is removed | `Scheduled` | `Done` <br /> see [stop_consumer_test.go](../x/ccv/provider/stop_consumer_test.go) | `Future work` | `Scheduled` | `NA` |
-| 4.13 | The provider chain can graciously handle a `SpawnConsumerChainProposal` <br /> - expected outcome: a consumer chain is registered and a client is created | `Scheduled` |`Done` <br /> see [TestCreateConsumerChainProposal](../x/ccv/provider/keeper/proposal_test.go#L44) | `Future work` | `Scheduled` | `NA` |
+| 4.13 | The provider chain can graciously handle a `SpawnConsumerChainProposal` <br /> - expected outcome: a consumer chain is registered and a client is created | `Scheduled` |`Done` <br /> see [TestConsumerAdditionProposal](../x/ccv/provider/keeper/proposal_test.go#L44) | `Future work` | `Scheduled` | `NA` |
 
 ### Interchain Security Protocol Correctness
 

--- a/docs/quality_assurance.md
+++ b/docs/quality_assurance.md
@@ -84,7 +84,7 @@ The main concern addressed in this section is the correctness of the provider ch
 | 4.09 | The provider chain can easily be restarted with IS enabled <br /> - `ExportGenesis` & `InitGenesis` | `Scheduled` | `Future work` | `Future work` | `Scheduled` | `NA` |
 | 4.10 | The provider chain's correctness is not affected by a consumer chain shutting down | `Scheduled` | `Future work` | `Future work` | `Scheduled` | `NA` |
 | 4.11 | The provider chain can graciously handle a CCV packet timing out (without shuting down) <br /> - expected outcome: consumer chain shuts down and its state in provider CCV module is removed | `Scheduled` | `Future work` | `Future work` | `Scheduled` | `NA` |
-| 4.12 | The provider chain can graciously handle a `StopConsumerChainProposal` <br /> - expected outcome: consumer chain shuts down and its state in provider CCV module is removed | `Scheduled` | `Done` <br /> see [stop_consumer_test.go](../x/ccv/provider/stop_consumer_test.go) | `Future work` | `Scheduled` | `NA` |
+| 4.12 | The provider chain can graciously handle a `ConsumerRemovalProposal` <br /> - expected outcome: consumer chain shuts down and its state in provider CCV module is removed | `Scheduled` | `Done` <br /> see [stop_consumer_test.go](../x/ccv/provider/stop_consumer_test.go) | `Future work` | `Scheduled` | `NA` |
 | 4.13 | The provider chain can graciously handle a `SpawnConsumerChainProposal` <br /> - expected outcome: a consumer chain is registered and a client is created | `Scheduled` |`Done` <br /> see [TestConsumerAdditionProposal](../x/ccv/provider/keeper/proposal_test.go#L44) | `Future work` | `Scheduled` | `NA` |
 
 ### Interchain Security Protocol Correctness
@@ -150,8 +150,8 @@ The main concern addressed in this section is the correctness of the consumer ch
 | -- | ------- | ----------- | ------------ | ------------- | ------- | ----- |
 | 10.01 | Consumer chain liveness (blocks are being produced) | `Scheduled` | `NA` | `??` | `Scheduled` | `NA` |
 | 10.02 | A chain has the ability to restart as a consumer chain with no more than 24 hours downtime | `Scheduled` | `NA` | `??` | `Scheduled` | `NA` |
-| 10.03 | A consumer chain has the ability to restart as a normal chain after shutting down, either controlled (via `StopConsumerChainProposal`) or due to timing out | `Scheduled` | `??` | `??` | `Scheduled` | `NA` |
-| 10.04 | A consumer chain has the ability to restart as a consumer chain with the same `chainId` after shutting down, either controlled (via `StopConsumerChainProposal`) or due to timing out | `Scheduled` | `??` | `??` | `Scheduled` | `NA` |
+| 10.03 | A consumer chain has the ability to restart as a normal chain after shutting down, either controlled (via `ConsumerRemovalProposal`) or due to timing out | `Scheduled` | `??` | `??` | `Scheduled` | `NA` |
+| 10.04 | A consumer chain has the ability to restart as a consumer chain with the same `chainId` after shutting down, either controlled (via `ConsumerRemovalProposal`) or due to timing out | `Scheduled` | `??` | `??` | `Scheduled` | `NA` |
 | 10.05 | Governance on `gov-cc` | `Scheduled` | `??` | `??` | `Scheduled` | `NA` |
 | 10.06 | CosmWasm on `wasm-cc` | `Scheduled` | `??` | `??` | `Scheduled` | `NA` |
 | TBA ...

--- a/proto/interchain_security/ccv/provider/v1/provider.proto
+++ b/proto/interchain_security/ccv/provider/v1/provider.proto
@@ -9,10 +9,10 @@ import "google/protobuf/timestamp.proto";
 import "ibc/core/client/v1/client.proto";
 import "ibc/lightclients/tendermint/v1/tendermint.proto";
 
-// CreateConsumerChainProposal is a governance proposal on the provider chain to spawn a new consumer chain.
+// ConsumerAdditionProposal is a governance proposal on the provider chain to spawn a new consumer chain.
 // If it passes, then all validators on the provider chain are expected to validate the consumer chain at spawn time
 // or get slashed. It is recommended that spawn time occurs after the proposal end time.
-message CreateConsumerChainProposal {
+message ConsumerAdditionProposal {
     option (gogoproto.goproto_getters)  = false;
     option (gogoproto.goproto_stringer) = false;
   

--- a/proto/interchain_security/ccv/provider/v1/provider.proto
+++ b/proto/interchain_security/ccv/provider/v1/provider.proto
@@ -40,10 +40,10 @@ message ConsumerAdditionProposal {
     bool lock_unbonding_on_timeout = 8;   
   }
  
-// StopConsumerProposal is a governance proposal on the provider chain to stop a consumer chain.
+// ConsumerRemovalProposal is a governance proposal on the provider chain to remove (and stop) a consumer chain.
 // If it passes, all the consumer chain's state is removed from the provider chain. The outstanding unbonding
 // operation funds are released if the LockUnbondingOnTimeout parameter is set to false for the consumer chain ID.
- message StopConsumerChainProposal {
+ message ConsumerRemovalProposal {
     // the title of the proposal
     string title = 1;
     // the description of the proposal

--- a/tests/e2e/channel_init_test.go
+++ b/tests/e2e/channel_init_test.go
@@ -714,7 +714,7 @@ func (suite *ProviderTestSuite) TestConsumerChainProposalHandler() {
 			}, true,
 		},
 		{
-			"valid stop consumer chain proposal", func(suite *ProviderTestSuite) {
+			"valid consumer removal proposal", func(suite *ProviderTestSuite) {
 				ctx = suite.providerChain.GetContext().WithBlockTime(time.Now().Add(time.Hour))
 				content, err = types.NewConsumerRemovalProposal("title", "description", "chainID", time.Now())
 				suite.Require().NoError(err)

--- a/tests/e2e/channel_init_test.go
+++ b/tests/e2e/channel_init_test.go
@@ -690,7 +690,7 @@ func (suite *ProviderTestSuite) TestOnChanOpenInit() {
 }
 
 // TestConsumerChainProposalHandler tests the handler for consumer chain proposals
-// for both ConsumerAdditionProposal and StopConsumerChainProposal
+// for both ConsumerAdditionProposal and ConsumerRemovalProposal
 //
 // TODO: Determine if it's possible to make this a unit test
 func (suite *ProviderTestSuite) TestConsumerChainProposalHandler() {
@@ -716,7 +716,7 @@ func (suite *ProviderTestSuite) TestConsumerChainProposalHandler() {
 		{
 			"valid stop consumer chain proposal", func(suite *ProviderTestSuite) {
 				ctx = suite.providerChain.GetContext().WithBlockTime(time.Now().Add(time.Hour))
-				content, err = types.NewStopConsumerChainProposal("title", "description", "chainID", time.Now())
+				content, err = types.NewConsumerRemovalProposal("title", "description", "chainID", time.Now())
 				suite.Require().NoError(err)
 			}, true,
 		},

--- a/tests/e2e/channel_init_test.go
+++ b/tests/e2e/channel_init_test.go
@@ -716,8 +716,7 @@ func (suite *ProviderTestSuite) TestConsumerChainProposalHandler() {
 		{
 			"valid consumer removal proposal", func(suite *ProviderTestSuite) {
 				ctx = suite.providerChain.GetContext().WithBlockTime(time.Now().Add(time.Hour))
-				content, err = types.NewConsumerRemovalProposal("title", "description", "chainID", time.Now())
-				suite.Require().NoError(err)
+				content = types.NewConsumerRemovalProposal("title", "description", "chainID", time.Now())
 			}, true,
 		},
 		{

--- a/tests/e2e/channel_init_test.go
+++ b/tests/e2e/channel_init_test.go
@@ -689,8 +689,8 @@ func (suite *ProviderTestSuite) TestOnChanOpenInit() {
 	suite.Require().Error(err, "OnChanOpenInit must error on provider chain")
 }
 
-// TestConsumerChainProposalHandler tests the handler for consumer chain proposals
-// for both ConsumerAdditionProposal and ConsumerRemovalProposal
+// TestConsumerChainProposalHandler tests the highest level handler
+// for both ConsumerAdditionProposals and ConsumerRemovalProposals
 //
 // TODO: Determine if it's possible to make this a unit test
 func (suite *ProviderTestSuite) TestConsumerChainProposalHandler() {

--- a/tests/e2e/stop_consumer_test.go
+++ b/tests/e2e/stop_consumer_test.go
@@ -111,7 +111,7 @@ func (s *ProviderTestSuite) TestConsumerRemovalProposal() {
 		stopReached bool
 	}{
 		{
-			"valid stop consumer chain proposal: stop time reached", func(suite *ProviderTestSuite) {
+			"valid consumer removal proposal: stop time reached", func(suite *ProviderTestSuite) {
 
 				// ctx blocktime is after proposal's stop time
 				ctx = s.providerCtx().WithBlockTime(time.Now().Add(time.Hour))
@@ -158,19 +158,19 @@ func (s *ProviderTestSuite) TestConsumerRemovalProposal() {
 
 			tc.malleate(s)
 
-			err := s.providerChain.App.(*appProvider.App).ProviderKeeper.ConsumerRemovalProposal(ctx, proposal)
+			err := s.providerChain.App.(*appProvider.App).ProviderKeeper.HandleConsumerRemovalProposal(ctx, proposal)
 			if tc.expPass {
 				s.Require().NoError(err, "error returned on valid case")
 				if tc.stopReached {
-					// check that the pending stop consumer chain proposal is deleted
-					found := s.providerChain.App.(*appProvider.App).ProviderKeeper.GetPendingStopProposal(ctx, chainID, proposal.StopTime)
-					s.Require().False(found, "pending stop consumer proposal wasn't deleted")
+					// check that the pending consumer removal proposal is deleted
+					found := s.providerChain.App.(*appProvider.App).ProviderKeeper.GetPendingConsumerRemovalProp(ctx, chainID, proposal.StopTime)
+					s.Require().False(found, "pending consumer removal proposal wasn't deleted")
 
 					// check that the consumer chain is removed
 					s.checkConsumerChainIsRemoved(chainID, false)
 
 				} else {
-					found := s.providerChain.App.(*appProvider.App).ProviderKeeper.GetPendingStopProposal(ctx, chainID, proposal.StopTime)
+					found := s.providerChain.App.(*appProvider.App).ProviderKeeper.GetPendingConsumerRemovalProp(ctx, chainID, proposal.StopTime)
 					s.Require().True(found, "pending stop consumer was not found for chain ID %s", chainID)
 
 					// check that the consumer chain client exists

--- a/tests/e2e/stop_consumer_test.go
+++ b/tests/e2e/stop_consumer_test.go
@@ -95,10 +95,10 @@ func (s *ProviderTestSuite) TestStopConsumerChain() {
 	s.checkConsumerChainIsRemoved(consumerChainID, false)
 }
 
-func (s *ProviderTestSuite) TestStopConsumerChainProposal() {
+func (s *ProviderTestSuite) TestConsumerRemovalProposal() {
 	var (
 		ctx      sdk.Context
-		proposal *providertypes.StopConsumerChainProposal
+		proposal *providertypes.ConsumerRemovalProposal
 		ok       bool
 	)
 
@@ -115,9 +115,9 @@ func (s *ProviderTestSuite) TestStopConsumerChainProposal() {
 
 				// ctx blocktime is after proposal's stop time
 				ctx = s.providerCtx().WithBlockTime(time.Now().Add(time.Hour))
-				content, err := providertypes.NewStopConsumerChainProposal("title", "description", chainID, time.Now())
+				content, err := providertypes.NewConsumerRemovalProposal("title", "description", chainID, time.Now())
 				s.Require().NoError(err)
-				proposal, ok = content.(*providertypes.StopConsumerChainProposal)
+				proposal, ok = content.(*providertypes.ConsumerRemovalProposal)
 				s.Require().True(ok)
 			}, true, true,
 		},
@@ -126,9 +126,9 @@ func (s *ProviderTestSuite) TestStopConsumerChainProposal() {
 
 				// ctx blocktime is before proposal's stop time
 				ctx = s.providerCtx().WithBlockTime(time.Now())
-				content, err := providertypes.NewStopConsumerChainProposal("title", "description", chainID, time.Now().Add(time.Hour))
+				content, err := providertypes.NewConsumerRemovalProposal("title", "description", chainID, time.Now().Add(time.Hour))
 				s.Require().NoError(err)
-				proposal, ok = content.(*providertypes.StopConsumerChainProposal)
+				proposal, ok = content.(*providertypes.ConsumerRemovalProposal)
 				s.Require().True(ok)
 			}, true, false,
 		},
@@ -141,9 +141,9 @@ func (s *ProviderTestSuite) TestStopConsumerChainProposal() {
 				// set invalid unbonding op index
 				s.providerChain.App.(*appProvider.App).ProviderKeeper.SetUnbondingOpIndex(ctx, chainID, 0, []uint64{0})
 
-				content, err := providertypes.NewStopConsumerChainProposal("title", "description", chainID, time.Now())
+				content, err := providertypes.NewConsumerRemovalProposal("title", "description", chainID, time.Now())
 				s.Require().NoError(err)
-				proposal, ok = content.(*providertypes.StopConsumerChainProposal)
+				proposal, ok = content.(*providertypes.ConsumerRemovalProposal)
 				s.Require().True(ok)
 			}, false, true,
 		},
@@ -158,7 +158,7 @@ func (s *ProviderTestSuite) TestStopConsumerChainProposal() {
 
 			tc.malleate(s)
 
-			err := s.providerChain.App.(*appProvider.App).ProviderKeeper.StopConsumerChainProposal(ctx, proposal)
+			err := s.providerChain.App.(*appProvider.App).ProviderKeeper.ConsumerRemovalProposal(ctx, proposal)
 			if tc.expPass {
 				s.Require().NoError(err, "error returned on valid case")
 				if tc.stopReached {

--- a/tests/e2e/stop_consumer_test.go
+++ b/tests/e2e/stop_consumer_test.go
@@ -115,8 +115,7 @@ func (s *ProviderTestSuite) TestConsumerRemovalProposal() {
 
 				// ctx blocktime is after proposal's stop time
 				ctx = s.providerCtx().WithBlockTime(time.Now().Add(time.Hour))
-				content, err := providertypes.NewConsumerRemovalProposal("title", "description", chainID, time.Now())
-				s.Require().NoError(err)
+				content := providertypes.NewConsumerRemovalProposal("title", "description", chainID, time.Now())
 				proposal, ok = content.(*providertypes.ConsumerRemovalProposal)
 				s.Require().True(ok)
 			}, true, true,
@@ -126,8 +125,7 @@ func (s *ProviderTestSuite) TestConsumerRemovalProposal() {
 
 				// ctx blocktime is before proposal's stop time
 				ctx = s.providerCtx().WithBlockTime(time.Now())
-				content, err := providertypes.NewConsumerRemovalProposal("title", "description", chainID, time.Now().Add(time.Hour))
-				s.Require().NoError(err)
+				content := providertypes.NewConsumerRemovalProposal("title", "description", chainID, time.Now().Add(time.Hour))
 				proposal, ok = content.(*providertypes.ConsumerRemovalProposal)
 				s.Require().True(ok)
 			}, true, false,
@@ -141,8 +139,7 @@ func (s *ProviderTestSuite) TestConsumerRemovalProposal() {
 				// set invalid unbonding op index
 				s.providerChain.App.(*appProvider.App).ProviderKeeper.SetUnbondingOpIndex(ctx, chainID, 0, []uint64{0})
 
-				content, err := providertypes.NewConsumerRemovalProposal("title", "description", chainID, time.Now())
-				s.Require().NoError(err)
+				content := providertypes.NewConsumerRemovalProposal("title", "description", chainID, time.Now())
 				proposal, ok = content.(*providertypes.ConsumerRemovalProposal)
 				s.Require().True(ok)
 			}, false, true,

--- a/tests/integration/actions.go
+++ b/tests/integration/actions.go
@@ -10,7 +10,8 @@ import (
 	"sync"
 	"time"
 
-	clienttypes "github.com/cosmos/ibc-go/modules/core/02-client/types"
+	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
+	"github.com/cosmos/interchain-security/x/ccv/provider/client"
 )
 
 type SendTokensAction struct {
@@ -191,25 +192,13 @@ type submitConsumerProposalAction struct {
 	initialHeight clienttypes.Height
 }
 
-// TODO: import this directly from the module once it is merged
-type createConsumerChainProposalJSON struct {
-	Title         string             `json:"title"`
-	Description   string             `json:"description"`
-	ChainId       string             `json:"chain_id"`
-	InitialHeight clienttypes.Height `json:"initial_height"`
-	GenesisHash   []byte             `json:"genesis_hash"`
-	BinaryHash    []byte             `json:"binary_hash"`
-	SpawnTime     time.Time          `json:"spawn_time"`
-	Deposit       string             `json:"deposit"`
-}
-
-func (tr TestRun) submitConsumerProposal(
+func (tr TestRun) submitConsumerAdditionProposal(
 	action submitConsumerProposalAction,
 	verbose bool,
 ) {
 	spawnTime := tr.containerConfig.now.Add(time.Duration(action.spawnTime) * time.Millisecond)
-	prop := createConsumerChainProposalJSON{
-		Title:         "Create a chain",
+	prop := client.ConsumerAdditionProposalJSON{
+		Title:         "Propose the addition of a new chain",
 		Description:   "Gonna be a great chain",
 		ChainId:       string(tr.chainConfigs[action.consumerChain].chainId),
 		InitialHeight: action.initialHeight,
@@ -240,7 +229,7 @@ func (tr TestRun) submitConsumerProposal(
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	bz, err = exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[action.chain].binaryName,
 
-		"tx", "gov", "submit-proposal", "create-consumer-chain",
+		"tx", "gov", "submit-proposal", "consumer-addition",
 		"/temp-proposal.json",
 
 		`--from`, `validator`+fmt.Sprint(action.from),

--- a/tests/integration/main.go
+++ b/tests/integration/main.go
@@ -37,7 +37,7 @@ func (tr TestRun) runStep(step Step, verbose bool) {
 	case submitTextProposalAction:
 		tr.submitTextProposal(action, verbose)
 	case submitConsumerProposalAction:
-		tr.submitConsumerProposal(action, verbose)
+		tr.submitConsumerAdditionProposal(action, verbose)
 	case voteGovProposalAction:
 		tr.voteGovProposal(action, verbose)
 	case startConsumerChainAction:

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	clienttypes "github.com/cosmos/ibc-go/modules/core/02-client/types"
+	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 	"github.com/tidwall/gjson"
 	"gopkg.in/yaml.v2"
 )

--- a/tests/integration/state.go
+++ b/tests/integration/state.go
@@ -200,7 +200,7 @@ func (tr TestRun) getProposal(chain chainID, proposal uint) Proposal {
 			Title:       title,
 			Description: description,
 		}
-	case "/interchain_security.ccv.provider.v1.CreateConsumerChainProposal":
+	case "/interchain_security.ccv.provider.v1.ConsumerAdditionProposal":
 		chainId := gjson.Get(string(bz), `content.chain_id`).String()
 		spawnTime := gjson.Get(string(bz), `content.spawn_time`).Time().Sub(tr.containerConfig.now)
 

--- a/tests/integration/steps.go
+++ b/tests/integration/steps.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	clienttypes "github.com/cosmos/ibc-go/modules/core/02-client/types"
+	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 )
 
 type Step struct {

--- a/x/ccv/provider/client/proposal_handler.go
+++ b/x/ccv/provider/client/proposal_handler.go
@@ -21,21 +21,21 @@ import (
 )
 
 // ProposalHandler is the param change proposal handler.
-var ProposalHandler = govclient.NewProposalHandler(NewConsumerAdditionProposalTxCmd, ProposalRESTHandler)
+var ProposalHandler = govclient.NewProposalHandler(SubmitConsumerAdditionPropTxCmd, ProposalRESTHandler)
 
-// NewConsumerAdditionProposalTxCmd returns a CLI command handler for creating
-// a new consumer chain proposal governance transaction.
-func NewConsumerAdditionProposalTxCmd() *cobra.Command {
+// SubmitConsumerAdditionPropTxCmd returns a CLI command handler for submitting
+// a consumer addition proposal via a transaction.
+func SubmitConsumerAdditionPropTxCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "create-consumer-chain [proposal-file]",
+		Use:   "consumer-addition [proposal-file]",
 		Args:  cobra.ExactArgs(1),
-		Short: "Submit a consumer chain creation proposal",
+		Short: "Submit a consumer addition proposal",
 		Long: `
-Submit a consumer chain creation proposal along with an initial deposit.
+Submit a consumer addition proposal along with an initial deposit.
 The proposal details must be supplied via a JSON file.
 
 Example:
-$ %s tx gov submit-proposal create-consumer-chain <path/to/proposal.json> --from=<key_or_address>
+$ %s tx gov submit-proposal consumer-addition <path/to/proposal.json> --from=<key_or_address>
 
 Where proposal.json contains:
 
@@ -129,7 +129,7 @@ func ParseConsumerAdditionProposalJSON(proposalFile string) (ConsumerAdditionPro
 // change REST handler with a given sub-route.
 func ProposalRESTHandler(clientCtx client.Context) govrest.ProposalRESTHandler {
 	return govrest.ProposalRESTHandler{
-		SubRoute: "create_consumer_chain",
+		SubRoute: "propose_consumer_addition",
 		Handler:  postProposalHandlerFn(clientCtx),
 	}
 }

--- a/x/ccv/provider/client/proposal_handler.go
+++ b/x/ccv/provider/client/proposal_handler.go
@@ -21,11 +21,11 @@ import (
 )
 
 // ProposalHandler is the param change proposal handler.
-var ProposalHandler = govclient.NewProposalHandler(NewCreateConsumerChainProposalTxCmd, ProposalRESTHandler)
+var ProposalHandler = govclient.NewProposalHandler(NewConsumerAdditionProposalTxCmd, ProposalRESTHandler)
 
-// NewCreateConsumerChainProposalTxCmd returns a CLI command handler for creating
+// NewConsumerAdditionProposalTxCmd returns a CLI command handler for creating
 // a new consumer chain proposal governance transaction.
-func NewCreateConsumerChainProposalTxCmd() *cobra.Command {
+func NewConsumerAdditionProposalTxCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "create-consumer-chain [proposal-file]",
 		Args:  cobra.ExactArgs(1),
@@ -59,12 +59,12 @@ Where proposal.json contains:
 				return err
 			}
 
-			proposal, err := ParseCreateConsumerChainProposalJSON(args[0])
+			proposal, err := ParseConsumerAdditionProposalJSON(args[0])
 			if err != nil {
 				return err
 			}
 
-			content := types.NewCreateConsumerChainProposal(
+			content := types.NewConsumerAdditionProposal(
 				proposal.Title, proposal.Description, proposal.ChainId, proposal.InitialHeight,
 				proposal.GenesisHash, proposal.BinaryHash, proposal.SpawnTime)
 
@@ -85,7 +85,7 @@ Where proposal.json contains:
 	}
 }
 
-type CreateConsumerChainProposalJSON struct {
+type ConsumerAdditionProposalJSON struct {
 	Title         string             `json:"title"`
 	Description   string             `json:"description"`
 	ChainId       string             `json:"chain_id"`
@@ -96,7 +96,7 @@ type CreateConsumerChainProposalJSON struct {
 	Deposit       string             `json:"deposit"`
 }
 
-type CreateConsumerChainProposalReq struct {
+type ConsumerAdditionProposalReq struct {
 	BaseReq  rest.BaseReq   `json:"base_req"`
 	Proposer sdk.AccAddress `json:"proposer"`
 
@@ -110,8 +110,8 @@ type CreateConsumerChainProposalReq struct {
 	Deposit       sdk.Coins          `json:"deposit"`
 }
 
-func ParseCreateConsumerChainProposalJSON(proposalFile string) (CreateConsumerChainProposalJSON, error) {
-	proposal := CreateConsumerChainProposalJSON{}
+func ParseConsumerAdditionProposalJSON(proposalFile string) (ConsumerAdditionProposalJSON, error) {
+	proposal := ConsumerAdditionProposalJSON{}
 
 	contents, err := ioutil.ReadFile(filepath.Clean(proposalFile))
 	if err != nil {
@@ -136,7 +136,7 @@ func ProposalRESTHandler(clientCtx client.Context) govrest.ProposalRESTHandler {
 
 func postProposalHandlerFn(clientCtx client.Context) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var req CreateConsumerChainProposalReq
+		var req ConsumerAdditionProposalReq
 		if !rest.ReadRESTReq(w, r, clientCtx.LegacyAmino, &req) {
 			return
 		}
@@ -146,7 +146,7 @@ func postProposalHandlerFn(clientCtx client.Context) http.HandlerFunc {
 			return
 		}
 
-		content := types.NewCreateConsumerChainProposal(
+		content := types.NewConsumerAdditionProposal(
 			req.Title, req.Description, req.ChainId, req.InitialHeight,
 			req.GenesisHash, req.BinaryHash, req.SpawnTime)
 

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -37,9 +37,9 @@ func (k Keeper) HandleConsumerAdditionProposal(ctx sdk.Context, p *types.Consume
 	return nil
 }
 
-// StopConsumerChainProposal stops a consumer chain and released the outstanding unbonding operations.
+// ConsumerRemovalProposal stops a consumer chain and released the outstanding unbonding operations.
 // If the stop time hasn't already passed, it stores the proposal as a pending proposal.
-func (k Keeper) StopConsumerChainProposal(ctx sdk.Context, p *types.StopConsumerChainProposal) error {
+func (k Keeper) ConsumerRemovalProposal(ctx sdk.Context, p *types.ConsumerRemovalProposal) error {
 
 	if !ctx.BlockTime().Before(p.StopTime) {
 		return k.StopConsumerChain(ctx, p.ChainId, false, true)
@@ -327,7 +327,7 @@ func (k Keeper) GetPendingStopProposal(ctx sdk.Context, chainID string, timestam
 }
 
 // DeletePendingStopProposals deletes the given stop proposals
-func (k Keeper) DeletePendingStopProposals(ctx sdk.Context, proposals ...types.StopConsumerChainProposal) {
+func (k Keeper) DeletePendingStopProposals(ctx sdk.Context, proposals ...types.ConsumerRemovalProposal) {
 	store := ctx.KVStore(k.storeKey)
 
 	for _, p := range proposals {
@@ -359,10 +359,10 @@ func (k Keeper) IteratePendingStopProposal(ctx sdk.Context) {
 // ie. consumer chains to stop. A prop is included in the returned list if its proposed stop time has passed.
 //
 // Note: this method is split out from IteratePendingCreateProposal to be easily unit tested.
-func (k Keeper) StopProposalsToExecute(ctx sdk.Context) []types.StopConsumerChainProposal {
+func (k Keeper) StopProposalsToExecute(ctx sdk.Context) []types.ConsumerRemovalProposal {
 
 	// store the (to be) executed stop proposals in order
-	propsToExecute := []types.StopConsumerChainProposal{}
+	propsToExecute := []types.ConsumerRemovalProposal{}
 
 	iterator := k.PendingStopProposalIterator(ctx)
 	defer iterator.Close()
@@ -381,7 +381,7 @@ func (k Keeper) StopProposalsToExecute(ctx sdk.Context) []types.StopConsumerChai
 
 		if !ctx.BlockTime().Before(stopTime) {
 			propsToExecute = append(propsToExecute,
-				types.StopConsumerChainProposal{ChainId: chainID, StopTime: stopTime})
+				types.ConsumerRemovalProposal{ChainId: chainID, StopTime: stopTime})
 		} else {
 			// No more proposals to check, since they're stored/ordered by timestamp.
 			break

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -228,14 +228,14 @@ func (k Keeper) SetPendingConsumerAdditionProp(ctx sdk.Context, clientInfo *type
 		return err
 	}
 
-	store.Set(types.PendingConsumerAdditionPropKey(clientInfo.SpawnTime, clientInfo.ChainId), bz)
+	store.Set(types.PendingCAPKey(clientInfo.SpawnTime, clientInfo.ChainId), bz)
 	return nil
 }
 
 // GetPendingConsumerAdditionProp retrieves a pending proposal to create a consumer chain client (by spawn time and chain id)
 func (k Keeper) GetPendingConsumerAdditionProp(ctx sdk.Context, spawnTime time.Time, chainID string) types.ConsumerAdditionProposal {
 	store := ctx.KVStore(k.storeKey)
-	bz := store.Get(types.PendingConsumerAdditionPropKey(spawnTime, chainID))
+	bz := store.Get(types.PendingCAPKey(spawnTime, chainID))
 	if len(bz) == 0 {
 		return types.ConsumerAdditionProposal{}
 	}
@@ -247,7 +247,7 @@ func (k Keeper) GetPendingConsumerAdditionProp(ctx sdk.Context, spawnTime time.T
 
 func (k Keeper) PendingConsumerAdditionPropIterator(ctx sdk.Context) sdk.Iterator {
 	store := ctx.KVStore(k.storeKey)
-	return sdk.KVStorePrefixIterator(store, []byte{types.PendingConsumerAdditionPropBytePrefix})
+	return sdk.KVStorePrefixIterator(store, []byte{types.PendingCAPBytePrefix})
 }
 
 // IteratePendingConsumerAdditionProps iterates over the pending consumer addition proposals to create
@@ -285,7 +285,7 @@ func (k Keeper) ConsumerAdditionPropsToExecute(ctx sdk.Context) []types.Consumer
 
 	for ; iterator.Valid(); iterator.Next() {
 		key := iterator.Key()
-		spawnTime, _, err := types.ParsePendingConsumerAdditionPropKey(key)
+		spawnTime, _, err := types.ParsePendingCAPKey(key)
 		if err != nil {
 			panic(fmt.Errorf("failed to parse pending client key: %w", err))
 		}
@@ -308,7 +308,7 @@ func (k Keeper) DeletePendingConsumerAdditionProps(ctx sdk.Context, proposals ..
 	store := ctx.KVStore(k.storeKey)
 
 	for _, p := range proposals {
-		store.Delete(types.PendingConsumerAdditionPropKey(p.SpawnTime, p.ChainId))
+		store.Delete(types.PendingCAPKey(p.SpawnTime, p.ChainId))
 	}
 }
 

--- a/x/ccv/provider/keeper/proposal_test.go
+++ b/x/ccv/provider/keeper/proposal_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cosmos/interchain-security/x/ccv/provider/types"
 )
 
-func TestPendingStopProposalDeletion(t *testing.T) {
+func TestPendingConsumerRemovalPropDeletion(t *testing.T) {
 
 	testCases := []struct {
 		types.ConsumerRemovalProposal
@@ -28,29 +28,29 @@ func TestPendingStopProposalDeletion(t *testing.T) {
 	providerKeeper, ctx := testkeeper.GetProviderKeeperAndCtx(t)
 
 	for _, tc := range testCases {
-		providerKeeper.SetPendingStopProposal(ctx, tc.ChainId, tc.StopTime)
+		providerKeeper.SetPendingConsumerRemovalProp(ctx, tc.ChainId, tc.StopTime)
 	}
 
 	ctx = ctx.WithBlockTime(time.Now().UTC())
 
-	propsToExecute := providerKeeper.StopProposalsToExecute(ctx)
-	// Delete stop proposals, same as what would be done by IteratePendingStopProposal
-	providerKeeper.DeletePendingStopProposals(ctx, propsToExecute...)
+	propsToExecute := providerKeeper.ConsumerRemovalPropsToExecute(ctx)
+	// Delete consumer removal proposals, same as what would be done by IteratePendingConsumerRemovalProps
+	providerKeeper.DeletePendingConsumerRemovalProps(ctx, propsToExecute...)
 	numDeleted := 0
 	for _, tc := range testCases {
-		res := providerKeeper.GetPendingStopProposal(ctx, tc.ChainId, tc.StopTime)
+		res := providerKeeper.GetPendingConsumerRemovalProp(ctx, tc.ChainId, tc.StopTime)
 		if !tc.ExpDeleted {
-			require.NotEmpty(t, res, "stop proposal was deleted: %s %s", tc.ChainId, tc.StopTime.String())
+			require.NotEmpty(t, res, "consumer removal prop was deleted: %s %s", tc.ChainId, tc.StopTime.String())
 			continue
 		}
-		require.Empty(t, res, "stop proposal was not deleted %s %s", tc.ChainId, tc.StopTime.String())
+		require.Empty(t, res, "consumer removal prop was not deleted %s %s", tc.ChainId, tc.StopTime.String())
 		require.Equal(t, propsToExecute[numDeleted].ChainId, tc.ChainId)
 		numDeleted += 1
 	}
 }
 
-// Tests that pending stop proposals are accessed in order by timestamp via the iterator
-func TestPendingStopProposalsOrder(t *testing.T) {
+// Tests that pending consumer removal proposals are accessed in order by timestamp via the iterator
+func TestPendingConsumerRemovalPropOrder(t *testing.T) {
 
 	now := time.Now().UTC()
 
@@ -100,14 +100,14 @@ func TestPendingStopProposalsOrder(t *testing.T) {
 		ctx = ctx.WithBlockTime(tc.accessTime)
 
 		for _, prop := range tc.propSubmitOrder {
-			providerKeeper.SetPendingStopProposal(ctx, prop.ChainId, prop.StopTime)
+			providerKeeper.SetPendingConsumerRemovalProp(ctx, prop.ChainId, prop.StopTime)
 		}
-		propsToExecute := providerKeeper.StopProposalsToExecute(ctx)
+		propsToExecute := providerKeeper.ConsumerRemovalPropsToExecute(ctx)
 		require.Equal(t, tc.expectedOrderedProps, propsToExecute)
 	}
 }
 
-func TestPendingCreateProposalsDeletion(t *testing.T) {
+func TestPendingConsumerAdditionPropDeletion(t *testing.T) {
 
 	testCases := []struct {
 		types.ConsumerAdditionProposal
@@ -138,17 +138,17 @@ func TestPendingCreateProposalsDeletion(t *testing.T) {
 	for _, tc := range testCases {
 		res := providerKeeper.GetPendingConsumerAdditionProp(ctx, tc.SpawnTime, tc.ChainId)
 		if !tc.ExpDeleted {
-			require.NotEmpty(t, res, "create proposal was deleted: %s %s", tc.ChainId, tc.SpawnTime.String())
+			require.NotEmpty(t, res, "consumer addition proposal was deleted: %s %s", tc.ChainId, tc.SpawnTime.String())
 			continue
 		}
-		require.Empty(t, res, "create proposal was not deleted %s %s", tc.ChainId, tc.SpawnTime.String())
+		require.Empty(t, res, "consumer addition proposal was not deleted %s %s", tc.ChainId, tc.SpawnTime.String())
 		require.Equal(t, propsToExecute[numDeleted].ChainId, tc.ChainId)
 		numDeleted += 1
 	}
 }
 
-// Tests that pending create proposals are accessed in order by timestamp via the iterator
-func TestPendingCreateProposalsOrder(t *testing.T) {
+// Tests that pending consumer addition proposals are accessed in order by timestamp via the iterator
+func TestPendingConsumerAdditionPropOrder(t *testing.T) {
 
 	now := time.Now().UTC()
 

--- a/x/ccv/provider/keeper/proposal_test.go
+++ b/x/ccv/provider/keeper/proposal_test.go
@@ -13,16 +13,16 @@ import (
 func TestPendingStopProposalDeletion(t *testing.T) {
 
 	testCases := []struct {
-		types.StopConsumerChainProposal
+		types.ConsumerRemovalProposal
 		ExpDeleted bool
 	}{
 		{
-			StopConsumerChainProposal: types.StopConsumerChainProposal{ChainId: "8", StopTime: time.Now().UTC()},
-			ExpDeleted:                true,
+			ConsumerRemovalProposal: types.ConsumerRemovalProposal{ChainId: "8", StopTime: time.Now().UTC()},
+			ExpDeleted:              true,
 		},
 		{
-			StopConsumerChainProposal: types.StopConsumerChainProposal{ChainId: "9", StopTime: time.Now().UTC().Add(time.Hour)},
-			ExpDeleted:                false,
+			ConsumerRemovalProposal: types.ConsumerRemovalProposal{ChainId: "9", StopTime: time.Now().UTC().Add(time.Hour)},
+			ExpDeleted:              false,
 		},
 	}
 	providerKeeper, ctx := testkeeper.GetProviderKeeperAndCtx(t)
@@ -55,41 +55,41 @@ func TestPendingStopProposalsOrder(t *testing.T) {
 	now := time.Now().UTC()
 
 	// props with unique chain ids and spawn times
-	sampleProp1 := types.StopConsumerChainProposal{ChainId: "1", StopTime: now}
-	sampleProp2 := types.StopConsumerChainProposal{ChainId: "2", StopTime: now.Add(1 * time.Hour)}
-	sampleProp3 := types.StopConsumerChainProposal{ChainId: "3", StopTime: now.Add(2 * time.Hour)}
-	sampleProp4 := types.StopConsumerChainProposal{ChainId: "4", StopTime: now.Add(3 * time.Hour)}
-	sampleProp5 := types.StopConsumerChainProposal{ChainId: "5", StopTime: now.Add(4 * time.Hour)}
+	sampleProp1 := types.ConsumerRemovalProposal{ChainId: "1", StopTime: now}
+	sampleProp2 := types.ConsumerRemovalProposal{ChainId: "2", StopTime: now.Add(1 * time.Hour)}
+	sampleProp3 := types.ConsumerRemovalProposal{ChainId: "3", StopTime: now.Add(2 * time.Hour)}
+	sampleProp4 := types.ConsumerRemovalProposal{ChainId: "4", StopTime: now.Add(3 * time.Hour)}
+	sampleProp5 := types.ConsumerRemovalProposal{ChainId: "5", StopTime: now.Add(4 * time.Hour)}
 
 	testCases := []struct {
-		propSubmitOrder      []types.StopConsumerChainProposal
+		propSubmitOrder      []types.ConsumerRemovalProposal
 		accessTime           time.Time
-		expectedOrderedProps []types.StopConsumerChainProposal
+		expectedOrderedProps []types.ConsumerRemovalProposal
 	}{
 		{
-			propSubmitOrder: []types.StopConsumerChainProposal{
+			propSubmitOrder: []types.ConsumerRemovalProposal{
 				sampleProp1, sampleProp2, sampleProp3, sampleProp4, sampleProp5,
 			},
 			accessTime: now.Add(30 * time.Minute),
-			expectedOrderedProps: []types.StopConsumerChainProposal{
+			expectedOrderedProps: []types.ConsumerRemovalProposal{
 				sampleProp1,
 			},
 		},
 		{
-			propSubmitOrder: []types.StopConsumerChainProposal{
+			propSubmitOrder: []types.ConsumerRemovalProposal{
 				sampleProp3, sampleProp2, sampleProp1, sampleProp5, sampleProp4,
 			},
 			accessTime: now.Add(3 * time.Hour).Add(30 * time.Minute),
-			expectedOrderedProps: []types.StopConsumerChainProposal{
+			expectedOrderedProps: []types.ConsumerRemovalProposal{
 				sampleProp1, sampleProp2, sampleProp3, sampleProp4,
 			},
 		},
 		{
-			propSubmitOrder: []types.StopConsumerChainProposal{
+			propSubmitOrder: []types.ConsumerRemovalProposal{
 				sampleProp5, sampleProp4, sampleProp3, sampleProp2, sampleProp1,
 			},
 			accessTime: now.Add(5 * time.Hour),
-			expectedOrderedProps: []types.StopConsumerChainProposal{
+			expectedOrderedProps: []types.ConsumerRemovalProposal{
 				sampleProp1, sampleProp2, sampleProp3, sampleProp4, sampleProp5,
 			},
 		},

--- a/x/ccv/provider/module.go
+++ b/x/ccv/provider/module.go
@@ -153,7 +153,7 @@ func (AppModule) ConsensusVersion() uint64 { return 1 }
 // BeginBlock implements the AppModule interface
 func (am AppModule) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {
 	// Check if there are any consumer chains that are due to be started
-	am.keeper.IteratePendingCreateProposal(ctx)
+	am.keeper.IteratePendingConsumerAdditionProps(ctx)
 	// Check if there are any consumer chains that are due to be stopped
 	am.keeper.IteratePendingStopProposal(ctx)
 }

--- a/x/ccv/provider/module.go
+++ b/x/ccv/provider/module.go
@@ -152,10 +152,10 @@ func (AppModule) ConsensusVersion() uint64 { return 1 }
 
 // BeginBlock implements the AppModule interface
 func (am AppModule) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {
-	// Check if there are any consumer chains that are due to be started
+	// Check if there are any consumer chains that are due to be spawned
 	am.keeper.IteratePendingConsumerAdditionProps(ctx)
 	// Check if there are any consumer chains that are due to be stopped
-	am.keeper.IteratePendingStopProposal(ctx)
+	am.keeper.IteratePendingConsumerRemovalProps(ctx)
 }
 
 // EndBlock implements the AppModule interface

--- a/x/ccv/provider/proposal_handler.go
+++ b/x/ccv/provider/proposal_handler.go
@@ -8,12 +8,12 @@ import (
 	"github.com/cosmos/interchain-security/x/ccv/provider/types"
 )
 
-// NewConsumerChainProposalHandler defines the CCV provider proposal handler
+// NewConsumerChainProposalHandler defines the handler for consumer addition and consumer removal proposals.
 func NewConsumerChainProposalHandler(k keeper.Keeper) govtypes.Handler {
 	return func(ctx sdk.Context, content govtypes.Content) error {
 		switch c := content.(type) {
-		case *types.CreateConsumerChainProposal:
-			return k.CreateConsumerChainProposal(ctx, c)
+		case *types.ConsumerAdditionProposal:
+			return k.HandleConsumerAdditionProposal(ctx, c)
 		case *types.StopConsumerChainProposal:
 			return k.StopConsumerChainProposal(ctx, c)
 		default:

--- a/x/ccv/provider/proposal_handler.go
+++ b/x/ccv/provider/proposal_handler.go
@@ -14,8 +14,8 @@ func NewConsumerChainProposalHandler(k keeper.Keeper) govtypes.Handler {
 		switch c := content.(type) {
 		case *types.ConsumerAdditionProposal:
 			return k.HandleConsumerAdditionProposal(ctx, c)
-		case *types.StopConsumerChainProposal:
-			return k.StopConsumerChainProposal(ctx, c)
+		case *types.ConsumerRemovalProposal:
+			return k.ConsumerRemovalProposal(ctx, c)
 		default:
 			return sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized ccv proposal content type: %T", c)
 		}

--- a/x/ccv/provider/proposal_handler.go
+++ b/x/ccv/provider/proposal_handler.go
@@ -15,7 +15,7 @@ func NewConsumerChainProposalHandler(k keeper.Keeper) govtypes.Handler {
 		case *types.ConsumerAdditionProposal:
 			return k.HandleConsumerAdditionProposal(ctx, c)
 		case *types.ConsumerRemovalProposal:
-			return k.ConsumerRemovalProposal(ctx, c)
+			return k.HandleConsumerRemovalProposal(ctx, c)
 		default:
 			return sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "unrecognized ccv proposal content type: %T", c)
 		}

--- a/x/ccv/provider/types/codec.go
+++ b/x/ccv/provider/types/codec.go
@@ -16,7 +16,7 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterImplementations(
 		(*govtypes.Content)(nil),
-		&CreateConsumerChainProposal{},
+		&ConsumerAdditionProposal{},
 	)
 }
 

--- a/x/ccv/provider/types/errors.go
+++ b/x/ccv/provider/types/errors.go
@@ -6,8 +6,8 @@ import (
 
 // Provider sentinel errors
 var (
-	ErrInvalidCreateProposal    = sdkerrors.Register(ModuleName, 1, "invalid create consumer chain proposal")
-	ErrInvalidStopProposal      = sdkerrors.Register(ModuleName, 2, "invalid stop consumer chain proposal")
-	ErrUnknownConsumerChainId   = sdkerrors.Register(ModuleName, 3, "no consumer chain with this chain id")
-	ErrUnknownConsumerChannelId = sdkerrors.Register(ModuleName, 4, "no consumer chain with this channel id")
+	ErrInvalidConsumerAdditionProposal = sdkerrors.Register(ModuleName, 1, "invalid consumer addition proposal")
+	ErrInvalidStopProposal             = sdkerrors.Register(ModuleName, 2, "invalid stop consumer chain proposal")
+	ErrUnknownConsumerChainId          = sdkerrors.Register(ModuleName, 3, "no consumer chain with this chain id")
+	ErrUnknownConsumerChannelId        = sdkerrors.Register(ModuleName, 4, "no consumer chain with this channel id")
 )

--- a/x/ccv/provider/types/errors.go
+++ b/x/ccv/provider/types/errors.go
@@ -7,7 +7,7 @@ import (
 // Provider sentinel errors
 var (
 	ErrInvalidConsumerAdditionProposal = sdkerrors.Register(ModuleName, 1, "invalid consumer addition proposal")
-	ErrInvalidStopProposal             = sdkerrors.Register(ModuleName, 2, "invalid stop consumer chain proposal")
+	ErrInvalidConsumerRemovalProp      = sdkerrors.Register(ModuleName, 2, "invalid consumer removal proposal")
 	ErrUnknownConsumerChainId          = sdkerrors.Register(ModuleName, 3, "no consumer chain with this chain id")
 	ErrUnknownConsumerChannelId        = sdkerrors.Register(ModuleName, 4, "no consumer chain with this channel id")
 )

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -52,9 +52,9 @@ const (
 	// ChainToClientBytePrefix is the byte prefix for storing the consumer chainID for a given consumer clientid.
 	ChainToClientBytePrefix
 
-	// PendingConsumerAdditionPropBytePrefix is the byte prefix for storing the pending consumer addition proposal before the spawn time occurs.
+	// PendingCAPBytePrefix is the byte prefix for storing pending consumer addition proposals before the spawn time occurs.
 	// The key includes the BigEndian timestamp to allow for efficient chronological iteration
-	PendingConsumerAdditionPropBytePrefix
+	PendingCAPBytePrefix
 
 	// PendingStopProposalBytePrefix is the byte prefix for storing the pending identified consumer chain before the stop time occurs.
 	// The key includes the BigEndian timestamp to allow for efficient chronological iteration
@@ -123,15 +123,15 @@ func ChainToClientKey(chainID string) []byte {
 	return append([]byte{ChainToClientBytePrefix}, []byte(chainID)...)
 }
 
-// PendingConsumerAdditionPropKey returns the key under which a pending consumer addition proposal is stored
-func PendingConsumerAdditionPropKey(timestamp time.Time, chainID string) []byte {
+// PendingCAPKey returns the key under which a pending consumer addition proposal is stored
+func PendingCAPKey(timestamp time.Time, chainID string) []byte {
 	timeBz := sdk.FormatTimeBytes(timestamp)
 	timeBzL := len(timeBz)
-	prefixL := len([]byte{PendingConsumerAdditionPropBytePrefix})
+	prefixL := len([]byte{PendingCAPBytePrefix})
 
 	bz := make([]byte, prefixL+8+timeBzL+len(chainID))
 	// copy the prefix
-	copy(bz[:prefixL], []byte{PendingConsumerAdditionPropBytePrefix})
+	copy(bz[:prefixL], []byte{PendingCAPBytePrefix})
 	// copy the time length
 	copy(bz[prefixL:prefixL+8], sdk.Uint64ToBigEndian(uint64(timeBzL)))
 	// copy the time bytes
@@ -141,10 +141,10 @@ func PendingConsumerAdditionPropKey(timestamp time.Time, chainID string) []byte 
 	return bz
 }
 
-// ParsePendingConsumerAdditionPropKey returns the time and chain ID
-// for a pending consumer addition proposal key or an error if unparsable
-func ParsePendingConsumerAdditionPropKey(bz []byte) (time.Time, string, error) {
-	expectedPrefix := []byte{PendingConsumerAdditionPropBytePrefix}
+// ParsePendingCAPKey returns the time and chain ID for a pending consumer addition proposal key
+// or an error if unparsable
+func ParsePendingCAPKey(bz []byte) (time.Time, string, error) {
+	expectedPrefix := []byte{PendingCAPBytePrefix}
 	prefixL := len(expectedPrefix)
 	if prefix := bz[:prefixL]; !bytes.Equal(prefix, expectedPrefix) {
 		return time.Time{}, "", fmt.Errorf("invalid prefix; expected: %X, got: %X", expectedPrefix, prefix)

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -56,9 +56,9 @@ const (
 	// The key includes the BigEndian timestamp to allow for efficient chronological iteration
 	PendingCAPBytePrefix
 
-	// PendingStopProposalBytePrefix is the byte prefix for storing the pending identified consumer chain before the stop time occurs.
+	// PendingCRPBytePrefix is the byte prefix for storing pending consumer removal proposals before the stop time occurs.
 	// The key includes the BigEndian timestamp to allow for efficient chronological iteration
-	PendingStopProposalBytePrefix
+	PendingCRPBytePrefix
 
 	// UnbondingOpBytePrefix is the byte prefix that stores a record of all the ids of consumer chains that
 	// need to unbond before a given delegation can unbond on this chain.
@@ -160,15 +160,15 @@ func ParsePendingCAPKey(bz []byte) (time.Time, string, error) {
 	return timestamp, chainID, nil
 }
 
-// PendingStopProposalKey returns the key under which pending consumer chain stop proposals are stored
-func PendingStopProposalKey(timestamp time.Time, chainID string) []byte {
+// PendingCRPKey returns the key under which pending consumer removal proposals are stored
+func PendingCRPKey(timestamp time.Time, chainID string) []byte {
 	timeBz := sdk.FormatTimeBytes(timestamp)
 	timeBzL := len(timeBz)
-	prefixL := len([]byte{PendingStopProposalBytePrefix})
+	prefixL := len([]byte{PendingCRPBytePrefix})
 
 	bz := make([]byte, prefixL+8+timeBzL+len(chainID))
 	// copy the prefix
-	copy(bz[:prefixL], []byte{PendingStopProposalBytePrefix})
+	copy(bz[:prefixL], []byte{PendingCRPBytePrefix})
 	// copy the time length
 	copy(bz[prefixL:prefixL+8], sdk.Uint64ToBigEndian(uint64(timeBzL)))
 	// copy the time bytes
@@ -178,9 +178,9 @@ func PendingStopProposalKey(timestamp time.Time, chainID string) []byte {
 	return bz
 }
 
-// ParsePendingStopProposalKey returns the time and chain ID for a pending consumer chain stop proposal key or an error if unparseable
-func ParsePendingStopProposalKey(bz []byte) (time.Time, string, error) {
-	expectedPrefix := []byte{PendingStopProposalBytePrefix}
+// ParsePendingCRPKey returns the time and chain ID for a pending consumer removal proposal key or an error if unparseable
+func ParsePendingCRPKey(bz []byte) (time.Time, string, error) {
+	expectedPrefix := []byte{PendingCRPBytePrefix}
 	prefixL := len(expectedPrefix)
 	if prefix := bz[:prefixL]; !bytes.Equal(prefix, expectedPrefix) {
 		return time.Time{}, "", fmt.Errorf("invalid prefix; expected: %X, got: %X", expectedPrefix, prefix)

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -52,9 +52,9 @@ const (
 	// ChainToClientBytePrefix is the byte prefix for storing the consumer chainID for a given consumer clientid.
 	ChainToClientBytePrefix
 
-	// PendingCreateProposalBytePrefix is the byte prefix for storing the pending identified consumer chain client before the spawn time occurs.
+	// PendingConsumerAdditionPropBytePrefix is the byte prefix for storing the pending consumer addition proposal before the spawn time occurs.
 	// The key includes the BigEndian timestamp to allow for efficient chronological iteration
-	PendingCreateProposalBytePrefix
+	PendingConsumerAdditionPropBytePrefix
 
 	// PendingStopProposalBytePrefix is the byte prefix for storing the pending identified consumer chain before the stop time occurs.
 	// The key includes the BigEndian timestamp to allow for efficient chronological iteration
@@ -123,15 +123,15 @@ func ChainToClientKey(chainID string) []byte {
 	return append([]byte{ChainToClientBytePrefix}, []byte(chainID)...)
 }
 
-// PendingCreateProposalKey returns the key under which a pending identified client is stored
-func PendingCreateProposalKey(timestamp time.Time, chainID string) []byte {
+// PendingConsumerAdditionPropKey returns the key under which a pending consumer addition proposal is stored
+func PendingConsumerAdditionPropKey(timestamp time.Time, chainID string) []byte {
 	timeBz := sdk.FormatTimeBytes(timestamp)
 	timeBzL := len(timeBz)
-	prefixL := len([]byte{PendingCreateProposalBytePrefix})
+	prefixL := len([]byte{PendingConsumerAdditionPropBytePrefix})
 
 	bz := make([]byte, prefixL+8+timeBzL+len(chainID))
 	// copy the prefix
-	copy(bz[:prefixL], []byte{PendingCreateProposalBytePrefix})
+	copy(bz[:prefixL], []byte{PendingConsumerAdditionPropBytePrefix})
 	// copy the time length
 	copy(bz[prefixL:prefixL+8], sdk.Uint64ToBigEndian(uint64(timeBzL)))
 	// copy the time bytes
@@ -141,9 +141,10 @@ func PendingCreateProposalKey(timestamp time.Time, chainID string) []byte {
 	return bz
 }
 
-// ParsePendingCreateProposalKey returns the time and chain ID for a pending client key or an error if unparseable
-func ParsePendingCreateProposalKey(bz []byte) (time.Time, string, error) {
-	expectedPrefix := []byte{PendingCreateProposalBytePrefix}
+// ParsePendingConsumerAdditionPropKey returns the time and chain ID
+// for a pending consumer addition proposal key or an error if unparsable
+func ParsePendingConsumerAdditionPropKey(bz []byte) (time.Time, string, error) {
+	expectedPrefix := []byte{PendingConsumerAdditionPropBytePrefix}
 	prefixL := len(expectedPrefix)
 	if prefix := bz[:prefixL]; !bytes.Equal(prefix, expectedPrefix) {
 		return time.Time{}, "", fmt.Errorf("invalid prefix; expected: %X, got: %X", expectedPrefix, prefix)

--- a/x/ccv/provider/types/keys_test.go
+++ b/x/ccv/provider/types/keys_test.go
@@ -43,7 +43,7 @@ func getSingleByteKeys() [][]byte {
 	keys[i], i = []byte{ChainToChannelBytePrefix}, i+1
 	keys[i], i = []byte{ChannelToChainBytePrefix}, i+1
 	keys[i], i = []byte{ChainToClientBytePrefix}, i+1
-	keys[i], i = []byte{PendingCreateProposalBytePrefix}, i+1
+	keys[i], i = []byte{PendingConsumerAdditionPropBytePrefix}, i+1
 	keys[i], i = []byte{PendingStopProposalBytePrefix}, i+1
 	keys[i], i = []byte{UnbondingOpBytePrefix}, i+1
 	keys[i], i = []byte{UnbondingOpIndexBytePrefix}, i+1
@@ -69,12 +69,12 @@ func TestPendingClientKeyAndParse(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		key := PendingCreateProposalKey(test.timestamp, test.chainID)
+		key := PendingConsumerAdditionPropKey(test.timestamp, test.chainID)
 		require.NotEmpty(t, key)
 		// Expected bytes = prefix + time length + time bytes + length of chainID
 		expectedBytes := 1 + 8 + len(sdk.FormatTimeBytes(time.Time{})) + len(test.chainID)
 		require.Equal(t, expectedBytes, len(key))
-		parsedTime, parsedID, err := ParsePendingCreateProposalKey(key)
+		parsedTime, parsedID, err := ParsePendingConsumerAdditionPropKey(key)
 		require.Equal(t, test.timestamp.UTC(), parsedTime.UTC())
 		require.Equal(t, test.chainID, parsedID)
 		require.NoError(t, err)

--- a/x/ccv/provider/types/keys_test.go
+++ b/x/ccv/provider/types/keys_test.go
@@ -43,7 +43,7 @@ func getSingleByteKeys() [][]byte {
 	keys[i], i = []byte{ChainToChannelBytePrefix}, i+1
 	keys[i], i = []byte{ChannelToChainBytePrefix}, i+1
 	keys[i], i = []byte{ChainToClientBytePrefix}, i+1
-	keys[i], i = []byte{PendingConsumerAdditionPropBytePrefix}, i+1
+	keys[i], i = []byte{PendingCAPBytePrefix}, i+1
 	keys[i], i = []byte{PendingStopProposalBytePrefix}, i+1
 	keys[i], i = []byte{UnbondingOpBytePrefix}, i+1
 	keys[i], i = []byte{UnbondingOpIndexBytePrefix}, i+1
@@ -57,7 +57,8 @@ func getSingleByteKeys() [][]byte {
 	return keys
 }
 
-func TestPendingClientKeyAndParse(t *testing.T) {
+// Tests the construction and parsing of keys for storing pending consumer addition proposals
+func TestPendingCAPKeyAndParse(t *testing.T) {
 	tests := []struct {
 		timestamp time.Time
 		chainID   string
@@ -69,12 +70,12 @@ func TestPendingClientKeyAndParse(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		key := PendingConsumerAdditionPropKey(test.timestamp, test.chainID)
+		key := PendingCAPKey(test.timestamp, test.chainID)
 		require.NotEmpty(t, key)
 		// Expected bytes = prefix + time length + time bytes + length of chainID
 		expectedBytes := 1 + 8 + len(sdk.FormatTimeBytes(time.Time{})) + len(test.chainID)
 		require.Equal(t, expectedBytes, len(key))
-		parsedTime, parsedID, err := ParsePendingConsumerAdditionPropKey(key)
+		parsedTime, parsedID, err := ParsePendingCAPKey(key)
 		require.Equal(t, test.timestamp.UTC(), parsedTime.UTC())
 		require.Equal(t, test.chainID, parsedID)
 		require.NoError(t, err)

--- a/x/ccv/provider/types/keys_test.go
+++ b/x/ccv/provider/types/keys_test.go
@@ -44,7 +44,7 @@ func getSingleByteKeys() [][]byte {
 	keys[i], i = []byte{ChannelToChainBytePrefix}, i+1
 	keys[i], i = []byte{ChainToClientBytePrefix}, i+1
 	keys[i], i = []byte{PendingCAPBytePrefix}, i+1
-	keys[i], i = []byte{PendingStopProposalBytePrefix}, i+1
+	keys[i], i = []byte{PendingCRPBytePrefix}, i+1
 	keys[i], i = []byte{UnbondingOpBytePrefix}, i+1
 	keys[i], i = []byte{UnbondingOpIndexBytePrefix}, i+1
 	keys[i], i = []byte{ValsetUpdateBlockHeightBytePrefix}, i+1
@@ -82,7 +82,8 @@ func TestPendingCAPKeyAndParse(t *testing.T) {
 	}
 }
 
-func TestPendingStopProposalKeyAndParse(t *testing.T) {
+// Tests the construction and parsing of keys for storing pending consumer removal proposals
+func TestPendingCRPKeyAndParse(t *testing.T) {
 	tests := []struct {
 		timestamp time.Time
 		chainID   string
@@ -94,12 +95,12 @@ func TestPendingStopProposalKeyAndParse(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		key := PendingStopProposalKey(test.timestamp, test.chainID)
+		key := PendingCRPKey(test.timestamp, test.chainID)
 		require.NotEmpty(t, key)
 		// Expected bytes = prefix + time length + time bytes + length of chainID
 		expectedBytes := 1 + 8 + len(sdk.FormatTimeBytes(time.Time{})) + len(test.chainID)
 		require.Equal(t, expectedBytes, len(key))
-		parsedTime, parsedID, err := ParsePendingStopProposalKey(key)
+		parsedTime, parsedID, err := ParsePendingCRPKey(key)
 		require.Equal(t, test.timestamp.UTC(), parsedTime.UTC())
 		require.Equal(t, test.chainID, parsedID)
 		require.NoError(t, err)

--- a/x/ccv/provider/types/proposal.go
+++ b/x/ccv/provider/types/proposal.go
@@ -89,9 +89,9 @@ func (cccp *ConsumerAdditionProposal) String() string {
 	SpawnTime: %s`, cccp.Title, cccp.Description, cccp.ChainId, cccp.InitialHeight, cccp.GenesisHash, cccp.BinaryHash, cccp.SpawnTime)
 }
 
-// NewStopConsumerChainProposal creates a new stop consumer chain proposal.
-func NewStopConsumerChainProposal(title, description, chainID string, stopTime time.Time) (govtypes.Content, error) {
-	return &StopConsumerChainProposal{
+// NewConsumerRemovalProposal creates a new stop consumer chain proposal.
+func NewConsumerRemovalProposal(title, description, chainID string, stopTime time.Time) (govtypes.Content, error) {
+	return &ConsumerRemovalProposal{
 		Title:       title,
 		Description: description,
 		ChainId:     chainID,
@@ -100,13 +100,13 @@ func NewStopConsumerChainProposal(title, description, chainID string, stopTime t
 }
 
 // ProposalRoute returns the routing key of a stop consumer chain proposal.
-func (sccp *StopConsumerChainProposal) ProposalRoute() string { return RouterKey }
+func (sccp *ConsumerRemovalProposal) ProposalRoute() string { return RouterKey }
 
 // ProposalType returns the type of a stop consumer chain proposal.
-func (sccp *StopConsumerChainProposal) ProposalType() string { return ProposalTypeStopConsumerChain }
+func (sccp *ConsumerRemovalProposal) ProposalType() string { return ProposalTypeStopConsumerChain }
 
 // ValidateBasic runs basic stateless validity checks
-func (sccp *StopConsumerChainProposal) ValidateBasic() error {
+func (sccp *ConsumerRemovalProposal) ValidateBasic() error {
 	if err := govtypes.ValidateAbstract(sccp); err != nil {
 		return err
 	}

--- a/x/ccv/provider/types/proposal.go
+++ b/x/ccv/provider/types/proposal.go
@@ -23,7 +23,7 @@ func init() {
 	govtypes.RegisterProposalType(ProposalTypeCreateConsumerChain)
 }
 
-// NewConsumerAdditionProposal creates a new create consumerchain proposal.
+// NewConsumerAdditionProposal creates a new consumer addition proposal.
 func NewConsumerAdditionProposal(title, description, chainID string, initialHeight clienttypes.Height, genesisHash, binaryHash []byte, spawnTime time.Time) govtypes.Content {
 	return &ConsumerAdditionProposal{
 		Title:         title,

--- a/x/ccv/provider/types/proposal.go
+++ b/x/ccv/provider/types/proposal.go
@@ -90,13 +90,13 @@ func (cccp *ConsumerAdditionProposal) String() string {
 }
 
 // NewConsumerRemovalProposal creates a new consumer removal proposal.
-func NewConsumerRemovalProposal(title, description, chainID string, stopTime time.Time) (govtypes.Content, error) {
+func NewConsumerRemovalProposal(title, description, chainID string, stopTime time.Time) govtypes.Content {
 	return &ConsumerRemovalProposal{
 		Title:       title,
 		Description: description,
 		ChainId:     chainID,
 		StopTime:    stopTime,
-	}, nil
+	}
 }
 
 // ProposalRoute returns the routing key of a consumer removal proposal.

--- a/x/ccv/provider/types/proposal.go
+++ b/x/ccv/provider/types/proposal.go
@@ -16,16 +16,16 @@ const (
 )
 
 var (
-	_ govtypes.Content = &CreateConsumerChainProposal{}
+	_ govtypes.Content = &ConsumerAdditionProposal{}
 )
 
 func init() {
 	govtypes.RegisterProposalType(ProposalTypeCreateConsumerChain)
 }
 
-// NewCreateConsumerChainProposal creates a new create consumerchain proposal.
-func NewCreateConsumerChainProposal(title, description, chainID string, initialHeight clienttypes.Height, genesisHash, binaryHash []byte, spawnTime time.Time) govtypes.Content {
-	return &CreateConsumerChainProposal{
+// NewConsumerAdditionProposal creates a new create consumerchain proposal.
+func NewConsumerAdditionProposal(title, description, chainID string, initialHeight clienttypes.Height, genesisHash, binaryHash []byte, spawnTime time.Time) govtypes.Content {
+	return &ConsumerAdditionProposal{
 		Title:         title,
 		Description:   description,
 		ChainId:       chainID,
@@ -36,49 +36,49 @@ func NewCreateConsumerChainProposal(title, description, chainID string, initialH
 	}
 }
 
-// GetTitle returns the title of a create consumerchain proposal.
-func (cccp *CreateConsumerChainProposal) GetTitle() string { return cccp.Title }
+// GetTitle returns the title of a consumer addition proposal.
+func (cccp *ConsumerAdditionProposal) GetTitle() string { return cccp.Title }
 
-// GetDescription returns the description of a create consumerchain proposal.
-func (cccp *CreateConsumerChainProposal) GetDescription() string { return cccp.Description }
+// GetDescription returns the description of a consumer addition proposal.
+func (cccp *ConsumerAdditionProposal) GetDescription() string { return cccp.Description }
 
-// ProposalRoute returns the routing key of a create consumerchain proposal.
-func (cccp *CreateConsumerChainProposal) ProposalRoute() string { return RouterKey }
+// ProposalRoute returns the routing key of a consumer addition proposal.
+func (cccp *ConsumerAdditionProposal) ProposalRoute() string { return RouterKey }
 
-// ProposalType returns the type of a create consumerchain proposal.
-func (cccp *CreateConsumerChainProposal) ProposalType() string {
+// ProposalType returns the type of a consumer addition proposal.
+func (cccp *ConsumerAdditionProposal) ProposalType() string {
 	return ProposalTypeCreateConsumerChain
 }
 
 // ValidateBasic runs basic stateless validity checks
-func (cccp *CreateConsumerChainProposal) ValidateBasic() error {
+func (cccp *ConsumerAdditionProposal) ValidateBasic() error {
 	if err := govtypes.ValidateAbstract(cccp); err != nil {
 		return err
 	}
 
 	if strings.TrimSpace(cccp.ChainId) == "" {
-		return sdkerrors.Wrap(ErrInvalidCreateProposal, "consumer chain id must not be blank")
+		return sdkerrors.Wrap(ErrInvalidConsumerAdditionProposal, "consumer chain id must not be blank")
 	}
 
 	if cccp.InitialHeight.IsZero() {
-		return sdkerrors.Wrap(ErrInvalidCreateProposal, "initial height cannot be zero")
+		return sdkerrors.Wrap(ErrInvalidConsumerAdditionProposal, "initial height cannot be zero")
 	}
 
 	if len(cccp.GenesisHash) == 0 {
-		return sdkerrors.Wrap(ErrInvalidCreateProposal, "genesis hash cannot be empty")
+		return sdkerrors.Wrap(ErrInvalidConsumerAdditionProposal, "genesis hash cannot be empty")
 	}
 	if len(cccp.BinaryHash) == 0 {
-		return sdkerrors.Wrap(ErrInvalidCreateProposal, "binary hash cannot be empty")
+		return sdkerrors.Wrap(ErrInvalidConsumerAdditionProposal, "binary hash cannot be empty")
 	}
 
 	if cccp.SpawnTime.IsZero() {
-		return sdkerrors.Wrap(ErrInvalidCreateProposal, "spawn time cannot be zero")
+		return sdkerrors.Wrap(ErrInvalidConsumerAdditionProposal, "spawn time cannot be zero")
 	}
 	return nil
 }
 
-// String returns the string representation of the CreateConsumerChainProposal.
-func (cccp *CreateConsumerChainProposal) String() string {
+// String returns the string representation of the ConsumerAdditionProposal.
+func (cccp *ConsumerAdditionProposal) String() string {
 	return fmt.Sprintf(`CreateConsumerChain Proposal
 	Title: %s
 	Description: %s

--- a/x/ccv/provider/types/proposal.go
+++ b/x/ccv/provider/types/proposal.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	ProposalTypeCreateConsumerChain = "CreateConsumerChain"
-	ProposalTypeStopConsumerChain   = "StopConsumerChain"
+	ProposalTypeConsumerAddition = "ConsumerAddition"
+	ProposalTypeConsumerRemoval  = "ConsumerRemoval"
 )
 
 var (
@@ -20,7 +20,7 @@ var (
 )
 
 func init() {
-	govtypes.RegisterProposalType(ProposalTypeCreateConsumerChain)
+	govtypes.RegisterProposalType(ProposalTypeConsumerAddition)
 }
 
 // NewConsumerAdditionProposal creates a new consumer addition proposal.
@@ -47,7 +47,7 @@ func (cccp *ConsumerAdditionProposal) ProposalRoute() string { return RouterKey 
 
 // ProposalType returns the type of a consumer addition proposal.
 func (cccp *ConsumerAdditionProposal) ProposalType() string {
-	return ProposalTypeCreateConsumerChain
+	return ProposalTypeConsumerAddition
 }
 
 // ValidateBasic runs basic stateless validity checks
@@ -89,7 +89,7 @@ func (cccp *ConsumerAdditionProposal) String() string {
 	SpawnTime: %s`, cccp.Title, cccp.Description, cccp.ChainId, cccp.InitialHeight, cccp.GenesisHash, cccp.BinaryHash, cccp.SpawnTime)
 }
 
-// NewConsumerRemovalProposal creates a new stop consumer chain proposal.
+// NewConsumerRemovalProposal creates a new consumer removal proposal.
 func NewConsumerRemovalProposal(title, description, chainID string, stopTime time.Time) (govtypes.Content, error) {
 	return &ConsumerRemovalProposal{
 		Title:       title,
@@ -99,11 +99,11 @@ func NewConsumerRemovalProposal(title, description, chainID string, stopTime tim
 	}, nil
 }
 
-// ProposalRoute returns the routing key of a stop consumer chain proposal.
+// ProposalRoute returns the routing key of a consumer removal proposal.
 func (sccp *ConsumerRemovalProposal) ProposalRoute() string { return RouterKey }
 
-// ProposalType returns the type of a stop consumer chain proposal.
-func (sccp *ConsumerRemovalProposal) ProposalType() string { return ProposalTypeStopConsumerChain }
+// ProposalType returns the type of a consumer removal proposal.
+func (sccp *ConsumerRemovalProposal) ProposalType() string { return ProposalTypeConsumerRemoval }
 
 // ValidateBasic runs basic stateless validity checks
 func (sccp *ConsumerRemovalProposal) ValidateBasic() error {
@@ -112,11 +112,11 @@ func (sccp *ConsumerRemovalProposal) ValidateBasic() error {
 	}
 
 	if strings.TrimSpace(sccp.ChainId) == "" {
-		return sdkerrors.Wrap(ErrInvalidStopProposal, "consumer chain id must not be blank")
+		return sdkerrors.Wrap(ErrInvalidConsumerRemovalProp, "consumer chain id must not be blank")
 	}
 
 	if sccp.StopTime.IsZero() {
-		return sdkerrors.Wrap(ErrInvalidStopProposal, "spawn time cannot be zero")
+		return sdkerrors.Wrap(ErrInvalidConsumerRemovalProp, "spawn time cannot be zero")
 	}
 	return nil
 }

--- a/x/ccv/provider/types/proposal_test.go
+++ b/x/ccv/provider/types/proposal_test.go
@@ -27,22 +27,22 @@ func TestValidateBasic(t *testing.T) {
 	}{
 		{
 			"success",
-			types.NewCreateConsumerChainProposal("title", "description", "chainID", initialHeight, []byte("gen_hash"), []byte("bin_hash"), time.Now()),
+			types.NewConsumerAdditionProposal("title", "description", "chainID", initialHeight, []byte("gen_hash"), []byte("bin_hash"), time.Now()),
 			true,
 		},
 		{
 			"fails validate abstract - empty title",
-			types.NewCreateConsumerChainProposal(" ", "description", "chainID", initialHeight, []byte("gen_hash"), []byte("bin_hash"), time.Now()),
+			types.NewConsumerAdditionProposal(" ", "description", "chainID", initialHeight, []byte("gen_hash"), []byte("bin_hash"), time.Now()),
 			false,
 		},
 		{
 			"chainID is empty",
-			types.NewCreateConsumerChainProposal("title", "description", " ", initialHeight, []byte("gen_hash"), []byte("bin_hash"), time.Now()),
+			types.NewConsumerAdditionProposal("title", "description", " ", initialHeight, []byte("gen_hash"), []byte("bin_hash"), time.Now()),
 			false,
 		},
 		{
 			"initial height is zero",
-			&types.CreateConsumerChainProposal{
+			&types.ConsumerAdditionProposal{
 				Title:         "title",
 				Description:   "description",
 				ChainId:       "chainID",
@@ -55,17 +55,17 @@ func TestValidateBasic(t *testing.T) {
 		},
 		{
 			"genesis hash is empty",
-			types.NewCreateConsumerChainProposal("title", "description", "chainID", initialHeight, []byte(""), []byte("bin_hash"), time.Now()),
+			types.NewConsumerAdditionProposal("title", "description", "chainID", initialHeight, []byte(""), []byte("bin_hash"), time.Now()),
 			false,
 		},
 		{
 			"binary hash is empty",
-			types.NewCreateConsumerChainProposal("title", "description", "chainID", initialHeight, []byte("gen_hash"), []byte(""), time.Now()),
+			types.NewConsumerAdditionProposal("title", "description", "chainID", initialHeight, []byte("gen_hash"), []byte(""), time.Now()),
 			false,
 		},
 		{
 			"time is zero",
-			types.NewCreateConsumerChainProposal("title", "description", "chainID", initialHeight, []byte("gen_hash"), []byte("bin_hash"), time.Time{}),
+			types.NewConsumerAdditionProposal("title", "description", "chainID", initialHeight, []byte("gen_hash"), []byte("bin_hash"), time.Time{}),
 			false,
 		},
 	}
@@ -81,10 +81,10 @@ func TestValidateBasic(t *testing.T) {
 	}
 }
 
-func TestMarshalCreateConsumerChainProposal(t *testing.T) {
-	content := types.NewCreateConsumerChainProposal("title", "description", "chainID", clienttypes.NewHeight(0, 1), []byte("gen_hash"), []byte("bin_hash"), time.Now().UTC())
+func TestMarshalConsumerAdditionProposal(t *testing.T) {
+	content := types.NewConsumerAdditionProposal("title", "description", "chainID", clienttypes.NewHeight(0, 1), []byte("gen_hash"), []byte("bin_hash"), time.Now().UTC())
 
-	cccp, ok := content.(*types.CreateConsumerChainProposal)
+	cccp, ok := content.(*types.ConsumerAdditionProposal)
 	require.True(t, ok)
 
 	// create codec
@@ -100,17 +100,17 @@ func TestMarshalCreateConsumerChainProposal(t *testing.T) {
 	require.NoError(t, err)
 
 	// unmarshal proposal
-	newCccp := &types.CreateConsumerChainProposal{}
+	newCccp := &types.ConsumerAdditionProposal{}
 	err = cdc.UnmarshalJSON(bz, newCccp)
 	require.NoError(t, err)
 
 	require.True(t, proto.Equal(cccp, newCccp), "unmarshalled proposal does not equal original proposal")
 }
 
-func TestCreateConsumerChainProposalString(t *testing.T) {
+func TestConsumerAdditionProposalString(t *testing.T) {
 	initialHeight := clienttypes.NewHeight(2, 3)
 	spawnTime := time.Now()
-	proposal := types.NewCreateConsumerChainProposal("title", "description", "chainID", initialHeight, []byte("gen_hash"), []byte("bin_hash"), spawnTime)
+	proposal := types.NewConsumerAdditionProposal("title", "description", "chainID", initialHeight, []byte("gen_hash"), []byte("bin_hash"), spawnTime)
 
 	expect := fmt.Sprintf(`CreateConsumerChain Proposal
 	Title: title
@@ -121,5 +121,5 @@ func TestCreateConsumerChainProposalString(t *testing.T) {
 	BinaryHash: %s
 	SpawnTime: %s`, initialHeight, []byte("gen_hash"), []byte("bin_hash"), spawnTime)
 
-	require.Equal(t, expect, proposal.String(), "string method for CreateConsumerChainProposal returned unexpected string")
+	require.Equal(t, expect, proposal.String(), "string method for ConsumerAdditionProposal returned unexpected string")
 }

--- a/x/ccv/provider/types/provider.pb.go
+++ b/x/ccv/provider/types/provider.pb.go
@@ -91,7 +91,7 @@ var xxx_messageInfo_ConsumerAdditionProposal proto.InternalMessageInfo
 // StopConsumerProposal is a governance proposal on the provider chain to stop a consumer chain.
 // If it passes, all the consumer chain's state is removed from the provider chain. The outstanding unbonding
 // operation funds are released if the LockUnbondingOnTimeout parameter is set to false for the consumer chain ID.
-type StopConsumerChainProposal struct {
+type ConsumerRemovalProposal struct {
 	// the title of the proposal
 	Title string `protobuf:"bytes,1,opt,name=title,proto3" json:"title,omitempty"`
 	// the description of the proposal
@@ -102,18 +102,18 @@ type StopConsumerChainProposal struct {
 	StopTime time.Time `protobuf:"bytes,4,opt,name=stop_time,json=stopTime,proto3,stdtime" json:"stop_time"`
 }
 
-func (m *StopConsumerChainProposal) Reset()         { *m = StopConsumerChainProposal{} }
-func (m *StopConsumerChainProposal) String() string { return proto.CompactTextString(m) }
-func (*StopConsumerChainProposal) ProtoMessage()    {}
-func (*StopConsumerChainProposal) Descriptor() ([]byte, []int) {
+func (m *ConsumerRemovalProposal) Reset()         { *m = ConsumerRemovalProposal{} }
+func (m *ConsumerRemovalProposal) String() string { return proto.CompactTextString(m) }
+func (*ConsumerRemovalProposal) ProtoMessage()    {}
+func (*ConsumerRemovalProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_f22ec409a72b7b72, []int{1}
 }
-func (m *StopConsumerChainProposal) XXX_Unmarshal(b []byte) error {
+func (m *ConsumerRemovalProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *StopConsumerChainProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *ConsumerRemovalProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_StopConsumerChainProposal.Marshal(b, m, deterministic)
+		return xxx_messageInfo_ConsumerRemovalProposal.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -123,40 +123,40 @@ func (m *StopConsumerChainProposal) XXX_Marshal(b []byte, deterministic bool) ([
 		return b[:n], nil
 	}
 }
-func (m *StopConsumerChainProposal) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_StopConsumerChainProposal.Merge(m, src)
+func (m *ConsumerRemovalProposal) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ConsumerRemovalProposal.Merge(m, src)
 }
-func (m *StopConsumerChainProposal) XXX_Size() int {
+func (m *ConsumerRemovalProposal) XXX_Size() int {
 	return m.Size()
 }
-func (m *StopConsumerChainProposal) XXX_DiscardUnknown() {
-	xxx_messageInfo_StopConsumerChainProposal.DiscardUnknown(m)
+func (m *ConsumerRemovalProposal) XXX_DiscardUnknown() {
+	xxx_messageInfo_ConsumerRemovalProposal.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_StopConsumerChainProposal proto.InternalMessageInfo
+var xxx_messageInfo_ConsumerRemovalProposal proto.InternalMessageInfo
 
-func (m *StopConsumerChainProposal) GetTitle() string {
+func (m *ConsumerRemovalProposal) GetTitle() string {
 	if m != nil {
 		return m.Title
 	}
 	return ""
 }
 
-func (m *StopConsumerChainProposal) GetDescription() string {
+func (m *ConsumerRemovalProposal) GetDescription() string {
 	if m != nil {
 		return m.Description
 	}
 	return ""
 }
 
-func (m *StopConsumerChainProposal) GetChainId() string {
+func (m *ConsumerRemovalProposal) GetChainId() string {
 	if m != nil {
 		return m.ChainId
 	}
 	return ""
 }
 
-func (m *StopConsumerChainProposal) GetStopTime() time.Time {
+func (m *ConsumerRemovalProposal) GetStopTime() time.Time {
 	if m != nil {
 		return m.StopTime
 	}
@@ -262,7 +262,7 @@ func (m *HandshakeMetadata) GetVersion() string {
 
 func init() {
 	proto.RegisterType((*ConsumerAdditionProposal)(nil), "interchain_security.ccv.provider.v1.ConsumerAdditionProposal")
-	proto.RegisterType((*StopConsumerChainProposal)(nil), "interchain_security.ccv.provider.v1.StopConsumerChainProposal")
+	proto.RegisterType((*ConsumerRemovalProposal)(nil), "interchain_security.ccv.provider.v1.ConsumerRemovalProposal")
 	proto.RegisterType((*Params)(nil), "interchain_security.ccv.provider.v1.Params")
 	proto.RegisterType((*HandshakeMetadata)(nil), "interchain_security.ccv.provider.v1.HandshakeMetadata")
 }
@@ -400,7 +400,7 @@ func (m *ConsumerAdditionProposal) MarshalToSizedBuffer(dAtA []byte) (int, error
 	return len(dAtA) - i, nil
 }
 
-func (m *StopConsumerChainProposal) Marshal() (dAtA []byte, err error) {
+func (m *ConsumerRemovalProposal) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -410,12 +410,12 @@ func (m *StopConsumerChainProposal) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *StopConsumerChainProposal) MarshalTo(dAtA []byte) (int, error) {
+func (m *ConsumerRemovalProposal) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *StopConsumerChainProposal) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *ConsumerRemovalProposal) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -571,7 +571,7 @@ func (m *ConsumerAdditionProposal) Size() (n int) {
 	return n
 }
 
-func (m *StopConsumerChainProposal) Size() (n int) {
+func (m *ConsumerRemovalProposal) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -930,7 +930,7 @@ func (m *ConsumerAdditionProposal) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *StopConsumerChainProposal) Unmarshal(dAtA []byte) error {
+func (m *ConsumerRemovalProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -953,10 +953,10 @@ func (m *StopConsumerChainProposal) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: StopConsumerChainProposal: wiretype end group for non-group")
+			return fmt.Errorf("proto: ConsumerRemovalProposal: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: StopConsumerChainProposal: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: ConsumerRemovalProposal: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:

--- a/x/ccv/provider/types/provider.pb.go
+++ b/x/ccv/provider/types/provider.pb.go
@@ -29,10 +29,10 @@ var _ = time.Kitchen
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// CreateConsumerChainProposal is a governance proposal on the provider chain to spawn a new consumer chain.
+// ConsumerAdditionProposal is a governance proposal on the provider chain to spawn a new consumer chain.
 // If it passes, then all validators on the provider chain are expected to validate the consumer chain at spawn time
 // or get slashed. It is recommended that spawn time occurs after the proposal end time.
-type CreateConsumerChainProposal struct {
+type ConsumerAdditionProposal struct {
 	// the title of the proposal
 	Title string `protobuf:"bytes,1,opt,name=title,proto3" json:"title,omitempty"`
 	// the description of the proposal
@@ -56,17 +56,17 @@ type CreateConsumerChainProposal struct {
 	LockUnbondingOnTimeout bool `protobuf:"varint,8,opt,name=lock_unbonding_on_timeout,json=lockUnbondingOnTimeout,proto3" json:"lock_unbonding_on_timeout,omitempty"`
 }
 
-func (m *CreateConsumerChainProposal) Reset()      { *m = CreateConsumerChainProposal{} }
-func (*CreateConsumerChainProposal) ProtoMessage() {}
-func (*CreateConsumerChainProposal) Descriptor() ([]byte, []int) {
+func (m *ConsumerAdditionProposal) Reset()      { *m = ConsumerAdditionProposal{} }
+func (*ConsumerAdditionProposal) ProtoMessage() {}
+func (*ConsumerAdditionProposal) Descriptor() ([]byte, []int) {
 	return fileDescriptor_f22ec409a72b7b72, []int{0}
 }
-func (m *CreateConsumerChainProposal) XXX_Unmarshal(b []byte) error {
+func (m *ConsumerAdditionProposal) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *CreateConsumerChainProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *ConsumerAdditionProposal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_CreateConsumerChainProposal.Marshal(b, m, deterministic)
+		return xxx_messageInfo_ConsumerAdditionProposal.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -76,17 +76,17 @@ func (m *CreateConsumerChainProposal) XXX_Marshal(b []byte, deterministic bool) 
 		return b[:n], nil
 	}
 }
-func (m *CreateConsumerChainProposal) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CreateConsumerChainProposal.Merge(m, src)
+func (m *ConsumerAdditionProposal) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_ConsumerAdditionProposal.Merge(m, src)
 }
-func (m *CreateConsumerChainProposal) XXX_Size() int {
+func (m *ConsumerAdditionProposal) XXX_Size() int {
 	return m.Size()
 }
-func (m *CreateConsumerChainProposal) XXX_DiscardUnknown() {
-	xxx_messageInfo_CreateConsumerChainProposal.DiscardUnknown(m)
+func (m *ConsumerAdditionProposal) XXX_DiscardUnknown() {
+	xxx_messageInfo_ConsumerAdditionProposal.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CreateConsumerChainProposal proto.InternalMessageInfo
+var xxx_messageInfo_ConsumerAdditionProposal proto.InternalMessageInfo
 
 // StopConsumerProposal is a governance proposal on the provider chain to stop a consumer chain.
 // If it passes, all the consumer chain's state is removed from the provider chain. The outstanding unbonding
@@ -261,7 +261,7 @@ func (m *HandshakeMetadata) GetVersion() string {
 }
 
 func init() {
-	proto.RegisterType((*CreateConsumerChainProposal)(nil), "interchain_security.ccv.provider.v1.CreateConsumerChainProposal")
+	proto.RegisterType((*ConsumerAdditionProposal)(nil), "interchain_security.ccv.provider.v1.ConsumerAdditionProposal")
 	proto.RegisterType((*StopConsumerChainProposal)(nil), "interchain_security.ccv.provider.v1.StopConsumerChainProposal")
 	proto.RegisterType((*Params)(nil), "interchain_security.ccv.provider.v1.Params")
 	proto.RegisterType((*HandshakeMetadata)(nil), "interchain_security.ccv.provider.v1.HandshakeMetadata")
@@ -314,7 +314,7 @@ var fileDescriptor_f22ec409a72b7b72 = []byte{
 	0x00, 0x00,
 }
 
-func (m *CreateConsumerChainProposal) Marshal() (dAtA []byte, err error) {
+func (m *ConsumerAdditionProposal) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -324,12 +324,12 @@ func (m *CreateConsumerChainProposal) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *CreateConsumerChainProposal) MarshalTo(dAtA []byte) (int, error) {
+func (m *ConsumerAdditionProposal) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *CreateConsumerChainProposal) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *ConsumerAdditionProposal) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -535,7 +535,7 @@ func encodeVarintProvider(dAtA []byte, offset int, v uint64) int {
 	dAtA[offset] = uint8(v)
 	return base
 }
-func (m *CreateConsumerChainProposal) Size() (n int) {
+func (m *ConsumerAdditionProposal) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -630,7 +630,7 @@ func sovProvider(x uint64) (n int) {
 func sozProvider(x uint64) (n int) {
 	return sovProvider(uint64((x << 1) ^ uint64((int64(x) >> 63))))
 }
-func (m *CreateConsumerChainProposal) Unmarshal(dAtA []byte) error {
+func (m *ConsumerAdditionProposal) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -653,10 +653,10 @@ func (m *CreateConsumerChainProposal) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: CreateConsumerChainProposal: wiretype end group for non-group")
+			return fmt.Errorf("proto: ConsumerAdditionProposal: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: CreateConsumerChainProposal: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: ConsumerAdditionProposal: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:

--- a/x/ccv/types/errors.go
+++ b/x/ccv/types/errors.go
@@ -19,7 +19,7 @@ var (
 	ErrInvalidVSCMaturedTime    = sdkerrors.Register(ModuleName, 12, "invalid maturity time for VSC packet")
 	ErrInvalidConsumerState     = sdkerrors.Register(ModuleName, 13, "provider chain has invalid state for consumer chain")
 	ErrInvalidConsumerClient    = sdkerrors.Register(ModuleName, 14, "ccv channel is not built on correct client")
-	ErrInvalidProposal          = sdkerrors.Register(ModuleName, 15, "invalid create consumer chain proposal")
+	ErrInvalidProposal          = sdkerrors.Register(ModuleName, 15, "invalid proposal")
 	ErrInvalidHandshakeMetadata = sdkerrors.Register(ModuleName, 16, "invalid provider handshake metadata")
 	ErrChannelNotFound          = sdkerrors.Register(ModuleName, 17, "channel not found")
 	ErrClientNotFound           = sdkerrors.Register(ModuleName, 18, "client not found")


### PR DESCRIPTION
Changes all instances, comments, methods, etc. such that:

- ```CreateConsumerChainProposal``` (the abstract type) is now ```ConsumerAdditionProposal```
- ```StopConsumerChainProposal``` (the abstract type) is now ```ConsumerRemovalProposal```
- ```StopConsumerChainProposal()``` (the method) is now ```HandleConsumerRemovalProposal()```
- ```CreateConsumerChainProposal()``` (the method) is now ```HandleConsumerAdditionProposal()```

Related to #331 