### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,66 +1,26 @@
----
-name: Pull request template
-about: Template for interchain security templates
-title: ''
-labels: ''
-assignees: ''
-
----
-
-
 # Description
 
 Please include a summary of the changes and the related issue. If the issue was ambiguous try to clarify it in this section.
 
-
-# Linked issues
+## Linked issues
 
 Closes: `#<issue>`
 
+## Type of change
 
-# Type of change
+If you've checked both of the first two boxes, consider splitting this PR into multiple PRs!
 
-Please delete options that are not relevant.
+- [ ] `Feature`: Changes existing code behavior
+- [ ] `Refactor`: Changes existing code style, but not behavior (naming, structure, etc.)
+- [ ] `Testing`: Adds testing
+- [ ] `Docs`: Added documentation
 
-- [ ] Non-breaking changes
-- [ ] New feature (adding functionality)
-- [ ] Breaking change (fix, feature or refactoring that changes existing functionality)
-- [ ] Requires state migrations
-- [ ] Proto files changes
-- [ ] Updates in store keepers or store keys
-- [ ] Changes in genesis (import/export)
-- [ ] Testing
-- [ ] Dependency management (updates dependencies, adds replace calls in go.mod, go mod tidy)
-- [ ] Documentation updates
+## Regression tests
 
+If `Refactor`, describe the new or existing tests that verify no behavior was changed where refactors were introduced.
 
-# How was the feature tested?
+## New behavior tests
 
-- [ ] Unit tests
-- [ ] E2E tests
-- [ ] Integration tests/simulation
-- [ ] Custom difference tests
+If `Feature`, describe the new or existing tests that verify the new behavior is correct and expected.
 
-
-# Issues and further questions
-
-Please write any concerns you may have about this feature (remove if not relevant).
-
-
-# Other information
-
-
-# Checklist:
-
-Please delete options that are not relevant.
-
-- [ ] Relevant issus are linked
-- [ ] PR depends on other features: `#<issue>`
-- [ ] Other PRs depend on this feature: `#<issue>`
-- [ ] Tests are passing (`make test`)
-- [ ] `make proto-gen` was run (for changes in `.proto` files)
-- [ ] `make proto-lint` was run (for changes in `.proto` files)
-- [ ] PR satisfies closing criteria defined in issue (remove if not applicable or issue has no criteria)
-- [ ] Added iterators follow SDK pattern (`IterateX(ctx sdk.Context, cb func(arg1, arg2) (stop bool))`)
-- [ ] testutil/e2e/debug_test.go is up-to-date with additional or changed e2e test names
-- [ ] Documentation has been updated
+## For merge checklist, see *guidelines doc*


### PR DESCRIPTION
Inspired by a talk @MSalopek and I just had. Only include things that're neccessary, merge agreements etc. should be defined elsewhere or enforced by reviewers and GH rules.