### PR TITLE
Danwt/key assignment unit tests

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -13,6 +13,7 @@ E2e tests are categorized into files as follows:
 - `stop_consumer.go` - e2e tests for the _Consumer Chain Removal_ sub-protocol
 - `normal_operations.go` - e2e tests for _normal operations_ of ICS enabled chains
 - `expired_client.go` - e2e tests for testing expired clients
+- `key_assignment.go` - e2e tests for testing key assignment
 - `instance_test.go` - ties the e2e test structure into golang's standard test mechanism, with appropriate definitions for concrete app types and setup callback
 
 To run the e2e tests defined in this repo on any arbitrary consumer and provider implementation, copy the pattern exemplified in `instance_test.go` and `specific_setup.go`

--- a/tests/e2e/channel_init.go
+++ b/tests/e2e/channel_init.go
@@ -37,7 +37,7 @@ func (suite *CCVTestSuite) TestConsumerGenesis() {
 	_, ok = suite.consumerApp.GetIBCKeeper().ClientKeeper.GetClientState(ctx, clientId)
 	suite.Require().True(ok)
 
-	suite.SetupCCVChannel()
+	suite.SetupCCVChannel(suite.path)
 
 	origTime := suite.consumerChain.GetContext().BlockTime()
 

--- a/tests/e2e/common.go
+++ b/tests/e2e/common.go
@@ -189,6 +189,7 @@ func relayAllCommittedPackets(
 	srcPortID string,
 	srcChannelID string,
 	expectedPackets int,
+	msgAndArgs ...interface{},
 ) {
 	// check that the packets are committed in  state
 	commitments := srcChain.App.GetIBCKeeper().ChannelKeeper.GetAllPacketCommitmentsAtChannel(
@@ -196,18 +197,26 @@ func relayAllCommittedPackets(
 		srcPortID,
 		srcChannelID,
 	)
-	s.Require().Equal(expectedPackets, len(commitments),
-		"actual number of packet commitments does not match expectation")
+	s.Require().Equal(
+		expectedPackets,
+		len(commitments),
+		fmt.Sprintf("actual number of packet commitments does not match expectation; %s", msgAndArgs...),
+	)
 
 	// relay all packets from srcChain to counterparty
 	for _, commitment := range commitments {
 		// - get packets
 		packet, found := srcChain.GetSentPacket(commitment.Sequence, srcChannelID)
-		s.Require().True(found, "did not find sent packet")
-
+		s.Require().True(
+			found,
+			fmt.Sprintf("did not find sent packet; %s", msgAndArgs...),
+		)
 		// - relay the packet
 		err := path.RelayPacket(packet)
-		s.Require().NoError(err)
+		s.Require().NoError(
+			err,
+			fmt.Sprintf("error while relaying packets; %s", msgAndArgs...),
+		)
 	}
 }
 

--- a/tests/e2e/distribution.go
+++ b/tests/e2e/distribution.go
@@ -14,7 +14,7 @@ import (
 func (s *CCVTestSuite) TestRewardsDistribution() {
 
 	//set up channel and delegate some tokens in order for validator set update to be sent to the consumer chain
-	s.SetupCCVChannel()
+	s.SetupCCVChannel(s.path)
 	s.SetupTransferChannel()
 	bondAmt := sdk.NewInt(10000000)
 	delAddr := s.providerChain.SenderAccount.GetAddress()

--- a/tests/e2e/expired_client.go
+++ b/tests/e2e/expired_client.go
@@ -20,7 +20,7 @@ import (
 func (s *CCVTestSuite) TestVSCPacketSendExpiredClient() {
 	providerKeeper := s.providerApp.GetProviderKeeper()
 
-	s.SetupCCVChannel()
+	s.SetupCCVChannel(s.path)
 
 	expireClient(s, Consumer)
 
@@ -85,7 +85,7 @@ func (s *CCVTestSuite) TestConsumerPacketSendExpiredClient() {
 	providerKeeper := s.providerApp.GetProviderKeeper()
 	consumerKeeper := s.consumerApp.GetConsumerKeeper()
 
-	s.SetupCCVChannel()
+	s.SetupCCVChannel(s.path)
 
 	// bond some tokens on provider to change validator powers
 	bondAmt := sdk.NewInt(1000000)

--- a/tests/e2e/key_assignment.go
+++ b/tests/e2e/key_assignment.go
@@ -1,0 +1,256 @@
+package e2e
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/cosmos/ibc-go/v3/testing/mock"
+	providerkeeper "github.com/cosmos/interchain-security/x/ccv/provider/keeper"
+	ccv "github.com/cosmos/interchain-security/x/ccv/types"
+	tmencoding "github.com/tendermint/tendermint/crypto/encoding"
+	tmprotocrypto "github.com/tendermint/tendermint/proto/tendermint/crypto"
+)
+
+func (s *CCVTestSuite) TestKeyAssignment() {
+	testCases := []struct {
+		name           string
+		assignFunc     func(*providerkeeper.Keeper) error
+		expError       bool
+		expPacketCount int
+	}{
+		{
+			"assignment during channel init", func(pk *providerkeeper.Keeper) error {
+				// key assignment
+				validator, consumerKey := generateNewConsumerKey(s, 0)
+				err := pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator, consumerKey)
+				if err != nil {
+					return err
+				}
+
+				// check that a VSCPacket is queued
+				s.providerChain.NextBlock()
+				pendingPackets := pk.GetPendingPackets(s.providerCtx(), s.consumerChain.ChainID)
+				s.Require().Len(pendingPackets, 1)
+
+				// establish CCV channel
+				s.SetupCCVChannel(s.path)
+
+				return nil
+			}, false, 2,
+		},
+		{
+			"assignment after channel init", func(pk *providerkeeper.Keeper) error {
+				// establish CCV channel
+				s.SetupCCVChannel(s.path)
+
+				// key assignment
+				validator, consumerKey := generateNewConsumerKey(s, 0)
+				err := pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator, consumerKey)
+				if err != nil {
+					return err
+				}
+				s.providerChain.NextBlock()
+
+				return nil
+			}, false, 2,
+		},
+		{
+			"assignment with power change", func(pk *providerkeeper.Keeper) error {
+				// establish CCV channel
+				s.SetupCCVChannel(s.path)
+
+				// key assignment
+				validator, consumerKey := generateNewConsumerKey(s, 0)
+				err := pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator, consumerKey)
+				if err != nil {
+					return err
+				}
+
+				// Bond some tokens on provider to change validator powers
+				bondAmt := sdk.NewInt(1000000)
+				delAddr := s.providerChain.SenderAccount.GetAddress()
+				delegate(s, delAddr, bondAmt)
+
+				s.providerChain.NextBlock()
+
+				return nil
+			}, false, 2,
+		},
+		{
+			"double same-key assignment in same block", func(pk *providerkeeper.Keeper) error {
+				// establish CCV channel
+				s.SetupCCVChannel(s.path)
+
+				// key assignment
+				validator, consumerKey := generateNewConsumerKey(s, 0)
+				err := pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator, consumerKey)
+				if err != nil {
+					return err
+				}
+
+				// same key assignment
+				err = pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator, consumerKey)
+				if err != nil {
+					return err
+				}
+				s.providerChain.NextBlock()
+
+				return nil
+			}, true, 2,
+		},
+		{
+			"double key assignment in same block", func(pk *providerkeeper.Keeper) error {
+				// establish CCV channel
+				s.SetupCCVChannel(s.path)
+
+				// key assignment
+				validator, consumerKey := generateNewConsumerKey(s, 0)
+				err := pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator, consumerKey)
+				if err != nil {
+					return err
+				}
+
+				// same key assignment
+				validator, consumerKey = generateNewConsumerKey(s, 0)
+				err = pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator, consumerKey)
+				if err != nil {
+					return err
+				}
+				s.providerChain.NextBlock()
+
+				return nil
+			}, false, 2,
+		},
+		{
+			"double same-key assignment in different blocks", func(pk *providerkeeper.Keeper) error {
+				// establish CCV channel
+				s.SetupCCVChannel(s.path)
+
+				// key assignment
+				validator, consumerKey := generateNewConsumerKey(s, 0)
+				err := pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator, consumerKey)
+				if err != nil {
+					return err
+				}
+				s.providerChain.NextBlock()
+
+				// same key assignment
+				err = pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator, consumerKey)
+				if err != nil {
+					return err
+				}
+				s.providerChain.NextBlock()
+
+				return nil
+			}, true, 2,
+		},
+		{
+			"double key assignment in different blocks", func(pk *providerkeeper.Keeper) error {
+				// establish CCV channel
+				s.SetupCCVChannel(s.path)
+
+				// key assignment
+				validator, consumerKey := generateNewConsumerKey(s, 0)
+				err := pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator, consumerKey)
+				if err != nil {
+					return err
+				}
+				s.providerChain.NextBlock()
+
+				// same key assignment
+				validator, consumerKey = generateNewConsumerKey(s, 0)
+				err = pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator, consumerKey)
+				if err != nil {
+					return err
+				}
+				s.providerChain.NextBlock()
+
+				return nil
+			}, false, 3,
+		},
+		// TODO: this test should pass if we manage to change the client update mode to sequential
+		// {
+		// 	"key assignment for all validators in the same block", func(pk *providerkeeper.Keeper) error {
+		// 		// establish CCV channel
+		// 		s.SetupCCVChannel(s.path)
+
+		// 		// key assignment
+		// 		for i, _ := range s.providerChain.Vals.Validators {
+		// 			validator, consumerKey := generateNewConsumerKey(s, i)
+		// 			err := pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator, consumerKey)
+		// 			if err != nil {
+		// 				return err
+		// 			}
+		// 		}
+		// 		// vscPakcketData := pk.GetPendingPackets(s.providerCtx(), s.consumerChain.ChainID)
+		// 		// s.Require().Len(vscPakcketData, 1)
+		// 		// s.Require().Len(vscPakcketData[0].ValidatorUpdates, 2*len(s.providerChain.Vals.Validators))
+
+		// 		s.providerChain.NextBlock()
+
+		// 		return nil
+		// 	}, false, 2,
+		// },
+	}
+	for i, tc := range testCases {
+		providerKeeper := s.providerApp.GetProviderKeeper()
+
+		err := tc.assignFunc(&providerKeeper)
+		if tc.expError {
+			s.Require().Error(err, "test: "+tc.name)
+		} else {
+			s.Require().NoError(err, "test: "+tc.name)
+		}
+
+		if !tc.expError {
+			// Bond some tokens on provider to change validator powers
+			bondAmt := sdk.NewInt(1000000)
+			delAddr := s.providerChain.SenderAccount.GetAddress()
+			delegate(s, delAddr, bondAmt)
+
+			// Send CCV packet to consumer
+			s.providerChain.NextBlock()
+
+			// Relay all VSC packets from provider to consumer
+			relayAllCommittedPackets(
+				s,
+				s.providerChain,
+				s.path,
+				ccv.ProviderPortID,
+				s.path.EndpointB.ChannelID,
+				tc.expPacketCount,
+				"test: "+tc.name,
+			)
+
+			// update clients
+			err := s.path.EndpointA.UpdateClient()
+			s.Require().NoError(err)
+			err = s.path.EndpointB.UpdateClient()
+			s.Require().NoError(err)
+		}
+
+		if i+1 < len(testCases) {
+			// reset suite to reset provider client
+			s.SetupTest()
+		}
+	}
+}
+
+// generateNewConsumerKey generate new consumer key for the validator with valIndex
+func generateNewConsumerKey(s *CCVTestSuite, valIndex int) (stakingtypes.Validator, tmprotocrypto.PublicKey) {
+	// get validator
+	s.Require().Less(valIndex, len(s.providerChain.Vals.Validators))
+	_, valAddr := s.getValByIdx(valIndex)
+	validator := s.getVal(s.providerCtx(), valAddr)
+
+	// generate new PrivValidator
+	privVal := mock.NewPV()
+	tmPubKey, err := privVal.GetPubKey()
+	s.Require().NoError(err)
+	pubKey, err := tmencoding.PubKeyToProto(tmPubKey)
+	s.Require().NoError(err)
+
+	// add Signer to the consumer chain
+	s.consumerChain.Signers[tmPubKey.Address().String()] = privVal
+
+	return validator, pubKey
+}

