### PR TITLE
Use `doContinue` callback across all iterators

### DIFF
--- a/tests/difference/core/driver/core_test.go
+++ b/tests/difference/core/driver/core_test.go
@@ -388,7 +388,7 @@ func (s *CoreSuite) TestAssumptions() {
 	s.consumerKeeper().IteratePacketMaturityTime(s.ctx(C),
 		func(vscId uint64, timeNs uint64) bool {
 			s.T().Fatal(FAIL_MSG)
-			return false // Don't stop
+			return true // Don't stop
 		})
 
 	// Consumer power

--- a/x/ccv/consumer/keeper/genesis.go
+++ b/x/ccv/consumer/keeper/genesis.go
@@ -121,7 +121,7 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) (genesis *consumertypes.GenesisSt
 				MaturityTime: timeNs,
 			}
 			maturingPackets = append(maturingPackets, mat)
-			return false
+			return true
 		})
 
 		heightToVCIDs := []types.HeightToValsetUpdateID{}

--- a/x/ccv/consumer/keeper/genesis.go
+++ b/x/ccv/consumer/keeper/genesis.go
@@ -140,7 +140,7 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) (genesis *consumertypes.GenesisSt
 				ValidatorConsensusAddress: addr,
 			}
 			outstandingDowntimes = append(outstandingDowntimes, od)
