### PR TITLE
update provider genesis validation

### DIFF
--- a/x/ccv/provider/types/genesis.go
+++ b/x/ccv/provider/types/genesis.go
@@ -1,19 +1,19 @@
 package types
 
 import (
+	"fmt"
 	"strings"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	host "github.com/cosmos/ibc-go/v3/modules/core/24-host"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
-	types "github.com/cosmos/interchain-security/x/ccv/types"
 )
 
 func NewGenesisState(
 	vscID uint64,
 	vscIdToHeights []ValsetUpdateIdToHeight,
 	consumerStates []ConsumerState,
-	unbondingOps []types.UnbondingOp,
+	unbondingOps []ccv.UnbondingOp,
 	matureUbdOps *ccv.MaturedUnbondingOps,
 	additionProposals []ConsumerAdditionProposal,
 	removalProposals []ConsumerRemovalProposal,
@@ -49,6 +49,8 @@ func (gs GenesisState) Validate() error {
 	return nil
 }
 
+// Validate performs a consumer state validation returning an error upon any failure.
+// It ensures that the chain id, client id and consumer genesis states are valid and non-empty.
 func (cs ConsumerState) Validate() error {
 	if strings.TrimSpace(cs.ChainId) == "" {
 		return sdkerrors.Wrap(sdkerrors.ErrInvalidChainID, "consumer chain id cannot be empty string")
@@ -56,5 +58,17 @@ func (cs ConsumerState) Validate() error {
 	if err := host.ChannelIdentifierValidator(cs.ChannelId); err != nil {
 		return sdkerrors.Wrapf(err, "ccv channel id for chain %s is not valid", cs.ChainId)
 	}
+	if cs.ClientId == "" {
+		return sdkerrors.Wrap(ccv.ErrInvalidGenesis, fmt.Sprintf("client id must be set for consumer chain %s", cs.ChainId))
+	}
+	// consumer genesis should be for a new chain only
+	if !cs.ConsumerGenesis.NewChain {
+		return sdkerrors.Wrap(ccv.ErrInvalidGenesis, cs.ChainId)
+	}
+	// validate a new chain genesis
+	if err := cs.ConsumerGenesis.Validate(); err != nil {
+		return sdkerrors.Wrap(ccv.ErrInvalidGenesis, err.Error())
+	}
+
 	return nil
 }

--- a/x/ccv/provider/types/genesis_test.go
+++ b/x/ccv/provider/types/genesis_test.go
@@ -7,14 +7,18 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 	commitmenttypes "github.com/cosmos/ibc-go/v3/modules/core/23-commitment/types"
 	ibctmtypes "github.com/cosmos/ibc-go/v3/modules/light-clients/07-tendermint/types"
+	testutil "github.com/cosmos/interchain-security/testutil/keeper"
+	consumertypes "github.com/cosmos/interchain-security/x/ccv/consumer/types"
 	"github.com/cosmos/interchain-security/x/ccv/provider/types"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
+	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/stretchr/testify/require"
 )
 
 // Tests validation of consumer states and params within a provider genesis state
 func TestValidateGenesisState(t *testing.T) {
+
 	testCases := []struct {
 		name     string
 		genState *types.GenesisState
@@ -25,21 +29,7 @@ func TestValidateGenesisState(t *testing.T) {
 			types.NewGenesisState(
 				0,
 				nil,
-				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid"}},
-				nil,
-				nil,
-				nil,
-				nil,
-				types.DefaultParams(),
-			),
-			true,
-		},
-		{
-			"valid validating provider genesis with nil updates",
-			types.NewGenesisState(
-				0,
-				nil,
-				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid"}},
+				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid", ClientId: "client-id", ConsumerGenesis: getInitialConsumerGenesis(t, "chainid-1")}},
 				nil,
 				nil,
 				nil,
@@ -54,10 +44,10 @@ func TestValidateGenesisState(t *testing.T) {
 				0,
 				nil,
 				[]types.ConsumerState{
-					{ChainId: "chainid-1", ChannelId: "channelid1"},
-					{ChainId: "chainid-2", ChannelId: "channelid2"},
-					{ChainId: "chainid-3", ChannelId: "channelid3"},
-					{ChainId: "chainid-4", ChannelId: "channelid4"},
+					{ChainId: "chainid-1", ChannelId: "channelid1", ClientId: "client-id", ConsumerGenesis: getInitialConsumerGenesis(t, "chainid-1")},
+					{ChainId: "chainid-2", ChannelId: "channelid2", ClientId: "client-id", ConsumerGenesis: getInitialConsumerGenesis(t, "chainid-2")},
+					{ChainId: "chainid-3", ChannelId: "channelid3", ClientId: "client-id", ConsumerGenesis: getInitialConsumerGenesis(t, "chainid-3")},
+					{ChainId: "chainid-4", ChannelId: "channelid4", ClientId: "client-id", ConsumerGenesis: getInitialConsumerGenesis(t, "chainid-4")},
 				},
 				nil,
 				nil,
@@ -72,7 +62,7 @@ func TestValidateGenesisState(t *testing.T) {
 			types.NewGenesisState(
 				0,
 				nil,
-				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid"}},
+				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid", ClientId: "client-id", ConsumerGenesis: getInitialConsumerGenesis(t, "chainid-1")}},
 				nil,
 				nil,
 				nil,
@@ -88,7 +78,7 @@ func TestValidateGenesisState(t *testing.T) {
 			types.NewGenesisState(
 				0,
 				nil,
-				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid"}},
+				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid", ClientId: "client-id"}},
 				nil,
 				nil,
 				nil,
@@ -110,7 +100,7 @@ func TestValidateGenesisState(t *testing.T) {
 			types.NewGenesisState(
 				0,
 				nil,
-				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid"}},
+				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid", ClientId: "client-id"}},
 				nil,
 				nil,
 				nil,
@@ -132,7 +122,7 @@ func TestValidateGenesisState(t *testing.T) {
 			types.NewGenesisState(
 				0,
 				nil,
-				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid"}},
+				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid", ClientId: "client-id"}},
 				nil,
 				nil,
 				nil,
@@ -154,7 +144,7 @@ func TestValidateGenesisState(t *testing.T) {
 			types.NewGenesisState(
 				0,
 				nil,
-				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid"}},
+				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid", ClientId: "client-id"}},
 				nil,
 				nil,
 				nil,
@@ -176,7 +166,7 @@ func TestValidateGenesisState(t *testing.T) {
 			types.NewGenesisState(
 				0,
 				nil,
-				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid"}},
+				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid", ClientId: "client-id"}},
 				nil,
 				nil,
 				nil,
@@ -198,7 +188,7 @@ func TestValidateGenesisState(t *testing.T) {
 			types.NewGenesisState(
 				0,
 				nil,
-				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid"}},
+				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid", ClientId: "client-id"}},
 				nil,
 				nil,
 				nil,
@@ -220,7 +210,7 @@ func TestValidateGenesisState(t *testing.T) {
 			types.NewGenesisState(
 				0,
 				nil,
-				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid"}},
+				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid", ClientId: "client-id"}},
 				nil,
 				nil,
 				nil,
@@ -242,7 +232,7 @@ func TestValidateGenesisState(t *testing.T) {
 			types.NewGenesisState(
 				0,
 				nil,
-				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid"}},
+				[]types.ConsumerState{{ChainId: "chainid-1", ChannelId: "channelid", ClientId: "client-id"}},
 				nil,
 				nil,
 				nil,
@@ -264,7 +254,7 @@ func TestValidateGenesisState(t *testing.T) {
 			types.NewGenesisState(
 				0,
 				nil,
-				[]types.ConsumerState{{ChainId: "", ChannelId: "channelid"}},
+				[]types.ConsumerState{{ChainId: "", ChannelId: "channelid", ClientId: "client-id"}},
 				nil,
 				nil,
 				nil,
@@ -278,7 +268,36 @@ func TestValidateGenesisState(t *testing.T) {
 			types.NewGenesisState(
 				0,
 				nil,
-				[]types.ConsumerState{{ChainId: "chainid", ChannelId: "ivnalidChannel{}"}},
+				[]types.ConsumerState{{ChainId: "chainid", ChannelId: "ivnalidChannel{}", ClientId: "client-id"}},
+				nil,
+				nil,
+				nil,
+				nil,
+				types.DefaultParams(),
+			),
+			false,
+		},
+		{
+			"empty client id",
+			types.NewGenesisState(
+				0,
+				nil,
+				[]types.ConsumerState{{ChainId: "chainid", ChannelId: "channel-0", ClientId: ""}},
+				nil,
+				nil,
+				nil,
+				nil,
+				types.DefaultParams(),
+			),
+			false,
+		},
+		{
+			"empty consumer genesis",
+			types.NewGenesisState(
+				0,
+				nil,
+				[]types.ConsumerState{{ChainId: "chainid", ChannelId: "channel-0", ClientId: "client-id",
+					ConsumerGenesis: consumertypes.GenesisState{}}},
 				nil,
 				nil,
 				nil,
@@ -290,12 +309,44 @@ func TestValidateGenesisState(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		err := tc.genState.Validate()
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.genState.Validate()
 
-		if tc.expPass {
-			require.NoError(t, err, "test case: %s must pass", tc.name)
-		} else {
-			require.Error(t, err, "test case: %s must fail", tc.name)
-		}
+			if tc.expPass {
+				require.NoError(t, err, "test case: %s must pass", tc.name)
+			} else {
+				require.Error(t, err, "test case: %s must fail", tc.name)
+			}
+		})
 	}
+}
+
+func getInitialConsumerGenesis(t *testing.T, chainID string) consumertypes.GenesisState {
+	// generate validator public key
+	pubKey, err := testutil.GenPubKey()
+	require.NoError(t, err)
+
+	// create validator set with single validator
+	validator := tmtypes.NewValidator(pubKey, 1)
+	valSet := tmtypes.NewValidatorSet([]*tmtypes.Validator{validator})
+	valHash := valSet.Hash()
+	valUpdates := tmtypes.TM2PB.ValidatorUpdates(valSet)
+
+	cs := ibctmtypes.NewClientState(
+		chainID,
+		ibctmtypes.DefaultTrustLevel,
+		time.Duration(1),
+		time.Duration(2),
+		time.Duration(1),
+		clienttypes.Height{RevisionNumber: clienttypes.ParseChainID(chainID), RevisionHeight: 1},
+		commitmenttypes.GetSDKSpecs(),
+		[]string{"upgrade", "upgradedIBCState"},
+		true,
+		true,
+	)
+	consensusState := ibctmtypes.NewConsensusState(time.Now(), commitmenttypes.NewMerkleRoot([]byte("apphash")), valHash[:])
+
+	params := consumertypes.DefaultParams()
+	params.Enabled = true
+	return *consumertypes.NewInitialGenesisState(cs, consensusState, valUpdates, params)
 }


### PR DESCRIPTION
# Description
Update provider genesis validation to check all the mandatory consumer states. Extend #382 to close #395.

# Linked issues

Closes: #395 


# Type of change

- [x] Non-breaking changes
- [x ] Testing

# How was the feature tested?

- [x] Unit tests
- [ ] E2E tests
- [ ] Integration tests/simulation
- [ ] Custom difference tests


# Checklist:

- [x] Relevant issues are linked
- [x] Tests are passing (`make test`)
- [x] PR satisfies closing criteria defined in issue (remove if not applicable or issue has no criteria)

