### PR TITLE
deactivate multi-consumer tests for goc-december

### DIFF
--- a/tests/e2e/slashing.go
+++ b/tests/e2e/slashing.go
@@ -19,7 +19,9 @@ import (
 )
 
 const (
+	//nolint
 	downtimeTestCase = iota
+	//nolint
 	doubleSignTestCase
 )
 

--- a/tests/integration/main.go
+++ b/tests/integration/main.go
@@ -37,10 +37,10 @@ func main() {
 	dmc.ValidateStringLiterals()
 	dmc.startDocker()
 
-	mul := MultiConsumerTestRun()
-	mul.SetLocalSDKPath(*localSdkPath)
-	mul.ValidateStringLiterals()
-	mul.startDocker()
+	// mul := MultiConsumerTestRun()
+	// mul.SetLocalSDKPath(*localSdkPath)
+	// mul.ValidateStringLiterals()
+	// mul.startDocker()
 
 	keys := KeyAssignmentTestRun()
 	keys.SetLocalSDKPath(*localSdkPath)
@@ -56,8 +56,8 @@ func main() {
 	wg.Add(1)
 	go dmc.ExecuteSteps(&wg, democracySteps)
 
-	wg.Add(1)
-	go mul.ExecuteSteps(&wg, multipleConsumers)
+	// wg.Add(1)
+	// go mul.ExecuteSteps(&wg, multipleConsumers)
 
 	wg.Wait()
 	fmt.Printf("TOTAL TIME ELAPSED: %v\n", time.Since(start))

--- a/tests/integration/steps.go
+++ b/tests/integration/steps.go
@@ -38,6 +38,7 @@ var democracySteps = concatSteps(
 	stepsDemocracy("democ"),
 )
 
+//nolint
 var multipleConsumers = concatSteps(
 	stepsStartChains([]string{"consu", "densu"}, false),
 	stepsMultiConsumerDelegate("consu", "densu"),


### PR DESCRIPTION
# Description

Turn off multi-consumer integration tests to prevent them from timing out when run in CI.

- [x] Non-breaking changes
- [x] Testing

# How was the feature tested?
- [x] Integration tests/simulation

Please delete options that are not relevant.
- [x] Tests are passing (`make test`)

