### PR TITLE
Improve how sent packets are stored in e2e tests 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -136,7 +136,7 @@ require (
 
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
-	github.com/cosmos/ibc-go/v3 => github.com/informalsystems/ibc-go/v3 v3.0.0-beta1.0.20221116144303-1e70792920f6
+	github.com/cosmos/ibc-go/v3 => github.com/informalsystems/ibc-go/v3 v3.0.0-beta1.0.20221121181828-c75c185d20b2
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/stretchr/testify => github.com/stretchr/testify v1.7.1
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2

--- a/go.sum
+++ b/go.sum
@@ -602,8 +602,8 @@ github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7P
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
-github.com/informalsystems/ibc-go/v3 v3.0.0-beta1.0.20221116144303-1e70792920f6 h1:e/G7C3YHFLY77ohtVCyxtDeGDGvRkbyu1UYOlqDbWDU=
-github.com/informalsystems/ibc-go/v3 v3.0.0-beta1.0.20221116144303-1e70792920f6/go.mod h1:HK6fQYzqivKkZ0Vgl/vh1kJz5D3dyKN2N/CWpEJvXgk=
+github.com/informalsystems/ibc-go/v3 v3.0.0-beta1.0.20221121181828-c75c185d20b2 h1:i9xbwqor18BxeFirWpH7N2qeJAl+VgydZN/R+S4KYks=
+github.com/informalsystems/ibc-go/v3 v3.0.0-beta1.0.20221121181828-c75c185d20b2/go.mod h1:HK6fQYzqivKkZ0Vgl/vh1kJz5D3dyKN2N/CWpEJvXgk=
 github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jedisct1/go-minisign v0.0.0-20190909160543-45766022959e/go.mod h1:G1CVv03EnqU1wYL2dFwXxW2An0az9JTl/ZsqXQeBlkU=
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -181,15 +181,15 @@ func relayAllCommittedPackets(
 	s *CCVTestSuite,
 	srcChain *ibctesting.TestChain,
 	path *ibctesting.Path,
-	portID string,
-	channelID string,
+	srcPortID string,
+	srcChannelID string,
 	expectedPackets int,
 ) {
 	// check that the packets are committed in  state
 	commitments := srcChain.App.GetIBCKeeper().ChannelKeeper.GetAllPacketCommitmentsAtChannel(
 		srcChain.GetContext(),
-		portID,
-		channelID,
+		srcPortID,
+		srcChannelID,
 	)
 	s.Require().Equal(expectedPackets, len(commitments),
 		"actual number of packet commitments does not match expectation")
@@ -197,7 +197,7 @@ func relayAllCommittedPackets(
 	// relay all packets from srcChain to counterparty
 	for _, commitment := range commitments {
 		// - get packets
-		packet, found := srcChain.GetSentPacket(commitment.Sequence)
+		packet, found := srcChain.GetSentPacket(commitment.Sequence, srcChannelID)
 		s.Require().True(found, "did not find sent packet")
 		// - relay the packet
 		err := path.RelayPacket(packet)


### PR DESCRIPTION
Closes #493 by referencing a new head of our [IBC fork](https://github.com/informalsystems/ibc-go/commits/interchain-security-2). See relevant IBC repo changes in https://github.com/informalsystems/ibc-go/pull/10