### PR TITLE
E2e setup cleanup

### DIFF
--- a/tests/e2e/channel_init.go
+++ b/tests/e2e/channel_init.go
@@ -21,8 +21,10 @@ func (suite *CCVTestSuite) TestConsumerGenesis() {
 
 	genesis := consumerKeeper.ExportGenesis(suite.consumerChain.GetContext())
 
-	suite.Require().Equal(suite.providerClient, genesis.ProviderClientState)
-	suite.Require().Equal(suite.providerConsState, genesis.ProviderConsensusState)
+	// Confirm that client and cons state are exported from consumer keeper properly
+	consumerEndpointClientState, consumerEndpointConsState := suite.GetConsumerEndpointClientAndConsState()
+	suite.Require().Equal(consumerEndpointClientState, genesis.ProviderClientState)
+	suite.Require().Equal(consumerEndpointConsState, genesis.ProviderConsensusState)
 
 	suite.Require().NotPanics(func() {
 		consumerKeeper.InitGenesis(suite.consumerChain.GetContext(), genesis)
@@ -83,15 +85,6 @@ func (suite *CCVTestSuite) TestConsumerGenesis() {
 	suite.Require().NotPanics(func() {
 		consumerKeeper.InitGenesis(suite.consumerChain.GetContext(), restartGenesis)
 	})
-}
-
-// TestProviderClientMatches tests that the provider client managed by the consumer keeper matches the client keeper's client state
-func (suite *CCVTestSuite) TestProviderClientMatches() {
-	providerClientID, ok := suite.consumerApp.GetConsumerKeeper().GetProviderClientID(suite.consumerCtx())
-	suite.Require().True(ok)
-
-	clientState, _ := suite.consumerApp.GetIBCKeeper().ClientKeeper.GetClientState(suite.consumerCtx(), providerClientID)
-	suite.Require().Equal(suite.providerClient, clientState, "stored client state does not match genesis provider client")
 }
 
 // TestInitTimeout tests the init timeout

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -406,3 +406,19 @@ func (suite *CCVTestSuite) CreateCustomClient(endpoint *ibctesting.Endpoint, unb
 	endpoint.ClientID, err = ibctesting.ParseClientIDFromEvents(res.GetEvents())
 	require.NoError(endpoint.Chain.T, err)
 }
+
+func (suite *CCVTestSuite) GetConsumerEndpointClientAndConsState() (exported.ClientState, exported.ConsensusState) {
+
+	clientID, found := suite.consumerApp.GetConsumerKeeper().GetProviderClientID(suite.consumerCtx())
+	suite.Require().True(found)
+
+	clientState, found := suite.consumerApp.GetIBCKeeper().ClientKeeper.GetClientState(
+		suite.consumerCtx(), clientID)
+	suite.Require().True(found)
+
+	consState, found := suite.consumerApp.GetIBCKeeper().ClientKeeper.GetClientConsensusState(
+		suite.consumerCtx(), clientID, clientState.GetLatestHeight())
+	suite.Require().True(found)
+
+	return clientState, consState
+}

--- a/tests/e2e/setup.go
+++ b/tests/e2e/setup.go
@@ -26,16 +26,14 @@ import (
 // Any method implemented for this struct will be ran when suite.Run() is called.
 type CCVTestSuite struct {
 	suite.Suite
-	coordinator       *ibctesting.Coordinator
-	providerChain     *ibctesting.TestChain
-	consumerChain     *ibctesting.TestChain
-	providerApp       e2e.ProviderApp
-	consumerApp       e2e.ConsumerApp
-	providerClient    *ibctmtypes.ClientState
-	providerConsState *ibctmtypes.ConsensusState
-	path              *ibctesting.Path
-	transferPath      *ibctesting.Path
-	setupCallback     SetupCallback
+	coordinator   *ibctesting.Coordinator
+	providerChain *ibctesting.TestChain
+	consumerChain *ibctesting.TestChain
+	providerApp   e2e.ProviderApp
+	consumerApp   e2e.ConsumerApp
+	path          *ibctesting.Path
+	transferPath  *ibctesting.Path
+	setupCallback SetupCallback
 }
 
 // NewCCVTestSuite returns a new instance of CCVTestSuite, ready to be tested against using suite.Run().

--- a/tests/e2e/setup.go
+++ b/tests/e2e/setup.go
@@ -118,6 +118,9 @@ func (suite *CCVTestSuite) SetupTest() {
 	suite.Require().True(found, "consumer endpoint clientID not found")
 	suite.path.EndpointA.ClientID = consumerEndpointClientID
 
+	// Note: suite.path.EndpointA.ClientConfig and suite.path.EndpointB.ClientConfig are not populated,
+	// since these IBC testing package fields are unused in our tests.
+
 	// Confirm client config is now correct
 	suite.TestEndpointsClientConfig()
 

--- a/tests/e2e/setup.go
+++ b/tests/e2e/setup.go
@@ -122,7 +122,7 @@ func (suite *CCVTestSuite) SetupTest() {
 	// since these IBC testing package fields are unused in our tests.
 
 	// Confirm client config is now correct
-	suite.TestEndpointsClientConfig()
+	suite.ValidateEndpointsClientConfig()
 
 	// - channel config
 	suite.path.EndpointA.ChannelConfig.PortID = ccv.ConsumerPortID
@@ -203,7 +203,7 @@ func (suite *CCVTestSuite) SetupTransferChannel() {
 	suite.Require().NoError(err)
 }
 
-func (s CCVTestSuite) TestEndpointsClientConfig() {
+func (s CCVTestSuite) ValidateEndpointsClientConfig() {
 	consumerKeeper := s.consumerApp.GetConsumerKeeper()
 	providerStakingKeeper := s.providerApp.GetStakingKeeper()
 

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -210,8 +210,8 @@ func (k Keeper) MakeConsumerGenesis(ctx sdk.Context) (gen consumertypes.GenesisS
 	height := clienttypes.GetSelfHeight(ctx)
 
 	clientState := k.GetTemplateClient(ctx)
-	clientState.ChainId = ctx.ChainID()
-	clientState.LatestHeight = height //(+-1???)
+	clientState.ChainId = ctx.ChainID() // This will be the counter party chain ID for the consumer
+	clientState.LatestHeight = height   //(+-1???)
 	clientState.TrustingPeriod = providerUnbondingPeriod / time.Duration(k.GetTrustingPeriodFraction(ctx))
 	clientState.UnbondingPeriod = providerUnbondingPeriod
 
@@ -224,6 +224,7 @@ func (k Keeper) MakeConsumerGenesis(ctx sdk.Context) (gen consumertypes.GenesisS
 
 	gen.Params.Enabled = true
 	gen.NewChain = true
+	// This will become the ccv client state for the consumer
 	gen.ProviderClientState = clientState
 	gen.ProviderConsensusState = consState.(*ibctmtypes.ConsensusState)
 


### PR DESCRIPTION
Closes https://github.com/cosmos/interchain-security/issues/436.

This PR removes the code that is confusing and effectively dead. IBC client states are actually setup [here](https://github.com/cosmos/interchain-security/blob/e2e-setup-cleanup/x/ccv/provider/keeper/proposal.go#L61) and [here](https://github.com/cosmos/interchain-security/blob/e2e-setup-cleanup/x/ccv/provider/keeper/proposal.go#L212), using correct convention of the client state's unbonding period being for the counterparty chain.

Aside: The nomenclature of how "providerClientState", "consumerClientState", etc. are used in this repo is pretty inconsistent. "consumerEndpointClientState", etc. is easier for me to understand as the client state used on the consumer's IBC endpoint