### PR TITLE
Renames AddPacket, AddAck methods in simibc utils

### DIFF
--- a/tests/difference/core/driver/core_test.go
+++ b/tests/difference/core/driver/core_test.go
@@ -189,7 +189,7 @@ func (s *CoreSuite) consumerSlash(val sdk.ConsAddress, h int64, isDowntime bool)
 		if e.Type == channeltypes.EventTypeSendPacket {
 			packet, err := channelkeeper.ReconstructPacketFromEvent(e)
 			s.Require().NoError(err)
-			s.simibc.Link.AddPacket(s.chainID(C), packet)
+			s.simibc.Link.AddOutboundPacket(s.chainID(C), packet)
 		}
 	}
 }

--- a/tests/difference/core/driver/setup.go
+++ b/tests/difference/core/driver/setup.go
@@ -571,7 +571,7 @@ func (b *Builder) sendEmptyVSCPacketToFinishHandshake() {
 
 	ack, err := simibc.TryRecvPacket(b.endpoint(P), b.endpoint(C), packet)
 
-	b.link.AddAck(b.chainID(C), ack, packet)
+	b.link.AddOutboundAck(b.chainID(C), ack, packet)
 
 	b.suite.Require().NoError(err)
 }
@@ -618,7 +618,7 @@ func (b *Builder) deliver(chainID string) {
 		if err != nil {
 			b.coordinator.Fatal("deliver")
 		}
-		b.link.AddAck(chainID, ack, p.Packet)
+		b.link.AddOutboundAck(chainID, ack, p.Packet)
 	}
 }
 
@@ -650,7 +650,7 @@ func (b *Builder) endBlock(chainID string) {
 		if e.Type == channeltypes.EventTypeSendPacket {
 			packet, _ := channelkeeper.ReconstructPacketFromEvent(e)
 			// Collect packets
-			b.link.AddPacket(chainID, packet)
+			b.link.AddOutboundPacket(chainID, packet)
 		}
 	}
 

--- a/testutil/simibc/ordered_link.go
+++ b/testutil/simibc/ordered_link.go
@@ -31,14 +31,14 @@ func MakeOrderedLink() OrderedLink {
 	}
 }
 
-// AddPacket adds an outbound packet from the sender to the counterparty.
-func (n OrderedLink) AddPacket(sender string, packet channeltypes.Packet) {
+// AddOutboundPacket adds an outbound packet from the sender to the counterparty.
+func (n OrderedLink) AddOutboundPacket(sender string, packet channeltypes.Packet) {
 	n.OutboxPackets[sender] = append(n.OutboxPackets[sender], Packet{packet, 0})
 }
 
-// AddAck adds an outbound ack, for future delivery to the sender of the packet
+// AddOutboundAck adds an outbound ack, for future delivery to the sender of the packet
 // being acked.
-func (n OrderedLink) AddAck(sender string, ack []byte, packet channeltypes.Packet) {
+func (n OrderedLink) AddOutboundAck(sender string, ack []byte, packet channeltypes.Packet) {
 	n.OutboxAcks[sender] = append(n.OutboxAcks[sender], Ack{ack, packet, 0})
 }
 

--- a/testutil/simibc/relayed_path.go
+++ b/testutil/simibc/relayed_path.go
@@ -73,7 +73,7 @@ func (f *RelayedPath) DeliverPackets(chainID string, num int) {
 		if err != nil {
 			f.t.Fatal("deliver")
 		}
-		f.Link.AddAck(chainID, ack, p.Packet)
+		f.Link.AddOutboundAck(chainID, ack, p.Packet)
 	}
 }
 
@@ -112,7 +112,7 @@ func (f *RelayedPath) EndAndBeginBlock(chainID string, dt time.Duration, preComm
 		if e.Type == channeltypes.EventTypeSendPacket {
 			packet, _ := channelkeeper.ReconstructPacketFromEvent(e)
 			// Collect packets
-			f.Link.AddPacket(chainID, packet)
+			f.Link.AddOutboundPacket(chainID, packet)
 		}
 	}
 


### PR DESCRIPTION
I'm making some improvements to the in memory fine grained testing framework and I'm trying to do it in small PRs.