### PR TITLE
Rename Empty prefix to Consume

### DIFF
--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -457,8 +457,8 @@ func (k Keeper) AppendMaturedUnbondingOps(ctx sdk.Context, ids []uint64) error {
 	return nil
 }
 
-// EmptyMaturedUnbondingOps empties and returns list of matured unbonding operation ids (if it exists)
-func (k Keeper) EmptyMaturedUnbondingOps(ctx sdk.Context) ([]uint64, error) {
+// ConsumeMaturedUnbondingOps empties and returns list of matured unbonding operation ids (if it exists)
+func (k Keeper) ConsumeMaturedUnbondingOps(ctx sdk.Context) ([]uint64, error) {
 	ids, err := k.GetMaturedUnbondingOps(ctx)
 	if err != nil {
 		return nil, err
@@ -657,8 +657,8 @@ func (k Keeper) GetSlashAcks(ctx sdk.Context, chainID string) []string {
 	return acks.GetAddresses()
 }
 
-// EmptySlashAcks empties and returns the slash acks for a given chain ID
-func (k Keeper) EmptySlashAcks(ctx sdk.Context, chainID string) (acks []string) {
+// ConsumeSlashAcks empties and returns the slash acks for a given chain ID
+func (k Keeper) ConsumeSlashAcks(ctx sdk.Context, chainID string) (acks []string) {
 	acks = k.GetSlashAcks(ctx, chainID)
 	if len(acks) < 1 {
 		return
@@ -773,8 +773,8 @@ func (k Keeper) AppendPendingVSC(ctx sdk.Context, chainID string, packet ccv.Val
 	store.Set(types.PendingVSCsKey(chainID), buf.Bytes())
 }
 
-// EmptyPendingVSC empties and returns the list of pending ValidatorSetChange packets for chain ID (if it exists)
-func (k Keeper) EmptyPendingVSC(ctx sdk.Context, chainID string) (packets []ccv.ValidatorSetChangePacketData) {
+// ConsumePendingVSCs empties and returns the list of pending ValidatorSetChange packets for chain ID (if it exists)
+func (k Keeper) ConsumePendingVSCs(ctx sdk.Context, chainID string) (packets []ccv.ValidatorSetChangePacketData) {
 	packets, found := k.GetPendingVSCs(ctx, chainID)
 	if !found {
 		// there is no list of pending ValidatorSetChange packets

--- a/x/ccv/provider/keeper/keeper_test.go
+++ b/x/ccv/provider/keeper/keeper_test.go
@@ -74,8 +74,8 @@ func TestSlashAcks(t *testing.T) {
 	require.NotNil(t, acks)
 
 	require.Len(t, acks, 3)
-	emptied := providerKeeper.EmptySlashAcks(ctx, chainID)
-	require.Len(t, emptied, 3)
+	slashAcks := providerKeeper.ConsumeSlashAcks(ctx, chainID)
+	require.Len(t, slashAcks, 3)
 
 	acks = providerKeeper.GetSlashAcks(ctx, chainID)
 	require.Nil(t, acks)
@@ -156,10 +156,10 @@ func TestPendingVSCs(t *testing.T) {
 		ValsetUpdateId: 3,
 	}
 	providerKeeper.AppendPendingVSC(ctx, chainID, newPacket)
-	emptied := providerKeeper.EmptyPendingVSC(ctx, chainID)
-	require.Len(t, emptied, 3)
-	require.True(t, emptied[len(emptied)-1].ValsetUpdateId == 3)
-	require.True(t, emptied[len(emptied)-1].GetValidatorUpdates()[0].PubKey.String() == ppks[3].String())
+	vscs := providerKeeper.ConsumePendingVSCs(ctx, chainID)
+	require.Len(t, vscs, 3)
+	require.True(t, vscs[len(vscs)-1].ValsetUpdateId == 3)
+	require.True(t, vscs[len(vscs)-1].GetValidatorUpdates()[0].PubKey.String() == ppks[3].String())
 
 	_, found = providerKeeper.GetPendingVSCs(ctx, chainID)
 	require.False(t, found)
@@ -289,7 +289,7 @@ func TestMaturedUnbondingOps(t *testing.T) {
 	err = providerKeeper.AppendMaturedUnbondingOps(ctx, unbondingOpIds)
 	require.NoError(t, err)
 
-	ids, err = providerKeeper.EmptyMaturedUnbondingOps(ctx)
+	ids, err = providerKeeper.ConsumeMaturedUnbondingOps(ctx)
 	require.NoError(t, err)
 	require.Equal(t, len(unbondingOpIds), len(ids))
 	for i := 0; i < len(unbondingOpIds); i++ {

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -136,8 +136,8 @@ func (k Keeper) StopConsumerChain(ctx sdk.Context, chainID string, lockUbd, clos
 	}
 
 	k.DeleteInitChainHeight(ctx, chainID)
-	k.EmptySlashAcks(ctx, chainID)
-	k.EmptyPendingVSC(ctx, chainID)
+	k.ConsumeSlashAcks(ctx, chainID)
+	k.ConsumePendingVSCs(ctx, chainID)
 
 	// release unbonding operations if they aren't locked
 	var vscIDs []uint64

--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -72,7 +72,7 @@ func (k Keeper) OnRecvVSCMaturedPacket(
 
 // CompleteMaturedUnbondingOps attempts to complete all matured unbonding operations
 func (k Keeper) CompleteMaturedUnbondingOps(ctx sdk.Context) {
-	ids, err := k.EmptyMaturedUnbondingOps(ctx)
+	ids, err := k.ConsumeMaturedUnbondingOps(ctx)
 	if err != nil {
 		panic(fmt.Sprintf("could not get the list of matured unbonding ops: %s", err.Error()))
 	}
@@ -135,7 +135,7 @@ func (k Keeper) SendValidatorUpdates(ctx sdk.Context) {
 		unbondingOps, _ := k.GetUnbondingOpsFromIndex(ctx, chainID, valUpdateID)
 		if len(valUpdates) != 0 || len(unbondingOps) != 0 {
 			// construct validator set change packet data
-			packetData := ccv.NewValidatorSetChangePacketData(valUpdates, valUpdateID, k.EmptySlashAcks(ctx, chainID))
+			packetData := ccv.NewValidatorSetChangePacketData(valUpdates, valUpdateID, k.ConsumeSlashAcks(ctx, chainID))
 
 			// check whether there is an established CCV channel to this consumer chain
 			if channelID, found := k.GetChainToChannel(ctx, chainID); found {
@@ -164,7 +164,7 @@ func (k Keeper) SendValidatorUpdates(ctx sdk.Context) {
 
 // Sends all pending ValidatorSetChangePackets to the specified chain
 func (k Keeper) SendPendingVSCPackets(ctx sdk.Context, chainID, channelID string) {
-	pendingPackets := k.EmptyPendingVSC(ctx, chainID)
+	pendingPackets := k.ConsumePendingVSCs(ctx, chainID)
 	for _, data := range pendingPackets {
 		// send packet over IBC
 		err := utils.SendIBCPacket(


### PR DESCRIPTION
Partially addresses

- https://github.com/cosmos/interchain-security/issues/331

We had some methods prefixed with `Empty` which I found confusing.