### PR TITLE
fix IterateInitTimeoutTimestamp

### DIFF
--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -785,6 +785,7 @@ func (k Keeper) DeleteInitTimeoutTimestamp(ctx sdk.Context, chainID string) {
 }
 
 // IterateInitTimeoutTimestamp iterates through the init timeout timestamps in the store
+// store is iterated in alphabetical ascending order not in the order of insertion
 func (k Keeper) IterateInitTimeoutTimestamp(ctx sdk.Context, cb func(chainID string, ts uint64) (stop bool)) {
 	store := ctx.KVStore(k.storeKey)
 	iterator := sdk.KVStorePrefixIterator(store, []byte{types.InitTimeoutTimestampBytePrefix})

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -784,8 +784,8 @@ func (k Keeper) DeleteInitTimeoutTimestamp(ctx sdk.Context, chainID string) {
 	store.Delete(types.InitTimeoutTimestampKey(chainID))
 }
 
-// IterateInitTimeoutTimestamp iterates through the init timeout timestamps in the store
-// store is iterated in alphabetical ascending order not in the order of insertion
+// IterateInitTimeoutTimestamp iterates through the init timeout timestamps in the store.
+// Note: as the keys have the `bytePrefix | chainID` format, the iteration is NOT done in timestamp order.
 func (k Keeper) IterateInitTimeoutTimestamp(ctx sdk.Context, cb func(chainID string, ts uint64) (stop bool)) {
 	store := ctx.KVStore(k.storeKey)
 	iterator := sdk.KVStorePrefixIterator(store, []byte{types.InitTimeoutTimestampBytePrefix})

--- a/x/ccv/provider/keeper/keeper_test.go
+++ b/x/ccv/provider/keeper/keeper_test.go
@@ -305,9 +305,10 @@ func TestInitTimeoutTimestamp(t *testing.T) {
 		chainID  string
 		expected uint64
 	}{
-		{expected: 5, chainID: "chain"},
-		{expected: 10, chainID: "chain1"},
-		{expected: 12, chainID: "chain2"},
+		// ordered alphabetically - descending
+		{expected: 5, chainID: "z-chain"},
+		{expected: 12, chainID: "b-chain"},
+		{expected: 10, chainID: "a-chain"},
 	}
 
 	_, found := providerKeeper.GetInitTimeoutTimestamp(ctx, tc[0].chainID)
@@ -317,14 +318,15 @@ func TestInitTimeoutTimestamp(t *testing.T) {
 	providerKeeper.SetInitTimeoutTimestamp(ctx, tc[1].chainID, tc[1].expected)
 	providerKeeper.SetInitTimeoutTimestamp(ctx, tc[2].chainID, tc[2].expected)
 
-	i := 0
+	i := 2
+	// store is iterated in alphabetical ascending order
+	// not in the order of insertion
 	providerKeeper.IterateInitTimeoutTimestamp(ctx, func(chainID string, ts uint64) (stop bool) {
 		require.Equal(t, chainID, tc[i].chainID)
 		require.Equal(t, ts, tc[i].expected)
-		i++
+		i--
 		return false // do not stop the iteration
 	})
-	require.Equal(t, len(tc), i)
 
 	for _, tc := range tc {
 		ts, found := providerKeeper.GetInitTimeoutTimestamp(ctx, tc.chainID)

--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -332,11 +332,9 @@ func (k Keeper) EndBlockCCR(ctx sdk.Context) {
 		if currentTimeUint64 > ts {
 			// initTimeout expired
 			chainIdsToRemove = append(chainIdsToRemove, chainID)
-			// continue to iterate through all timed out consumers
-			return false
 		}
-		// break iteration since the timeout timestamps are in order
-		return true
+		// continue to iterate through all timed out consumers
+		return false
 	})
 	// remove consumers that timed out
 	for _, chainID := range chainIdsToRemove {


### PR DESCRIPTION
# Description

`provider.EndBlockCCR` removes chains which timed out. However, when iterating through all chains, it stops as soon as it finds one chain that did not time out, falsely assuming that the chains are ordered by their time of arrival <=> expiration time.

# Linked issues

Closes: #513 


# Type of change

Please delete options that are not relevant.

- [x] Non-breaking changes
- [x] Updates in store keepers or store keys

# How was the feature tested?

- [x] Unit tests


# Other information
This bug was found during code audit.

# Checklist:

Please delete options that are not relevant.

- [x] Relevant issus are linked
- [x] Tests are passing (`make test`)
- [x] PR satisfies closing criteria defined in issue (remove if not applicable or issue has no criteria)
- [x] Added iterators follow SDK pattern (`IterateX(ctx sdk.Context, cb func(arg1, arg2) (stop bool))`)
