### PR TITLE
Extend #350

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ install: go.sum
 		go install $(BUILD_FLAGS) ./cmd/interchain-security-pd
 		go install $(BUILD_FLAGS) ./cmd/interchain-security-cd
 
-# run all tests: unit, e2e and diff
+# run all tests: unit, e2e, diff, and integration
 test: 
-	go test ./...
+	go test ./... && go run ./tests/integration/... 
 
 # run e2e and unit tests
 test-short:
@@ -25,7 +25,7 @@ test-integration:
 
 # run all tests with caching disabled
 test-no-cache:
-	go test ./... -count=1
+	go test ./... -count=1 && go run ./tests/integration/...
 
 BUILD_TARGETS := build
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Similar to e2e tests, but they compare the system state to an expected state gen
 Tests can be run using `make`:
 
 ```bash
-# run unit, e2e, and integration tests
+# run unit, e2e, diff, and integration tests
 make test
 
 # run unit and e2e tests - prefer this for local development
@@ -85,11 +85,11 @@ make test-no-cache
 
 Alternatively you can run tests using `go test`:
 ```bash
-# run all unit and e2e tests using go
+# run all unit, e2e, and diff tests using go
 go test ./...
-# run all unit and e2e tests with verbose output
+# run all unit, e2e, and diff tests with verbose output
 go test -v ./..
-# run all unit and e2e tests with coverage stats
+# run all unit, e2e, and diff tests with coverage stats
 go test -coverpkg=./x/... -coverprofile=coverage.out ./...
 # run a single unit test
 go test -run <unit-test-name> path/to/package


### PR DESCRIPTION
Reading through https://github.com/cosmos/interchain-security/issues/345 it seems there was agreement on implementing
```bash
# unit and handmade e2e
make test-fast
# unit, handmade e2e, diff, and integration
make test
```
Where make test would run all four of unit, e2e, diff, and integration tests. 

This PR slightly modifies #350 to make sure the make file aligns with the readme, and that all tests are included in ```make test```