-			return false
+			return true
 		})
 
 		genesis = types.NewRestartGenesisState(

--- a/x/ccv/consumer/keeper/keeper.go
+++ b/x/ccv/consumer/keeper/keeper.go
@@ -206,7 +206,7 @@ func (k Keeper) DeletePendingChanges(ctx sdk.Context) {
 }
 
 // IteratePacketMaturityTime iterates through the VSC packet maturity times set in the store
-func (k Keeper) IteratePacketMaturityTime(ctx sdk.Context, cb func(vscId, timeNs uint64) bool) {
+func (k Keeper) IteratePacketMaturityTime(ctx sdk.Context, doContinue func(vscId, timeNs uint64) bool) {
 	store := ctx.KVStore(k.storeKey)
 	iterator := sdk.KVStorePrefixIterator(store, []byte{types.PacketMaturityTimeBytePrefix})
 
@@ -218,7 +218,7 @@ func (k Keeper) IteratePacketMaturityTime(ctx sdk.Context, cb func(vscId, timeNs
 
 		timeNs := binary.BigEndian.Uint64(iterator.Value())
 
-		if !cb(seq, timeNs) {
+		if !doContinue(seq, timeNs) {
 			break
 		}
 	}
@@ -296,7 +296,7 @@ func (k Keeper) DeleteHeightValsetUpdateID(ctx sdk.Context, height uint64) {
 }
 
 // IterateHeightToValsetUpdateID iterates over the block height to valset update ID mapping in store
-func (k Keeper) IterateHeightToValsetUpdateID(ctx sdk.Context, cb func(height, vscID uint64) bool) {
+func (k Keeper) IterateHeightToValsetUpdateID(ctx sdk.Context, doContinue func(height, vscID uint64) bool) {
 	store := ctx.KVStore(k.storeKey)
 	iterator := sdk.KVStorePrefixIterator(store, []byte{types.HeightValsetUpdateIDBytePrefix})
 
@@ -307,7 +307,7 @@ func (k Keeper) IterateHeightToValsetUpdateID(ctx sdk.Context, cb func(height, v
 
 		vscID := binary.BigEndian.Uint64(iterator.Value())
 
-		if !cb(height, vscID) {
+		if !doContinue(height, vscID) {
 			break
 		}
 	}
@@ -337,7 +337,7 @@ func (k Keeper) DeleteOutstandingDowntime(ctx sdk.Context, consAddress string) {
 }
 
 // IterateOutstandingDowntime iterates over the validator addresses of outstanding downtime flags
-func (k Keeper) IterateOutstandingDowntime(ctx sdk.Context, cb func(address string) bool) {
+func (k Keeper) IterateOutstandingDowntime(ctx sdk.Context, doContinue func(address string) bool) {
 	store := ctx.KVStore(k.storeKey)
 	iterator := sdk.KVStorePrefixIterator(store, []byte{types.OutstandingDowntimeBytePrefix})
 
@@ -345,7 +345,7 @@ func (k Keeper) IterateOutstandingDowntime(ctx sdk.Context, cb func(address stri
 	for ; iterator.Valid(); iterator.Next() {
 		addrBytes := iterator.Key()[1:]
 		addr := sdk.ConsAddress(addrBytes).String()
-		if !cb(addr) {
+		if !doContinue(addr) {
 			break
 		}
 	}

--- a/x/ccv/consumer/keeper/keeper.go
+++ b/x/ccv/consumer/keeper/keeper.go
@@ -218,7 +218,7 @@ func (k Keeper) IteratePacketMaturityTime(ctx sdk.Context, cb func(vscId, timeNs
 
 		timeNs := binary.BigEndian.Uint64(iterator.Value())
 
-		if cb(seq, timeNs) {
+		if !cb(seq, timeNs) {
 			break
 		}
 	}

--- a/x/ccv/consumer/keeper/keeper_test.go
+++ b/x/ccv/consumer/keeper/keeper_test.go
@@ -107,7 +107,7 @@ func TestPacketMaturityTime(t *testing.T) {
 		require.Equal(t, orderedTimes[i][0], seq)
 		require.Equal(t, orderedTimes[i][1], time)
 		i++
-		return false
+		return true
 	})
 }
 

--- a/x/ccv/provider/keeper/grpc_query.go
+++ b/x/ccv/provider/keeper/grpc_query.go
@@ -43,7 +43,7 @@ func (k Keeper) QueryConsumerChains(goCtx context.Context, req *types.QueryConsu
 			ChainId:  chainID,
 			ClientId: clientID,
 		})
-		return false
+		return true
 	}
 	k.IterateConsumerChains(ctx, cb)
 

--- a/x/ccv/provider/keeper/grpc_query.go
+++ b/x/ccv/provider/keeper/grpc_query.go
@@ -38,14 +38,14 @@ func (k Keeper) QueryConsumerChains(goCtx context.Context, req *types.QueryConsu
 
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	chains := []*types.Chain{}
-	cb := func(ctx sdk.Context, chainID, clientID string) bool {
+	doContinue := func(ctx sdk.Context, chainID, clientID string) bool {
 		chains = append(chains, &types.Chain{
 			ChainId:  chainID,
 			ClientId: clientID,
 		})
 		return true
 	}
-	k.IterateConsumerChains(ctx, cb)
+	k.IterateConsumerChains(ctx, doContinue)
 
 	return &types.QueryConsumerChainsResponse{Chains: chains}, nil
 }

--- a/x/ccv/provider/keeper/hooks.go
+++ b/x/ccv/provider/keeper/hooks.go
@@ -25,9 +25,9 @@ func (k *Keeper) Hooks() Hooks {
 func (h Hooks) AfterUnbondingInitiated(ctx sdk.Context, ID uint64) {
 	var consumerChainIDS []string
 
-	h.k.IterateConsumerChains(ctx, func(ctx sdk.Context, chainID, clientID string) (stop bool) {
+	h.k.IterateConsumerChains(ctx, func(ctx sdk.Context, chainID, clientID string) (cont bool) {
 		consumerChainIDS = append(consumerChainIDS, chainID)
-		return false
+		return true
 	})
 	if len(consumerChainIDS) == 0 {
 		// Do not put the unbonding op on hold if there are no consumer chains

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -138,7 +138,7 @@ func (k Keeper) DeleteChainToChannel(ctx sdk.Context, chainID string) {
 // IterateConsumerChains iterates over all of the consumer chains that the provider module controls
 // It calls the provided callback function which takes in a chainID and client ID to return
 // a stop boolean which will stop the iteration.
-func (k Keeper) IterateConsumerChains(ctx sdk.Context, doContinue func(ctx sdk.Context, chainID, clientID string) (stop bool)) {
+func (k Keeper) IterateConsumerChains(ctx sdk.Context, doContinue func(ctx sdk.Context, chainID, clientID string) (cont bool)) {
 	store := ctx.KVStore(k.storeKey)
 	iterator := sdk.KVStorePrefixIterator(store, []byte{types.ChainToClientBytePrefix})
 	defer iterator.Close()

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -197,7 +197,7 @@ func (k Keeper) IterateChannelToChain(ctx sdk.Context, cb func(ctx sdk.Context, 
 
 		chainID := string(iterator.Value())
 
-		if cb(ctx, channelID, chainID) {
+		if !cb(ctx, channelID, chainID) {
 			break
 		}
 	}

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -337,7 +337,7 @@ func (k Keeper) ConsumerAdditionPropsToExecute(ctx sdk.Context) []types.Consumer
 	return propsToExecute
 }
 
-func (k Keeper) IteratePendingConsumerAdditionProps(ctx sdk.Context, cb func(spawnTime time.Time, prop types.ConsumerAdditionProposal) bool) {
+func (k Keeper) IteratePendingConsumerAdditionProps(ctx sdk.Context, doContinue func(spawnTime time.Time, prop types.ConsumerAdditionProposal) bool) {
 	iterator := k.PendingConsumerAdditionPropIterator(ctx)
 	defer iterator.Close()
 
@@ -351,7 +351,7 @@ func (k Keeper) IteratePendingConsumerAdditionProps(ctx sdk.Context, cb func(spa
 		var prop types.ConsumerAdditionProposal
 		k.cdc.MustUnmarshal(iterator.Value(), &prop)
 
-		if !cb(spawnTime, prop) {
+		if !doContinue(spawnTime, prop) {
 			return
 		}
 	}
@@ -457,7 +457,7 @@ func (k Keeper) ConsumerRemovalPropsToExecute(ctx sdk.Context) []types.ConsumerR
 	return propsToExecute
 }
 
-func (k Keeper) IteratePendingConsumerRemovalProps(ctx sdk.Context, cb func(stopTime time.Time, prop types.ConsumerRemovalProposal) bool) {
+func (k Keeper) IteratePendingConsumerRemovalProps(ctx sdk.Context, doContinue func(stopTime time.Time, prop types.ConsumerRemovalProposal) bool) {
 	iterator := k.PendingConsumerRemovalPropIterator(ctx)
 	defer iterator.Close()
 
@@ -469,7 +469,7 @@ func (k Keeper) IteratePendingConsumerRemovalProps(ctx sdk.Context, cb func(stop
 			panic(fmt.Errorf("failed to parse pending consumer removal proposal key: %w", err))
 		}
 
-		if !cb(stopTime, types.ConsumerRemovalProposal{ChainId: chainID, StopTime: stopTime}) {
+		if !doContinue(stopTime, types.ConsumerRemovalProposal{ChainId: chainID, StopTime: stopTime}) {
 			return
 		}
 	}

--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -135,7 +135,7 @@ func (k Keeper) sendValidatorUpdates(ctx sdk.Context) {
 	valUpdateID := k.GetValidatorSetUpdateId(ctx)
 	// get the validator updates from the staking module
 	valUpdates := k.stakingKeeper.GetValidatorUpdates(ctx)
-	k.IterateConsumerChains(ctx, func(ctx sdk.Context, chainID, clientID string) (stop bool) {
+	k.IterateConsumerChains(ctx, func(ctx sdk.Context, chainID, clientID string) (cont bool) {
 		// check whether there is an established CCV channel to this consumer chain
 		if channelID, found := k.GetChainToChannel(ctx, chainID); found {
 			// Send pending VSC packets to consumer chain
@@ -172,7 +172,7 @@ func (k Keeper) sendValidatorUpdates(ctx sdk.Context) {
 				k.AppendPendingVSC(ctx, chainID, packetData)
 			}
 		}
-		return false // do not stop the iteration
+		return true // do not stop the iteration
 	})
 	k.IncrementValidatorSetUpdateId(ctx)
 }


### PR DESCRIPTION
All iterators now have a doContinue callback which should make things less error prone.

Avoids bugs like

- https://github.com/cosmos/interchain-security/issues/433

I noticed that the sdk, ibc ect use a 

```
if cb(..) {break}
``` 

pattern.

Where we do

```
if !cb(..) {break}
``` 

For 18/20 iterators, so I opted to bring the last 2/20 to our pattern to make the smaller PR.

But a part of me thinks we should go the other way.

I think I fixed 3 or so bugs here.