### PR TITLE
Fixes #503 prevents two key assignment key overlap security issues

### DIFF
--- a/x/ccv/provider/keeper/hooks.go
+++ b/x/ccv/provider/keeper/hooks.go
@@ -70,15 +70,10 @@ func validatorConsensusKeyInUse(ctx sdk.Context, k *Keeper, valAddr sdk.ValAddre
 	// as argument at it is not possible to directly query the validator using
 	// the operator address. Nor is it possible to convert an operator addr
 	// to a consensus addr.
-	var val stakingtypes.ValidatorI
-	k.stakingKeeper.IterateValidators(ctx, func(_ int64, validator stakingtypes.ValidatorI) bool {
-		if validator.GetOperator().Equals(valAddr) {
-			val = validator
-			return true
-
-		}
-		return false
-	})
+	val, found := k.stakingKeeper.GetValidator(ctx, valAddr)
+	if !found {
+		panic("did not find newly created validator in staking module")
+	}
 
 	// Get the consensus address of the validator being added
 	cons, err := val.GetConsAddr()

--- a/x/ccv/provider/keeper/hooks.go
+++ b/x/ccv/provider/keeper/hooks.go
@@ -64,7 +64,7 @@ func (h Hooks) AfterUnbondingInitiated(ctx sdk.Context, ID uint64) error {
 	return nil
 }
 
-func validatorConsensusKeyInUse(ctx sdk.Context, k *Keeper, valAddr sdk.ValAddress) bool {
+func ValidatorConsensusKeyInUse(k *Keeper, ctx sdk.Context, valAddr sdk.ValAddress) bool {
 	// Find the validator being added in the staking module
 	// This is necessary because only the operator address is received
 	// as argument at it is not possible to directly query the validator using
@@ -97,7 +97,7 @@ func validatorConsensusKeyInUse(ctx sdk.Context, k *Keeper, valAddr sdk.ValAddre
 }
 
 func (h Hooks) AfterValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) {
-	if validatorConsensusKeyInUse(ctx, h.k, valAddr) {
+	if ValidatorConsensusKeyInUse(h.k, ctx, valAddr) {
 		// Abort TX, do NOT allow validator to be created
 		panic("cannot create a validator with a consensus key that is already in use or was recently in use as an assigned consumer chain key")
 	}

--- a/x/ccv/provider/keeper/hooks.go
+++ b/x/ccv/provider/keeper/hooks.go
@@ -64,7 +64,7 @@ func (h Hooks) AfterUnbondingInitiated(ctx sdk.Context, ID uint64) error {
 	return nil
 }
 
-func validatorConsensusKeyInUseOnConsumerChain(ctx sdk.Context, k *Keeper, valAddr sdk.ValAddress) bool {
+func validatorConsensusKeyInUse(ctx sdk.Context, k *Keeper, valAddr sdk.ValAddress) bool {
 	// Find the validator being added in the staking module
 	// This is necessary because only the operator address is received
 	// as argument at it is not possible to directly query the validator using
@@ -80,7 +80,7 @@ func validatorConsensusKeyInUseOnConsumerChain(ctx sdk.Context, k *Keeper, valAd
 		return false
 	})
 
-	// Get teh consensus address of the validator being added
+	// Get the consensus address of the validator being added
 	cons, err := val.GetConsAddr()
 	if err != nil {
 		panic("could not get validator cons addr ")
@@ -101,9 +101,8 @@ func validatorConsensusKeyInUseOnConsumerChain(ctx sdk.Context, k *Keeper, valAd
 	return inUse
 }
 
-// Define unimplemented methods to satisfy the StakingHooks contract
 func (h Hooks) AfterValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) {
-	if validatorConsensusKeyInUseOnConsumerChain(ctx, h.k, valAddr) {
+	if validatorConsensusKeyInUse(ctx, h.k, valAddr) {
 		// Abort TX, do NOT allow validator to be created
 		panic("cannot create a validator with a consensus key that is already in use or was recently in use as an assigned consumer chain key")
 	}

--- a/x/ccv/provider/keeper/hooks_test.go
+++ b/x/ccv/provider/keeper/hooks_test.go
@@ -1,0 +1,68 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	cryptotestutil "github.com/cosmos/interchain-security/testutil/crypto"
+	testkeeper "github.com/cosmos/interchain-security/testutil/keeper"
+	providerkeeper "github.com/cosmos/interchain-security/x/ccv/provider/keeper"
+	"github.com/golang/mock/gomock"
+)
+
+func TestValidatorConsensusKeyInUse(t *testing.T) {
+
+	newValidator := cryptotestutil.NewCryptoIdentityFromIntSeed(0)
+	anotherValidator0 := cryptotestutil.NewCryptoIdentityFromIntSeed(1)
+	anotherValidator1 := cryptotestutil.NewCryptoIdentityFromIntSeed(2)
+
+	tests := []struct {
+		name   string
+		setup  func(sdk.Context, providerkeeper.Keeper)
+		expect bool
+	}{
+		{
+			name: "not in use by another validator",
+			setup: func(ctx sdk.Context, k providerkeeper.Keeper) {
+				// Another validator does not exist
+			},
+			expect: false,
+		},
+		{
+			name: "in use by another validator",
+			setup: func(ctx sdk.Context, k providerkeeper.Keeper) {
+				// We are trying to add a new validator, but its address has already been used
+				// by another validator
+				k.SetValidatorByConsumerAddr(ctx, "chainid", newValidator.SDKConsAddress(), anotherValidator0.SDKConsAddress())
+			},
+			expect: true,
+		},
+		{
+			name: "in use by one of several other validators",
+			setup: func(ctx sdk.Context, k providerkeeper.Keeper) {
+				// We are trying to add a new validator, but its address has already been used
+				// by another validator, of which there are several, across potentially several chains
+				k.SetValidatorByConsumerAddr(ctx, "chainid0", newValidator.SDKConsAddress(), anotherValidator0.SDKConsAddress())
+				k.SetValidatorByConsumerAddr(ctx, "chainid1", anotherValidator1.SDKConsAddress(), anotherValidator1.SDKConsAddress())
+			},
+			expect: true,
+		},
+	}
+	for _, tt := range tests {
+		k, ctx, _, mocks := testkeeper.GetProviderKeeperAndCtx(t, testkeeper.NewInMemKeeperParams(t))
+
+		gomock.InOrder(
+			mocks.MockStakingKeeper.EXPECT().GetValidator(ctx,
+				newValidator.SDKStakingOperator(),
+			).Return(newValidator.SDKStakingValidator(), true),
+		)
+
+		tt.setup(ctx, k)
+
+		t.Run(tt.name, func(t *testing.T) {
+			if actual := providerkeeper.ValidatorConsensusKeyInUse(&k, ctx, newValidator.SDKStakingOperator()); actual != tt.expect {
+				t.Errorf("validatorConsensusKeyInUse() = %v, want %v", actual, tt.expect)
+			}
+		})
+	}
+}

--- a/x/ccv/provider/keeper/key_assignment.go
+++ b/x/ccv/provider/keeper/key_assignment.go
@@ -12,11 +12,6 @@ import (
 	tmprotocrypto "github.com/tendermint/tendermint/proto/tendermint/crypto"
 )
 
-// ValidatorConsumerPubKey: (chainID, providerAddr consAddr) -> consumerKey tmprotocrypto.PublicKey
-// ValidatorByConsumerAddr: (chainID, consumerAddr consAddr) -> providerAddr consAddr
-// KeyAssignmentReplacements: (chainID, providerAddr consAddr) -> replacement abci.ValidatorUpdate
-// ConsumerAddrsToPrune: (chainID, vscID uint64) -> consumerAddrsToPrune [][]byte
-
 // GetValidatorConsumerPubKey returns a validator's public key assigned for a consumer chain
 func (k Keeper) GetValidatorConsumerPubKey(
 	ctx sdk.Context,

--- a/x/ccv/provider/keeper/key_assignment.go
+++ b/x/ccv/provider/keeper/key_assignment.go
@@ -371,7 +371,8 @@ func (k Keeper) AssignConsumerKey(
 		if existingVal.OperatorAddress != validator.OperatorAddress {
 			// consumer key is already the key belonging to another existing
 			// and different provider
-			// prevent
+			// prevent a validator from assigning a key which is the *provider*
+			// key of another validator
 			return sdkerrors.Wrapf(
 				types.ErrConsumerKeyInUse, "a different validator already uses the consumer key",
 			)

--- a/x/ccv/provider/keeper/key_assignment_test.go
+++ b/x/ccv/provider/keeper/key_assignment_test.go
@@ -847,6 +847,14 @@ func TestSimulatedAssignmentsAndUpdateApplication(t *testing.T) {
 			// assignments that occur
 		}).AnyTimes()
 
+		// Mock calls to GetValidatorByConsAddr never find a validator
+		mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(
+			gomock.Any(),
+			gomock.Any(),
+		).DoAndReturn(func(_ interface{}, _ interface{}) (validator stakingtypes.Validator, found bool) {
+			return validator, false
+		}).AnyTimes()
+
 		// Helper: apply some updates to both the provider and consumer valsets
 		// and increment the provider vscid.
 		applyUpdatesAndIncrementVSCID := func(updates []abci.ValidatorUpdate) {

--- a/x/ccv/provider/keeper/key_assignment_test.go
+++ b/x/ccv/provider/keeper/key_assignment_test.go
@@ -740,9 +740,6 @@ type Assignment struct {
 // TestSimulatedAssignmentsAndUpdateApplication tests a series
 // of simulated scenarios where random key assignments and validator
 // set updates are generated.
-// TODO: this does not yet fully test the correct lookup of a provider
-// validator from a consumer consensus address, as is needed for handling
-// (double sign) slash packets.
 func TestSimulatedAssignmentsAndUpdateApplication(t *testing.T) {
 
 	CHAINID := "chainID"

--- a/x/ccv/provider/keeper/key_assignment_test.go
+++ b/x/ccv/provider/keeper/key_assignment_test.go
@@ -487,6 +487,9 @@ func TestAssignConsensusKeyForConsumerChain(t *testing.T) {
 			name: "0",
 			mockSetup: func(ctx sdk.Context, k providerkeeper.Keeper, mocks testkeeper.MockedKeepers) {
 				gomock.InOrder(
+					mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(ctx,
+						consumerIdentities[0].SDKConsAddress(),
+					).Return(stakingtypes.Validator{}, false),
 					mocks.MockStakingKeeper.EXPECT().GetLastValidatorPower(
 						ctx, providerIdentities[0].SDKValAddress(),
 					).Return(int64(0)),
@@ -508,9 +511,15 @@ func TestAssignConsensusKeyForConsumerChain(t *testing.T) {
 			name: "1",
 			mockSetup: func(ctx sdk.Context, k providerkeeper.Keeper, mocks testkeeper.MockedKeepers) {
 				gomock.InOrder(
+					mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(ctx,
+						consumerIdentities[0].SDKConsAddress(),
+					).Return(stakingtypes.Validator{}, false),
 					mocks.MockStakingKeeper.EXPECT().GetLastValidatorPower(
 						ctx, providerIdentities[0].SDKValAddress(),
 					).Return(int64(0)),
+					mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(ctx,
+						consumerIdentities[1].SDKConsAddress(),
+					).Return(stakingtypes.Validator{}, false),
 					mocks.MockStakingKeeper.EXPECT().GetLastValidatorPower(
 						ctx, providerIdentities[0].SDKValAddress(),
 					).Return(int64(0)),
@@ -537,9 +546,15 @@ func TestAssignConsensusKeyForConsumerChain(t *testing.T) {
 			name: "2",
 			mockSetup: func(ctx sdk.Context, k providerkeeper.Keeper, mocks testkeeper.MockedKeepers) {
 				gomock.InOrder(
+					mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(ctx,
+						consumerIdentities[0].SDKConsAddress(),
+					).Return(stakingtypes.Validator{}, false),
 					mocks.MockStakingKeeper.EXPECT().GetLastValidatorPower(
 						ctx, providerIdentities[0].SDKValAddress(),
 					).Return(int64(0)),
+					mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(ctx,
+						consumerIdentities[0].SDKConsAddress(),
+					).Return(stakingtypes.Validator{}, false),
 				)
 			},
 			doActions: func(ctx sdk.Context, k providerkeeper.Keeper) {
@@ -570,6 +585,11 @@ func TestAssignConsensusKeyForConsumerChain(t *testing.T) {
 		{
 			name: "4",
 			mockSetup: func(ctx sdk.Context, k providerkeeper.Keeper, mocks testkeeper.MockedKeepers) {
+				gomock.InOrder(
+					mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(ctx,
+						consumerIdentities[0].SDKConsAddress(),
+					).Return(stakingtypes.Validator{}, false),
+				)
 			},
 			doActions: func(ctx sdk.Context, k providerkeeper.Keeper) {
 				err := k.AssignConsumerKey(ctx, chainID,
@@ -585,6 +605,14 @@ func TestAssignConsensusKeyForConsumerChain(t *testing.T) {
 		{
 			name: "5",
 			mockSetup: func(ctx sdk.Context, k providerkeeper.Keeper, mocks testkeeper.MockedKeepers) {
+				gomock.InOrder(
+					mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(ctx,
+						consumerIdentities[0].SDKConsAddress(),
+					).Return(stakingtypes.Validator{}, false),
+					mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(ctx,
+						consumerIdentities[1].SDKConsAddress(),
+					).Return(stakingtypes.Validator{}, false),
+				)
 			},
 			doActions: func(ctx sdk.Context, k providerkeeper.Keeper) {
 				err := k.AssignConsumerKey(ctx, chainID,
@@ -605,6 +633,14 @@ func TestAssignConsensusKeyForConsumerChain(t *testing.T) {
 		{
 			name: "6",
 			mockSetup: func(ctx sdk.Context, k providerkeeper.Keeper, mocks testkeeper.MockedKeepers) {
+				gomock.InOrder(
+					mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(ctx,
+						consumerIdentities[0].SDKConsAddress(),
+					).Return(stakingtypes.Validator{}, false),
+					mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(ctx,
+						consumerIdentities[0].SDKConsAddress(),
+					).Return(stakingtypes.Validator{}, false),
+				)
 			},
 			doActions: func(ctx sdk.Context, k providerkeeper.Keeper) {
 				err := k.AssignConsumerKey(ctx, chainID,

--- a/x/ccv/provider/types/errors.go
+++ b/x/ccv/provider/types/errors.go
@@ -15,5 +15,5 @@ var (
 	ErrConsumerKeyNotFound             = sdkerrors.Register(ModuleName, 7, "consumer key not found")
 	ErrNoValidatorConsumerAddress      = sdkerrors.Register(ModuleName, 8, "error getting validator consumer address")
 	ErrNoValidatorProviderAddress      = sdkerrors.Register(ModuleName, 9, "error getting validator provider address")
-	ErrConsumerKeyExists               = sdkerrors.Register(ModuleName, 10, "consumer consensus public key already exists")
+	ErrConsumerKeyInUse                = sdkerrors.Register(ModuleName, 10, "consumer key is already in use by a validator")
 )

--- a/x/ccv/types/expected_keepers.go
+++ b/x/ccv/types/expected_keepers.go
@@ -33,6 +33,8 @@ type StakingKeeper interface {
 	IterateLastValidatorPowers(ctx sdk.Context, cb func(addr sdk.ValAddress, power int64) (stop bool))
 	PowerReduction(ctx sdk.Context) sdk.Int
 	PutUnbondingOnHold(ctx sdk.Context, id uint64) error
+
+	IterateValidators(sdk.Context, func(int64, stakingtypes.ValidatorI) bool)
 }
 
 // SlashingKeeper defines the contract expected to perform ccv slashing

--- a/x/ccv/types/expected_keepers.go
+++ b/x/ccv/types/expected_keepers.go
@@ -33,8 +33,6 @@ type StakingKeeper interface {
 	IterateLastValidatorPowers(ctx sdk.Context, cb func(addr sdk.ValAddress, power int64) (stop bool))
 	PowerReduction(ctx sdk.Context) sdk.Int
 	PutUnbondingOnHold(ctx sdk.Context, id uint64) error
-
-	IterateValidators(sdk.Context, func(int64, stakingtypes.ValidatorI) bool)
 }
 
 // SlashingKeeper defines the contract expected to perform ccv slashing


### PR DESCRIPTION
Fixes

- https://github.com/cosmos/interchain-security/issues/503
