### PR TITLE
Slashing related e2e test improvements

### DIFF
--- a/tests/e2e/slashing.go
+++ b/tests/e2e/slashing.go
@@ -23,7 +23,14 @@ const (
 	doubleSignTestCase
 )
 
-func (s *CCVTestSuite) TestSendAndApplySlashPacket() {
+// TestRelayAndApplySlashPacket tests that slash packets can be properly relayed
+// from consumer to provider, handled by provider, with a VSC and jailing/tombstoning
+// eventually effective on consumer and provider.
+//
+// Note: This method does not test the actual slash packet sending logic for downtime
+// and double-signing, see TestValidatorDowntime and TestValidatorDoubleSigning for
+// those types of tests.
+func (s *CCVTestSuite) TestRelayAndApplySlashPacket() {
 
 	testCases := []int{
 		downtimeTestCase,

--- a/tests/e2e/slashing.go
+++ b/tests/e2e/slashing.go
@@ -25,9 +25,6 @@ const (
 
 func (s *CCVTestSuite) TestSendAndApplySlashPacket() {
 
-	// TODO: make separate pr for these slashing test refactors, remember to mention parent pr, hacks make it fail
-	// TODO: make issue or just fix the slash fraction business below
-
 	testCases := []int{
 		downtimeTestCase,
 		doubleSignTestCase,
@@ -145,15 +142,14 @@ func (s *CCVTestSuite) TestSendAndApplySlashPacket() {
 		s.Require().Equal(validatorJailed.Status, stakingtypes.Unbonding)
 
 		// check that the validator's tokens were slashed
-		var slashedAmount sdk.Dec
-
+		var slashFraction sdk.Dec
 		if tc == downtimeTestCase {
-			slashFraction := int64(100) // TODO: make issue about this
-			slashedAmount = sdk.NewDec(1).QuoInt64(slashFraction).Mul(valOldBalance.ToDec())
+			slashFraction = providerSlashingKeeper.SlashFractionDowntime(s.providerCtx())
 
 		} else if tc == doubleSignTestCase {
-			slashedAmount = providerSlashingKeeper.SlashFractionDoubleSign(s.providerCtx()).Mul(valOldBalance.ToDec())
+			slashFraction = providerSlashingKeeper.SlashFractionDoubleSign(s.providerCtx())
 		}
+		slashedAmount := slashFraction.Mul(valOldBalance.ToDec())
 
 		resultingTokens := valOldBalance.Sub(slashedAmount.TruncateInt())
 		s.Require().Equal(resultingTokens, validatorJailed.GetTokens())

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -830,6 +830,24 @@ func (k Keeper) SetVscSendTimestamp(
 	store.Set(types.VscSendingTimestampKey(chainID, vscID), timeBz)
 }
 
+// GetVscSendTimestamp returns a VSC send timestamp by chainID and vscID
+//
+// Note: This method is used only for testing.
+func (k Keeper) GetVscSendTimestamp(ctx sdk.Context, chainID string, vscID uint64) (time.Time, bool) {
+	store := ctx.KVStore(k.storeKey)
+
+	timeBz := store.Get(types.VscSendingTimestampKey(chainID, vscID))
+	if timeBz == nil {
+		return time.Time{}, false
+	}
+
+	ts, err := sdk.ParseTimeBytes(timeBz)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return ts, true
+}
+
 // DeleteVscSendTimestamp removes from the store a specific VSC send timestamp
 // for the given chainID and vscID.
 func (k Keeper) DeleteVscSendTimestamp(ctx sdk.Context, chainID string, vscID uint64) {


### PR DESCRIPTION
Improves a couple slashing related e2e tests by:
1. Removing duplicate test/setup code in favor of test cases and if-statements (TestSendSlashPacketDowntime and TestSendSlashPacketDoubleSign were 90% the same, now they are one test method)
2. Removing a hack which previously reconstructed a VSC packet from local variables, and manually sent/received that packet using IBC testing functions
3. Using `providerSlashingKeeper.SlashFractionDowntime` instead of hardcoding an expected slash fraction

The second point here is needed to properly tie https://github.com/cosmos/interchain-security/pull/462 into existing e2e tests, the hack was faultily making e2e tests fail.