### PR TITLE
Remove false vscID initialization 

### DIFF
--- a/x/ccv/provider/module.go
+++ b/x/ccv/provider/module.go
@@ -137,9 +137,6 @@ func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, data json.
 
 	am.keeper.InitGenesis(ctx, &genesisState)
 
-	// initialize validator update id
-	// TODO: Include in genesis and initialize from genesis value
-	am.keeper.SetValidatorSetUpdateId(ctx, 1)
 	return []abci.ValidatorUpdate{}
 }
 


### PR DESCRIPTION
Closes https://github.com/cosmos/interchain-security/issues/428

Note that the vscID is already initialized from genesis in InitGenesis, see https://github.com/cosmos/interchain-security/blob/e0cbf9a8f17cb03d03604954ef8685d82d518ea5/x/ccv/provider/keeper/genesis.go#L27