### PR TITLE
refactor changes in expired consumer handling

### DIFF
--- a/app/consumer-democracy/app.go
+++ b/app/consumer-democracy/app.go
@@ -785,11 +785,6 @@ func (app *App) GetE2eEvidenceKeeper() e2e.E2eEvidenceKeeper {
 	return app.EvidenceKeeper
 }
 
-// GetUpgradeKeeper implements the ConsumerApp interface.
-func (app *App) GetUpgradeKeeper() upgradekeeper.Keeper {
-	return app.UpgradeKeeper
-}
-
 // GetE2eStakingKeeper implements the ConsumerApp interface.
 func (app *App) GetE2eStakingKeeper() e2e.E2eStakingKeeper {
 	return app.StakingKeeper

--- a/app/consumer/app.go
+++ b/app/consumer/app.go
@@ -679,11 +679,6 @@ func (app *App) GetE2eEvidenceKeeper() e2e.E2eEvidenceKeeper {
 	return app.EvidenceKeeper
 }
 
-// GetUpgradeKeeper implements the ConsumerApp interface.
-func (app *App) GetUpgradeKeeper() upgradekeeper.Keeper {
-	return app.UpgradeKeeper
-}
-
 // TestingApp functions
 
 // GetBaseApp implements the TestingApp interface.

--- a/testutil/e2e/interfaces.go
+++ b/testutil/e2e/interfaces.go
@@ -13,7 +13,6 @@ import (
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"github.com/cosmos/cosmos-sdk/x/staking/types"
-	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
 	ibctesting "github.com/cosmos/ibc-go/v3/testing"
 	consumerkeeper "github.com/cosmos/interchain-security/x/ccv/consumer/keeper"
 	providerkeeper "github.com/cosmos/interchain-security/x/ccv/provider/keeper"
@@ -62,8 +61,6 @@ type ConsumerApp interface {
 	GetE2eSlashingKeeper() E2eSlashingKeeper
 	// Returns an evidence keeper interface with more capabilities than the expected_keepers interface
 	GetE2eEvidenceKeeper() E2eEvidenceKeeper
-	// Returns the upgrade keeper interface
-	GetUpgradeKeeper() upgradekeeper.Keeper
 }
 
 type DemocConsumerApp interface {

--- a/x/ccv/consumer/keeper/keeper.go
+++ b/x/ccv/consumer/keeper/keeper.go
@@ -244,10 +244,12 @@ func (k Keeper) GetPacketMaturityTime(ctx sdk.Context, vscId uint64) uint64 {
 	return binary.BigEndian.Uint64(bz)
 }
 
-// DeletePacketMaturityTime deletes the packet maturity time for a given received VSC packet id
-func (k Keeper) DeletePacketMaturityTime(ctx sdk.Context, vscId uint64) {
+// DeletePacketMaturityTimes deletes the packet maturity time for given received VSC packet ids
+func (k Keeper) DeletePacketMaturityTimes(ctx sdk.Context, vscIds ...uint64) {
 	store := ctx.KVStore(k.storeKey)
-	store.Delete(types.PacketMaturityTimeKey(vscId))
+	for _, vscId := range vscIds {
+		store.Delete(types.PacketMaturityTimeKey(vscId))
+	}
 }
 
 // VerifyProviderChain verifies that the chain trying to connect on the channel handshake

--- a/x/ccv/consumer/keeper/keeper_test.go
+++ b/x/ccv/consumer/keeper/keeper_test.go
@@ -92,7 +92,7 @@ func TestPacketMaturityTime(t *testing.T) {
 	consumerKeeper.SetPacketMaturityTime(ctx, 5, 15)
 	consumerKeeper.SetPacketMaturityTime(ctx, 6, 40)
 
-	consumerKeeper.DeletePacketMaturityTime(ctx, 6)
+	consumerKeeper.DeletePacketMaturityTimes(ctx, 6)
 
 	require.Equal(t, uint64(10), consumerKeeper.GetPacketMaturityTime(ctx, 1))
 	require.Equal(t, uint64(25), consumerKeeper.GetPacketMaturityTime(ctx, 2))
@@ -110,6 +110,12 @@ func TestPacketMaturityTime(t *testing.T) {
 		i++
 		return false // do not stop the iteration
 	})
+
+	// delete all vscs remaining in state
+	consumerKeeper.DeletePacketMaturityTimes(ctx, 1, 2, 5)
+	require.Equal(t, uint64(0), consumerKeeper.GetPacketMaturityTime(ctx, 1))
+	require.Equal(t, uint64(0), consumerKeeper.GetPacketMaturityTime(ctx, 2))
+	require.Equal(t, uint64(0), consumerKeeper.GetPacketMaturityTime(ctx, 5))
 }
 
 // TestCrossChainValidator tests the getter, setter, and deletion method for cross chain validator records

--- a/x/ccv/consumer/keeper/relay.go
+++ b/x/ccv/consumer/keeper/relay.go
@@ -91,6 +91,7 @@ func (k Keeper) QueueVSCMaturedPackets(ctx sdk.Context) {
 
 	currentTime := uint64(ctx.BlockTime().UnixNano())
 
+	maturedVscIds := []uint64{}
 	for maturityIterator.Valid() {
 		vscId := types.IdFromPacketMaturityTimeKey(maturityIterator.Key())
 		if currentTime >= binary.BigEndian.Uint64(maturityIterator.Value()) {
@@ -104,12 +105,14 @@ func (k Keeper) QueueVSCMaturedPackets(ctx sdk.Context) {
 				Type: types.VscMaturedPacket,
 				Data: vscPacket.GetBytes(),
 			})
-			k.DeletePacketMaturityTime(ctx, vscId)
+			maturedVscIds = append(maturedVscIds, vscId)
 		} else {
 			break
 		}
 		maturityIterator.Next()
 	}
+
+	k.DeletePacketMaturityTimes(ctx, maturedVscIds...)
 }
 
 // QueueSlashPacket appends a slash packet containing the given validator data and slashing info to queue.

--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -185,10 +185,11 @@ func (k Keeper) SendPacketsToChain(ctx sdk.Context, chainID, channelID string) {
 // QueueVSCPackets queues latest validator updates for every registered consumer chain
 func (k Keeper) QueueVSCPackets(ctx sdk.Context) {
 	valUpdateID := k.GetValidatorSetUpdateId(ctx) // curent valset update ID
-	// check whether there are changes in the validator set;
+	// get the validator updates from the staking module
 	valUpdates := k.stakingKeeper.GetValidatorUpdates(ctx)
 
 	k.IterateConsumerChains(ctx, func(ctx sdk.Context, chainID, clientID string) (stop bool) {
+		// check whether there are changes in the validator set;
 		// note that this also entails unbonding operations
 		// w/o changes in the voting power of the validators in the validator set
 		unbondingOps, _ := k.GetUnbondingOpsFromIndex(ctx, chainID, valUpdateID)

--- a/x/ccv/types/events.go
+++ b/x/ccv/types/events.go
@@ -10,8 +10,8 @@ const (
 
 	EventTypeExecuteConsumerChainSlash = "execute_consumer_chain_slash"
 	EventTypeFeeDistribution           = "fee_distribution"
-	EventTypeSendSlashPacket           = "send_slash_packet"
-	EventTypeSendMaturedVSCPacket      = "send_matured_vsc_packet"
+	EventTypeConsumerSlashRequest      = "consumer_slash_request"
+	EventTypeVSCMatured                = "vsc_matured"
 
 	AttributeKeyAckSuccess = "success"
 	AttributeKeyAck        = "acknowledgement"


### PR DESCRIPTION
Closes: #435 

This is a follow-up to PR #448 

Removed events were reintroduced.

Comment strings were updated. Deleting maturity time during iteration was refactored.