--- a/tests/e2e/setup.go
+++ b/tests/e2e/setup.go
@@ -6,8 +6,8 @@ import (
 
 	ibctmtypes "github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types"
 	e2eutil "github.com/cosmos/interchain-security/testutil/e2e"
-	icstestingutils "github.com/cosmos/interchain-security/testutil/ibc_testing"
 
+	icstestingutils "github.com/cosmos/interchain-security/testutil/ibc_testing"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
 	"github.com/cosmos/interchain-security/x/ccv/utils"
 
@@ -27,14 +27,24 @@ import (
 type CCVTestSuite struct {
 	suite.Suite
 	coordinator   *ibctesting.Coordinator
-	providerChain *ibctesting.TestChain
-	consumerChain *ibctesting.TestChain
-	providerApp   e2eutil.ProviderApp
-	consumerApp   e2eutil.ConsumerApp
-	path          *ibctesting.Path
-	transferPath  *ibctesting.Path
 	setupCallback SetupCallback
-	skippedTests  map[string]bool
+
+	providerChain *ibctesting.TestChain
+	providerApp   e2eutil.ProviderApp
+
+	// The first consumer chain among multiple.
+	consumerChain *ibctesting.TestChain
+	// The first consumer app among multiple.
+	consumerApp e2eutil.ConsumerApp
+	// The ccv path to the first consumer among multiple.
+	path *ibctesting.Path
+	// The transfer path to the first consumer among multiple.
+	transferPath *ibctesting.Path
+
+	// A map from consumer chain ID to its consumer bundle.
+	// The preferred way to access chains, apps, and paths when designing tests around multiple consumers.
+	consumerBundles map[string]*icstestingutils.ConsumerBundle
+	skippedTests    map[string]bool
 }
 
 // NewCCVTestSuite returns a new instance of CCVTestSuite, ready to be tested against using suite.Run().
@@ -42,13 +52,13 @@ func NewCCVTestSuite[Tp e2eutil.ProviderApp, Tc e2eutil.ConsumerApp](
 	providerAppIniter ibctesting.AppIniter, consumerAppIniter ibctesting.AppIniter, skippedTests []string) *CCVTestSuite {
 
 	ccvSuite := new(CCVTestSuite)
-	
+
+	// Define callback called before each test.
 	ccvSuite.setupCallback = func(t *testing.T) (
 		*ibctesting.Coordinator,
 		*ibctesting.TestChain,
-		*ibctesting.TestChain,
 		e2eutil.ProviderApp,
-		e2eutil.ConsumerApp,
+		map[string]*icstestingutils.ConsumerBundle,
 	) {
 		// Instantiate the test coordinator.
 		coordinator := ibctesting.NewCoordinator(t, 0)
@@ -58,14 +68,15 @@ func NewCCVTestSuite[Tp e2eutil.ProviderApp, Tc e2eutil.ConsumerApp](
 		provider, providerApp := icstestingutils.AddProvider[Tp](
 			coordinator, t, providerAppIniter)
 
+		numConsumers := 5
+
 		// Add specified number of consumers to coordinator, store returned test chains and apps.
 		// Concrete consumer app type is passed to the generic function here.
-		consumers, consumerApps := icstestingutils.AddConsumers[Tc](
-			coordinator, t, 1, consumerAppIniter)
+		consumerBundles := icstestingutils.AddConsumers[Tc](
+			coordinator, t, numConsumers, consumerAppIniter)
 
 		// Pass variables to suite.
-		// TODO: accept multiple consumers here
-		return coordinator, provider, consumers[0], providerApp, consumerApps[0]
+		return coordinator, provider, providerApp, consumerBundles
 	}
 
 	ccvSuite.skippedTests = make(map[string]bool)
@@ -80,9 +91,8 @@ func NewCCVTestSuite[Tp e2eutil.ProviderApp, Tc e2eutil.ConsumerApp](
 type SetupCallback func(t *testing.T) (
 	coord *ibctesting.Coordinator,
 	providerChain *ibctesting.TestChain,
-	consumerChain *ibctesting.TestChain,
 	providerApp e2eutil.ProviderApp,
-	consumerApp e2eutil.ConsumerApp,
+	consumerBundles map[string]*icstestingutils.ConsumerBundle,
 )
 
 func (suite *CCVTestSuite) BeforeTest(suiteName, testName string) {
@@ -96,115 +106,143 @@ func (suite *CCVTestSuite) SetupTest() {
 
 	// Instantiate new test utils using callback
 	suite.coordinator, suite.providerChain,
-		suite.consumerChain, suite.providerApp,
-		suite.consumerApp = suite.setupCallback(suite.T())
+		suite.providerApp, suite.consumerBundles = suite.setupCallback(suite.T())
 
-	providerKeeper := suite.providerApp.GetProviderKeeper()
-	consumerKeeper := suite.consumerApp.GetConsumerKeeper()
+	// valsets must match between provider and all consumers
+	for _, bundle := range suite.consumerBundles {
 
-	// valsets must match
-	providerValUpdates := tmtypes.TM2PB.ValidatorUpdates(suite.providerChain.Vals)
-	consumerValUpdates := tmtypes.TM2PB.ValidatorUpdates(suite.consumerChain.Vals)
-	suite.Require().True(len(providerValUpdates) == len(consumerValUpdates), "initial valset not matching")
-	for i := 0; i < len(providerValUpdates); i++ {
-		addr1 := utils.GetChangePubKeyAddress(providerValUpdates[i])
-		addr2 := utils.GetChangePubKeyAddress(consumerValUpdates[i])
-		suite.Require().True(bytes.Equal(addr1, addr2), "validator mismatch")
+		providerValUpdates := tmtypes.TM2PB.ValidatorUpdates(suite.providerChain.Vals)
+		consumerValUpdates := tmtypes.TM2PB.ValidatorUpdates(bundle.Chain.Vals)
+		suite.Require().True(len(providerValUpdates) == len(consumerValUpdates), "initial valset not matching")
+		for i := 0; i < len(providerValUpdates); i++ {
+			addr1 := utils.GetChangePubKeyAddress(providerValUpdates[i])
+			addr2 := utils.GetChangePubKeyAddress(consumerValUpdates[i])
+			suite.Require().True(bytes.Equal(addr1, addr2), "validator mismatch")
+		}
+		// Move each consumer to next block
+		bundle.Chain.NextBlock()
 	}
 
-	// move both chains to the next block
+	// move provider to next block
 	suite.providerChain.NextBlock()
-	suite.consumerChain.NextBlock()
 
-	// create consumer client on provider chain and set as consumer client for consumer chainID in provider keeper.
-	err := providerKeeper.CreateConsumerClient(
-		suite.providerCtx(),
-		suite.consumerChain.ChainID,
-		suite.consumerChain.LastHeader.GetHeight().(clienttypes.Height),
-		false,
-	)
-	suite.Require().NoError(err)
+	providerKeeper := suite.providerApp.GetProviderKeeper()
+
+	for chainID, bundle := range suite.consumerBundles {
+		// For each consumer, create client to that consumer on the provider chain.
+		err := providerKeeper.CreateConsumerClient(
+			suite.providerCtx(),
+			chainID,
+			bundle.Chain.LastHeader.GetHeight().(clienttypes.Height),
+			false,
+		)
+		suite.Require().NoError(err)
+	}
+
 	// move provider to next block to commit the state
 	suite.providerChain.NextBlock()
 
-	// initialize the consumer chain with the genesis state stored on the provider
-	consumerGenesisState, found := providerKeeper.GetConsumerGenesis(
-		suite.providerCtx(),
-		suite.consumerChain.ChainID,
-	)
-	suite.Require().True(found, "consumer genesis not found")
-	consumerKeeper.InitGenesis(suite.consumerCtx(), &consumerGenesisState)
+	// initialize each consumer chain with it's corresponding genesis state
+	// stored on the provider.
+	for chainID, bundle := range suite.consumerBundles {
 
-	// Confirm client and cons state for consumer were set correctly in InitGenesis
-	consumerEndpointClientState, consumerEndpointConsState := suite.GetConsumerEndpointClientAndConsState()
-	suite.Require().Equal(consumerGenesisState.ProviderClientState, consumerEndpointClientState)
-	suite.Require().Equal(consumerGenesisState.ProviderConsensusState, consumerEndpointConsState)
+		consumerGenesisState, found := providerKeeper.GetConsumerGenesis(
+			suite.providerCtx(),
+			chainID,
+		)
+		suite.Require().True(found, "consumer genesis not found")
 
-	// create path for the CCV channel
-	suite.path = ibctesting.NewPath(suite.consumerChain, suite.providerChain)
+		consumerKeeper := bundle.GetKeeper()
+		consumerKeeper.InitGenesis(bundle.GetCtx(), &consumerGenesisState)
 
-	// Set provider endpoint's clientID
-	providerEndpointClientID, found := providerKeeper.GetConsumerClientId(
-		suite.providerCtx(),
-		suite.consumerChain.ChainID,
-	)
-	suite.Require().True(found, "provider endpoint clientID not found")
-	suite.path.EndpointB.ClientID = providerEndpointClientID
+		// Confirm client and cons state for consumer were set correctly in InitGenesis
+		consumerEndpointClientState,
+			consumerEndpointConsState := suite.GetConsumerEndpointClientAndConsState(*bundle)
+		suite.Require().Equal(consumerGenesisState.ProviderClientState, consumerEndpointClientState)
+		suite.Require().Equal(consumerGenesisState.ProviderConsensusState, consumerEndpointConsState)
 
-	// Set consumer endpoint's clientID
-	consumerEndpointClientID, found := consumerKeeper.GetProviderClientID(suite.consumerChain.GetContext())
-	suite.Require().True(found, "consumer endpoint clientID not found")
-	suite.path.EndpointA.ClientID = consumerEndpointClientID
+		// create path for the CCV channel
+		bundle.Path = ibctesting.NewPath(bundle.Chain, suite.providerChain)
 
-	// Note: suite.path.EndpointA.ClientConfig and suite.path.EndpointB.ClientConfig are not populated,
-	// since these IBC testing package fields are unused in our tests.
+		// Set provider endpoint's clientID for each consumer
+		providerEndpointClientID, found := providerKeeper.GetConsumerClientId(
+			suite.providerCtx(),
+			chainID,
+		)
+		suite.Require().True(found, "provider endpoint clientID not found")
+		bundle.Path.EndpointB.ClientID = providerEndpointClientID
 
-	// Confirm client config is now correct
-	suite.ValidateEndpointsClientConfig()
+		// Set consumer endpoint's clientID
+		consumerKeeper = bundle.GetKeeper()
+		consumerEndpointClientID, found := consumerKeeper.GetProviderClientID(bundle.GetCtx())
+		suite.Require().True(found, "consumer endpoint clientID not found")
+		bundle.Path.EndpointA.ClientID = consumerEndpointClientID
 
-	// - channel config
-	suite.path.EndpointA.ChannelConfig.PortID = ccv.ConsumerPortID
-	suite.path.EndpointB.ChannelConfig.PortID = ccv.ProviderPortID
-	suite.path.EndpointA.ChannelConfig.Version = ccv.Version
-	suite.path.EndpointB.ChannelConfig.Version = ccv.Version
-	suite.path.EndpointA.ChannelConfig.Order = channeltypes.ORDERED
-	suite.path.EndpointB.ChannelConfig.Order = channeltypes.ORDERED
+		// Note: suite.path.EndpointA.ClientConfig and suite.path.EndpointB.ClientConfig are not populated,
+		// since these IBC testing package fields are unused in our tests.
 
-	// create path for the transfer channel
-	suite.transferPath = ibctesting.NewPath(suite.consumerChain, suite.providerChain)
-	suite.transferPath.EndpointA.ChannelConfig.PortID = transfertypes.PortID
-	suite.transferPath.EndpointB.ChannelConfig.PortID = transfertypes.PortID
-	suite.transferPath.EndpointA.ChannelConfig.Version = transfertypes.Version
-	suite.transferPath.EndpointB.ChannelConfig.Version = transfertypes.Version
+		// Confirm client config is now correct
+		suite.ValidateEndpointsClientConfig(*bundle)
+
+		// - channel config
+		bundle.Path.EndpointA.ChannelConfig.PortID = ccv.ConsumerPortID
+		bundle.Path.EndpointB.ChannelConfig.PortID = ccv.ProviderPortID
+		bundle.Path.EndpointA.ChannelConfig.Version = ccv.Version
+		bundle.Path.EndpointB.ChannelConfig.Version = ccv.Version
+		bundle.Path.EndpointA.ChannelConfig.Order = channeltypes.ORDERED
+		bundle.Path.EndpointB.ChannelConfig.Order = channeltypes.ORDERED
+
+		// create path for the transfer channel
+		bundle.TransferPath = ibctesting.NewPath(bundle.Chain, suite.providerChain)
+		bundle.TransferPath.EndpointA.ChannelConfig.PortID = transfertypes.PortID
+		bundle.TransferPath.EndpointB.ChannelConfig.PortID = transfertypes.PortID
+		bundle.TransferPath.EndpointA.ChannelConfig.Version = transfertypes.Version
+		bundle.TransferPath.EndpointB.ChannelConfig.Version = transfertypes.Version
+	}
+
+	// Support tests that were written before multiple consumers were supported.
+	firstBundle := suite.getFirstBundle()
+	suite.consumerApp = firstBundle.App
+	suite.consumerChain = firstBundle.Chain
+	suite.path = firstBundle.Path
+	suite.transferPath = firstBundle.TransferPath
 }
 
-func (suite *CCVTestSuite) SetupCCVChannel() {
-	suite.StartSetupCCVChannel()
-	suite.CompleteSetupCCVChannel()
+func (suite *CCVTestSuite) SetupAllCCVChannels() {
+	for _, bundle := range suite.consumerBundles {
+		suite.SetupCCVChannel(bundle.Path)
+	}
 }
 
-func (suite *CCVTestSuite) StartSetupCCVChannel() {
-	suite.coordinator.CreateConnections(suite.path)
+func (suite *CCVTestSuite) SetupCCVChannel(path *ibctesting.Path) {
+	suite.StartSetupCCVChannel(path)
+	suite.CompleteSetupCCVChannel(path)
+}
 
-	err := suite.path.EndpointA.ChanOpenInit()
+func (suite *CCVTestSuite) StartSetupCCVChannel(path *ibctesting.Path) {
+	suite.coordinator.CreateConnections(path)
+
+	err := path.EndpointA.ChanOpenInit()
 	suite.Require().NoError(err)
 
-	err = suite.path.EndpointB.ChanOpenTry()
+	err = path.EndpointB.ChanOpenTry()
 	suite.Require().NoError(err)
 }
 
-func (suite *CCVTestSuite) CompleteSetupCCVChannel() {
-	err := suite.path.EndpointA.ChanOpenAck()
+func (suite *CCVTestSuite) CompleteSetupCCVChannel(path *ibctesting.Path) {
+	err := path.EndpointA.ChanOpenAck()
 	suite.Require().NoError(err)
 
-	err = suite.path.EndpointB.ChanOpenConfirm()
+	err = path.EndpointB.ChanOpenConfirm()
 	suite.Require().NoError(err)
 
 	// ensure counterparty is up to date
-	err = suite.path.EndpointA.UpdateClient()
+	err = path.EndpointA.UpdateClient()
 	suite.Require().NoError(err)
 }
 
+// TODO: Make SetupTransferChannel functional for multiple consumers by pattern matching SetupCCVChannel.
+// See: https://github.com/cosmos/interchain-security/issues/506
 func (suite *CCVTestSuite) SetupTransferChannel() {
 	// transfer path will use the same connection as ccv path
 
@@ -234,12 +272,13 @@ func (suite *CCVTestSuite) SetupTransferChannel() {
 	suite.Require().NoError(err)
 }
 
-func (s CCVTestSuite) ValidateEndpointsClientConfig() {
-	consumerKeeper := s.consumerApp.GetConsumerKeeper()
+func (s CCVTestSuite) ValidateEndpointsClientConfig(consumerBundle icstestingutils.ConsumerBundle) {
+	consumerKeeper := consumerBundle.GetKeeper()
 	providerStakingKeeper := s.providerApp.GetStakingKeeper()
 
-	consumerUnbondingPeriod := consumerKeeper.GetUnbondingPeriod(s.consumerCtx())
-	cs, ok := s.providerApp.GetIBCKeeper().ClientKeeper.GetClientState(s.providerCtx(), s.path.EndpointB.ClientID)
+	consumerUnbondingPeriod := consumerKeeper.GetUnbondingPeriod(consumerBundle.GetCtx())
+	cs, ok := s.providerApp.GetIBCKeeper().ClientKeeper.GetClientState(s.providerCtx(),
+		consumerBundle.Path.EndpointB.ClientID)
 	s.Require().True(ok)
 	s.Require().Equal(
 		consumerUnbondingPeriod,
@@ -248,7 +287,8 @@ func (s CCVTestSuite) ValidateEndpointsClientConfig() {
 	)
 
 	providerUnbondingPeriod := providerStakingKeeper.UnbondingTime(s.providerCtx())
-	cs, ok = s.consumerApp.GetIBCKeeper().ClientKeeper.GetClientState(s.consumerCtx(), s.path.EndpointA.ClientID)
+	cs, ok = consumerBundle.App.GetIBCKeeper().ClientKeeper.GetClientState(
+		consumerBundle.GetCtx(), consumerBundle.Path.EndpointA.ClientID)
 	s.Require().True(ok)
 	s.Require().Equal(
 		providerUnbondingPeriod,

--- a/tests/e2e/stop_consumer.go
+++ b/tests/e2e/stop_consumer.go
@@ -48,7 +48,7 @@ func (s *CCVTestSuite) TestStopConsumerChain() {
 	}{
 		{
 			func(suite *CCVTestSuite) error {
-				suite.SetupCCVChannel()
+				suite.SetupCCVChannel(s.path)
 				suite.SetupTransferChannel()
 				return nil
 			},
@@ -99,7 +99,7 @@ func (s *CCVTestSuite) TestStopConsumerChain() {
 // TODO Simon: implement OnChanCloseConfirm in IBC-GO testing to close the consumer chain's channel end
 func (s *CCVTestSuite) TestStopConsumerOnChannelClosed() {
 	// init the CCV channel states
-	s.SetupCCVChannel()
+	s.SetupCCVChannel(s.path)
 	s.SetupTransferChannel()
 	s.SendEmptyVSCPacket()
 
@@ -179,7 +179,7 @@ func (s *CCVTestSuite) checkConsumerChainIsRemoved(chainID string, lockUbd bool,
 // when the provider channel was established and then closed
 func (suite *CCVTestSuite) TestProviderChannelClosed() {
 
-	suite.SetupCCVChannel()
+	suite.SetupCCVChannel(suite.path)
 	// establish provider channel with a first VSC packet
 	suite.SendEmptyVSCPacket()
 

--- a/tests/e2e/unbonding.go
+++ b/tests/e2e/unbonding.go
@@ -79,7 +79,7 @@ func (s *CCVTestSuite) TestUndelegationNormalOperation() {
 		consumerKeeper := s.consumerApp.GetConsumerKeeper()
 		stakingKeeper := s.providerApp.GetE2eStakingKeeper()
 
-		s.SetupCCVChannel()
+		s.SetupCCVChannel(s.path)
 
 		// set VSC timeout period to not trigger the removal of the consumer chain
 		providerUnbondingPeriod := stakingKeeper.UnbondingTime(s.providerCtx())
@@ -129,7 +129,7 @@ func (s *CCVTestSuite) TestUndelegationNormalOperation() {
 func (s *CCVTestSuite) TestUndelegationVscTimeout() {
 	providerKeeper := s.providerApp.GetProviderKeeper()
 
-	s.SetupCCVChannel()
+	s.SetupCCVChannel(s.path)
 
 	// set VSC timeout period to trigger the removal of the consumer chain
 	vscTimeout := providerKeeper.GetVscTimeoutPeriod(s.providerCtx())
@@ -263,7 +263,7 @@ func (s *CCVTestSuite) TestUndelegationDuringInit() {
 			)
 
 			// complete CCV channel setup
-			s.SetupCCVChannel()
+			s.SetupCCVChannel(s.path)
 
 			// relay VSC packets from provider to consumer
 			relayAllCommittedPackets(s, s.providerChain, s.path, ccv.ProviderPortID, s.path.EndpointB.ChannelID, 2)
@@ -304,8 +304,10 @@ func (s *CCVTestSuite) TestUnbondingNoConsumer() {
 	providerKeeper := s.providerApp.GetProviderKeeper()
 	providerStakingKeeper := s.providerApp.GetE2eStakingKeeper()
 
-	// remove the consumer chain, which was already registered during setup
-	providerKeeper.DeleteConsumerClientId(s.providerCtx(), s.consumerChain.ChainID)
+	// remove all consumer chains, which were already registered during setup
+	for chainID := range s.consumerBundles {
+		providerKeeper.DeleteConsumerClientId(s.providerCtx(), chainID)
+	}
 
 	// delegate bondAmt and undelegate 1/2 of it
 	bondAmt := sdk.NewInt(10000000)
@@ -379,7 +381,7 @@ func (s *CCVTestSuite) TestRedelegationNoConsumer() {
 // TestRedelegationWithConsumer tests a redelegate transaction submitted on a provider chain
 // when the unbonding period elapses first on the provider chain
 func (s *CCVTestSuite) TestRedelegationProviderFirst() {
-	s.SetupCCVChannel()
+	s.SetupCCVChannel(s.path)
 	s.SetupTransferChannel()
 
 	providerKeeper := s.providerApp.GetProviderKeeper()

--- a/tests/e2e/valset_update.go
+++ b/tests/e2e/valset_update.go
@@ -13,7 +13,7 @@ import (
 
 // TestPacketRoundtrip tests a CCV packet roundtrip when tokens are bonded on provider
 func (s *CCVTestSuite) TestPacketRoundtrip() {
-	s.SetupCCVChannel()
+	s.SetupCCVChannel(s.path)
 	s.SetupTransferChannel()
 
 	// Bond some tokens on provider to change validator powers
@@ -41,7 +41,7 @@ func (suite *CCVTestSuite) TestQueueAndSendVSCMaturedPackets() {
 	consumerKeeper := suite.consumerApp.GetConsumerKeeper()
 
 	// setup CCV channel
-	suite.SetupCCVChannel()
+	suite.SetupCCVChannel(suite.path)
 
 	// send 3 packets to consumer chain at different times
 	pk, err := cryptocodec.FromTmPubKeyInterface(suite.providerChain.Vals.Validators[0].PubKey)

--- a/testutil/ibc_testing/generic_setup.go
+++ b/testutil/ibc_testing/generic_setup.go
@@ -3,8 +3,10 @@ package ibc_testing
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	ibctesting "github.com/cosmos/ibc-go/v3/testing"
-	"github.com/cosmos/interchain-security/testutil/e2e"
+	e2eutil "github.com/cosmos/interchain-security/testutil/e2e"
+	consumerkeeper "github.com/cosmos/interchain-security/x/ccv/consumer/keeper"
 )
 
 // Contains generic setup code for running e2e tests against a provider, consumer,
@@ -12,12 +14,32 @@ import (
 // to run e2e tests against your app.go implementations!
 
 var (
+	FirstConsumerChainID = ibctesting.GetChainID(2)
 	provChainID          = ibctesting.GetChainID(1)
-	democConsumerChainID = ibctesting.GetChainID(2)
+	democConsumerChainID = ibctesting.GetChainID(5000)
 )
 
+// ConsumerBundle serves as a way to store useful in-mem consumer app chain state
+// and relevant IBC paths in the context of CCV e2e testing.
+type ConsumerBundle struct {
+	Chain        *ibctesting.TestChain
+	App          e2eutil.ConsumerApp
+	Path         *ibctesting.Path
+	TransferPath *ibctesting.Path
+}
+
+// GetCtx returns the context for the ConsumerBundle
+func (cb ConsumerBundle) GetCtx() sdk.Context {
+	return cb.Chain.GetContext()
+}
+
+// GetKeeper returns the keeper for the ConsumerBundle
+func (cb ConsumerBundle) GetKeeper() consumerkeeper.Keeper {
+	return cb.App.GetConsumerKeeper()
+}
+
 // AddProvider adds a new provider chain to the coordinator and returns the test chain and app type
-func AddProvider[T e2e.ProviderApp](coordinator *ibctesting.Coordinator, t *testing.T, appIniter ibctesting.AppIniter) (
+func AddProvider[T e2eutil.ProviderApp](coordinator *ibctesting.Coordinator, t *testing.T, appIniter ibctesting.AppIniter) (
 	*ibctesting.TestChain, T) {
 
 	provider := ibctesting.NewTestChain(t, coordinator, appIniter, provChainID)
@@ -27,7 +49,7 @@ func AddProvider[T e2e.ProviderApp](coordinator *ibctesting.Coordinator, t *test
 }
 
 // AddDemocracyConsumer adds a new democ consumer chain to the coordinator and returns the test chain and app type
-func AddDemocracyConsumer[T e2e.DemocConsumerApp](coordinator *ibctesting.Coordinator, t *testing.T,
+func AddDemocracyConsumer[T e2eutil.DemocConsumerApp](coordinator *ibctesting.Coordinator, t *testing.T,
 	appIniter ibctesting.AppIniter) (*ibctesting.TestChain, T) {
 
 	democConsumer := ibctesting.NewTestChain(t, coordinator, appIniter, democConsumerChainID)
@@ -40,23 +62,23 @@ func AddDemocracyConsumer[T e2e.DemocConsumerApp](coordinator *ibctesting.Coordi
 // The new consumers are initialized with the valset of the existing provider chain.
 //
 // This method must be called after AddProvider.
-func AddConsumers[T e2e.ConsumerApp](coordinator *ibctesting.Coordinator,
-	t *testing.T, numConsumers int, appIniter ibctesting.AppIniter) ([]*ibctesting.TestChain, []T) {
+func AddConsumers[T e2eutil.ConsumerApp](coordinator *ibctesting.Coordinator,
+	t *testing.T, numConsumers int, appIniter ibctesting.AppIniter) map[string]*ConsumerBundle {
 
 	providerChain := coordinator.GetChain(provChainID)
 
-	// Instantiate specified number of consumers, add them to coordinator, and returned chain/app slices
-	consumerChains := []*ibctesting.TestChain{}
-	consumerApps := []T{}
+	// Instantiate specified number of consumer bundles, add each consumer chain to coordinator
+	consumerBundles := make(map[string]*ConsumerBundle)
 	for i := 0; i < numConsumers; i++ {
 		chainID := ibctesting.GetChainID(i + 2)
 		testChain := ibctesting.NewTestChainWithValSet(t, coordinator,
 			appIniter, chainID, providerChain.Vals, providerChain.Signers)
 
 		coordinator.Chains[chainID] = testChain
-		consumerChains = append(consumerChains, testChain)
-		consumerApps = append(consumerApps, testChain.App.(T))
+		consumerBundles[chainID] = &ConsumerBundle{
+			Chain: testChain,
+			App:   testChain.App.(T),
+		}
 	}
-
-	return consumerChains, consumerApps
+	return consumerBundles
 }

--- a/x/ccv/provider/keeper/key_assignment.go
+++ b/x/ccv/provider/keeper/key_assignment.go
@@ -423,7 +423,11 @@ func (k Keeper) AssignConsumerKey(
 		}
 
 		// check whether the validator is valid, i.e., its power is positive
-		if power := k.stakingKeeper.GetLastValidatorPower(ctx, sdk.ValAddress(validator.OperatorAddress)); power > 0 {
+		providerValidatorAddr, err := sdk.ValAddressFromBech32(validator.OperatorAddress)
+		if err != nil {
+			return err
+		}
+		if power := k.stakingKeeper.GetLastValidatorPower(ctx, providerValidatorAddr); power > 0 {
 			// to enable multiple calls of AssignConsumerKey in the same block by the same validator
 			// the key assignment replacement should not be overwritten
 			if _, _, found := k.GetKeyAssignmentReplacement(ctx, chainID, providerAddr); !found {

--- a/x/ccv/provider/keeper/key_assignment.go
+++ b/x/ccv/provider/keeper/key_assignment.go
@@ -394,7 +394,7 @@ func (k Keeper) AssignConsumerKey(
 	if _, found := k.GetValidatorByConsumerAddr(ctx, chainID, consumerAddr); found {
 		// mapping already exists; return error
 		return sdkerrors.Wrapf(
-			types.ErrInvalidConsumerConsensusPubKey, "consumer key already exists",
+			types.ErrConsumerKeyExists, "consumer key already exists",
 		)
 	}
 

--- a/x/ccv/provider/keeper/key_assignment_test.go
+++ b/x/ccv/provider/keeper/key_assignment_test.go
@@ -600,6 +600,77 @@ func TestAssignConsensusKeyForConsumerChain(t *testing.T) {
 				require.Equal(t, providerIdentities[0].SDKConsAddress(), providerAddr)
 			},
 		},
+		// (TODO: see https://github.com/cosmos/interchain-security/issues/503)
+		// {
+		// 	name: "3",
+		// 	mockSetup: func(ctx sdk.Context, k providerkeeper.Keeper, mocks testkeeper.MockedKeepers) {
+		// 	},
+		// 	doActions: func(ctx sdk.Context, k providerkeeper.Keeper) {
+		// 	},
+		// },
+		{
+			name: "4",
+			mockSetup: func(ctx sdk.Context, k providerkeeper.Keeper, mocks testkeeper.MockedKeepers) {
+			},
+			doActions: func(ctx sdk.Context, k providerkeeper.Keeper) {
+				err := k.AssignConsumerKey(ctx, chainID,
+					providerIdentities[0].SDKStakingValidator(),
+					consumerIdentities[0].TMProtoCryptoPublicKey(),
+				)
+				require.NoError(t, err)
+				providerAddr, found := k.GetValidatorByConsumerAddr(ctx, chainID, consumerIdentities[0].SDKConsAddress())
+				require.True(t, found)
+				require.Equal(t, providerIdentities[0].SDKConsAddress(), providerAddr)
+			},
+		},
+		{
+			name: "5",
+			mockSetup: func(ctx sdk.Context, k providerkeeper.Keeper, mocks testkeeper.MockedKeepers) {
+			},
+			doActions: func(ctx sdk.Context, k providerkeeper.Keeper) {
+				err := k.AssignConsumerKey(ctx, chainID,
+					providerIdentities[0].SDKStakingValidator(),
+					consumerIdentities[0].TMProtoCryptoPublicKey(),
+				)
+				require.NoError(t, err)
+				err = k.AssignConsumerKey(ctx, chainID,
+					providerIdentities[0].SDKStakingValidator(),
+					consumerIdentities[1].TMProtoCryptoPublicKey(),
+				)
+				require.NoError(t, err)
+				providerAddr, found := k.GetValidatorByConsumerAddr(ctx, chainID, consumerIdentities[1].SDKConsAddress())
+				require.True(t, found)
+				require.Equal(t, providerIdentities[0].SDKConsAddress(), providerAddr)
+			},
+		},
+		{
+			name: "6",
+			mockSetup: func(ctx sdk.Context, k providerkeeper.Keeper, mocks testkeeper.MockedKeepers) {
+			},
+			doActions: func(ctx sdk.Context, k providerkeeper.Keeper) {
+				err := k.AssignConsumerKey(ctx, chainID,
+					providerIdentities[0].SDKStakingValidator(),
+					consumerIdentities[0].TMProtoCryptoPublicKey(),
+				)
+				require.NoError(t, err)
+				err = k.AssignConsumerKey(ctx, chainID,
+					providerIdentities[1].SDKStakingValidator(),
+					consumerIdentities[0].TMProtoCryptoPublicKey(),
+				)
+				require.Error(t, err)
+				providerAddr, found := k.GetValidatorByConsumerAddr(ctx, chainID, consumerIdentities[0].SDKConsAddress())
+				require.True(t, found)
+				require.Equal(t, providerIdentities[0].SDKConsAddress(), providerAddr)
+			},
+		},
+		// (TODO: see https://github.com/cosmos/interchain-security/issues/503)
+		// {
+		// 	name: "7",
+		// 	mockSetup: func(ctx sdk.Context, k providerkeeper.Keeper, mocks testkeeper.MockedKeepers) {
+		// 	},
+		// 	doActions: func(ctx sdk.Context, k providerkeeper.Keeper) {
+		// 	},
+		// },
 	}
 
 	for _, tc := range testCases {

--- a/x/ccv/provider/types/errors.go
+++ b/x/ccv/provider/types/errors.go
@@ -15,4 +15,5 @@ var (
 	ErrConsumerKeyNotFound             = sdkerrors.Register(ModuleName, 7, "consumer key not found")
 	ErrNoValidatorConsumerAddress      = sdkerrors.Register(ModuleName, 8, "error getting validator consumer address")
 	ErrNoValidatorProviderAddress      = sdkerrors.Register(ModuleName, 9, "error getting validator provider address")
+	ErrConsumerKeyExists               = sdkerrors.Register(ModuleName, 10, "consumer consensus public key already exists")
 )


### PR DESCRIPTION
Adds some unit tests and random testing. It's a bit unfinished, the slash query isn't properly checked yet and the code is unpolished. But it's something.

Tests:

- assignment specific cases
- random assignents interleaved with applying mapping to random updates
- pruning property
- validator set replication

Does not test:

- Reverse lookup for slashing