### PR TITLE
Goc december with specialized integration test

### DIFF
--- a/tests/e2e/throttle.go
+++ b/tests/e2e/throttle.go
@@ -5,10 +5,8 @@ import (
 
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	channeltypes "github.com/cosmos/ibc-go/v3/modules/core/04-channel/types"
 	icstestingutils "github.com/cosmos/interchain-security/testutil/ibc_testing"
 	providertypes "github.com/cosmos/interchain-security/x/ccv/provider/types"
-	ccvtypes "github.com/cosmos/interchain-security/x/ccv/types"
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
@@ -339,57 +337,6 @@ func (s *CCVTestSuite) TestSlashMeterAllowanceChanges() {
 	providerKeeper.SetParams(s.providerCtx(), params)
 	s.Require().Equal(int64(1200), providerKeeper.GetSlashMeterAllowance(s.providerCtx()).Int64())
 
-}
-
-// TestSlashSameValidator tests the edge case that that the total slashed validator power
-// queued up for a single block exceeds the slash meter allowance,
-// but some of the slash packets are for the same validator, and should all be handled.
-func (s *CCVTestSuite) TestSlashSameValidator() {
-
-	s.SetupAllCCVChannels()
-
-	// Setup 4 validators with 25% of the total power each.
-	s.setupValidatorPowers()
-
-	providerKeeper := s.providerApp.GetProviderKeeper()
-
-	// Set replenish fraction to 1.0 so that all sent packets should handled immediately (no throttling)
-	params := providerKeeper.GetParams(s.providerCtx())
-	params.SlashMeterReplenishFraction = "1.0"
-	providerKeeper.SetParams(s.providerCtx(), params)
-	providerKeeper.InitializeSlashMeter(s.providerCtx())
-
-	// Send a downtime and double-sign slash packet for 3/4 validators
-	// This will have a total slashing power of 150% total power.
-	tmval1 := s.providerChain.Vals.Validators[1]
-	tmval2 := s.providerChain.Vals.Validators[2]
-	tmval3 := s.providerChain.Vals.Validators[3]
-	s.setDefaultValSigningInfo(*tmval1)
-	s.setDefaultValSigningInfo(*tmval2)
-	s.setDefaultValSigningInfo(*tmval3)
-
-	packets := []channeltypes.Packet{
-		s.constructSlashPacketFromConsumer(s.getFirstBundle(), *tmval1, stakingtypes.Downtime, 1),
-		s.constructSlashPacketFromConsumer(s.getFirstBundle(), *tmval2, stakingtypes.Downtime, 2),
-		s.constructSlashPacketFromConsumer(s.getFirstBundle(), *tmval3, stakingtypes.Downtime, 3),
-		s.constructSlashPacketFromConsumer(s.getFirstBundle(), *tmval1, stakingtypes.DoubleSign, 4),
-		s.constructSlashPacketFromConsumer(s.getFirstBundle(), *tmval2, stakingtypes.DoubleSign, 5),
-		s.constructSlashPacketFromConsumer(s.getFirstBundle(), *tmval3, stakingtypes.DoubleSign, 6),
-	}
-
-	// Recv and queue all slash packets.
-	for _, packet := range packets {
-		providerKeeper.OnRecvSlashPacket(s.providerCtx(), packet, ccvtypes.MustUnmarshalJsonBzToSlashPacketData(packet.GetData()))
-	}
-
-	// We should have 6 pending slash packet entries queued.
-	s.Require().Len(providerKeeper.GetAllPendingSlashPacketEntries(s.providerCtx()), 6)
-
-	// Call next block to process all pending slash packets in end blocker.
-	s.providerChain.NextBlock()
-
-	// All slash packets should have been handled immediately, even though they totaled to 150% of total power.
-	s.Require().Len(providerKeeper.GetAllPendingSlashPacketEntries(s.providerCtx()), 0)
 }
 
 func (s *CCVTestSuite) confirmValidatorJailed(tmVal tmtypes.Validator) {

--- a/tests/integration/actions.go
+++ b/tests/integration/actions.go
@@ -927,7 +927,7 @@ func (tr TestRun) invokeDowntimeSlash(action downtimeSlashAction, verbose bool) 
 	// Bring validator down
 	tr.setValidatorDowntime(action.chain, action.validator, true, verbose)
 	// Wait appropriate amount of blocks for validator to be slashed
-	tr.waitBlocks(action.chain, 3, time.Minute)
+	tr.waitBlocks(action.chain, 5, time.Minute)
 	// Bring validator back up
 	tr.setValidatorDowntime(action.chain, action.validator, false, verbose)
 }

--- a/tests/integration/main.go
+++ b/tests/integration/main.go
@@ -32,29 +32,29 @@ func main() {
 	tr.ValidateStringLiterals()
 	tr.startDocker()
 
-	dmc := DemocracyTestRun()
-	dmc.SetLocalSDKPath(*localSdkPath)
-	dmc.ValidateStringLiterals()
-	dmc.startDocker()
+	// dmc := DemocracyTestRun()
+	// dmc.SetLocalSDKPath(*localSdkPath)
+	// dmc.ValidateStringLiterals()
+	// dmc.startDocker()
 
 	// mul := MultiConsumerTestRun()
 	// mul.SetLocalSDKPath(*localSdkPath)
 	// mul.ValidateStringLiterals()
 	// mul.startDocker()
 
-	keys := KeyAssignmentTestRun()
-	keys.SetLocalSDKPath(*localSdkPath)
-	keys.ValidateStringLiterals()
-	keys.startDocker()
+	// keys := KeyAssignmentTestRun()
+	// keys.SetLocalSDKPath(*localSdkPath)
+	// keys.ValidateStringLiterals()
+	// keys.startDocker()
 
-	wg.Add(1)
-	go keys.ExecuteSteps(&wg, keyAssignmentSteps)
+	// wg.Add(1)
+	// go keys.ExecuteSteps(&wg, keyAssignmentSteps)
 
 	wg.Add(1)
 	go tr.ExecuteSteps(&wg, happyPathSteps)
 
-	wg.Add(1)
-	go dmc.ExecuteSteps(&wg, democracySteps)
+	// wg.Add(1)
+	// go dmc.ExecuteSteps(&wg, democracySteps)
 
 	// wg.Add(1)
 	// go mul.ExecuteSteps(&wg, multipleConsumers)

--- a/tests/integration/steps.go
+++ b/tests/integration/steps.go
@@ -13,38 +13,38 @@ func concatSteps(steps ...[]Step) []Step {
 	return concat
 }
 
-var keyAssignmentSteps = concatSteps(
-	stepsStartChains([]string{"consu"}, false),
-	stepsDelegate("consu"),
-	stepsAssignConsumerKeyOnStartedChain("consu", "bob"),
-	stepsUnbond("consu"),
-	stepsRedelegate("consu"),
-)
+// var keyAssignmentSteps = concatSteps(
+// 	stepsStartChains([]string{"consu"}, false),
+// 	stepsDelegate("consu"),
+// 	stepsAssignConsumerKeyOnStartedChain("consu", "bob"),
+// 	stepsUnbond("consu"),
+// 	stepsRedelegate("consu"),
+// )
 
 var happyPathSteps = concatSteps(
 	stepsStartChains([]string{"consu"}, false),
-	stepsDelegate("consu"),
-	stepsUnbond("consu"),
-	stepsRedelegate("consu"),
+	// stepsDelegate("consu"),
+	// stepsUnbond("consu"),
+	// stepsRedelegate("consu"),
 	stepsDowntime("consu"),
-	stepsStopChain("consu"),
+	// stepsStopChain("consu"),
 )
 
-var democracySteps = concatSteps(
-	// democracySteps requires a transfer channel
-	stepsStartChains([]string{"democ"}, true),
-	// delegation needs to happen so the first VSC packet can be delivered
-	stepsDelegate("democ"),
-	stepsDemocracy("democ"),
-)
+// var democracySteps = concatSteps(
+// 	// democracySteps requires a transfer channel
+// 	stepsStartChains([]string{"democ"}, true),
+// 	// delegation needs to happen so the first VSC packet can be delivered
+// 	stepsDelegate("democ"),
+// 	stepsDemocracy("democ"),
+// )
 
 //nolint
-var multipleConsumers = concatSteps(
-	stepsStartChains([]string{"consu", "densu"}, false),
-	stepsMultiConsumerDelegate("consu", "densu"),
-	stepsMultiConsumerUnbond("consu", "densu"),
-	stepsMultiConsumerRedelegate("consu", "densu"),
-	stepsMultiConsumerDowntimeFromConsumer("consu", "densu"),
-	stepsMultiConsumerDowntimeFromProvider("consu", "densu"),
-	stepsDoubleSign("consu", "densu"), // double sign on one of the chains
-)
+// var multipleConsumers = concatSteps(
+// 	stepsStartChains([]string{"consu", "densu"}, false),
+// 	stepsMultiConsumerDelegate("consu", "densu"),
+// 	stepsMultiConsumerUnbond("consu", "densu"),
+// 	stepsMultiConsumerRedelegate("consu", "densu"),
+// 	stepsMultiConsumerDowntimeFromConsumer("consu", "densu"),
+// 	stepsMultiConsumerDowntimeFromProvider("consu", "densu"),
+// 	stepsDoubleSign("consu", "densu"), // double sign on one of the chains
+// )

--- a/tests/integration/steps_downtime.go
+++ b/tests/integration/steps_downtime.go
@@ -1,9 +1,6 @@
 package main
 
 // stepsDowntime tests validator jailing and slashing.
-//
-// Note: These steps are not affected by slash packet throttling since
-// only one consumer initiated slash is implemented.
 func stepsDowntime(consumerName string) []Step {
 	return []Step{
 		{
@@ -15,16 +12,16 @@ func stepsDowntime(consumerName string) []Step {
 				// validator should be slashed on consumer, powers not affected on either chain yet
 				chainID("provi"): ChainState{
 					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
+						validatorID("alice"): 500,
 						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+						validatorID("carol"): 500,
 					},
 				},
 				chainID(consumerName): ChainState{
 					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
+						validatorID("alice"): 500,
 						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+						validatorID("carol"): 500,
 					},
 				},
 			},
@@ -38,17 +35,17 @@ func stepsDowntime(consumerName string) []Step {
 			state: State{
 				chainID("provi"): ChainState{
 					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
+						validatorID("alice"): 500,
 						// Downtime jailing and corresponding voting power change are processed by provider
 						validatorID("bob"):   0,
-						validatorID("carol"): 501,
+						validatorID("carol"): 500,
 					},
 				},
 				chainID(consumerName): ChainState{
 					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
+						validatorID("alice"): 500,
 						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+						validatorID("carol"): 500,
 					},
 				},
 			},
@@ -64,10 +61,10 @@ func stepsDowntime(consumerName string) []Step {
 			state: State{
 				chainID(consumerName): ChainState{
 					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
+						validatorID("alice"): 500,
 						// VSC now seen on consumer
 						validatorID("bob"):   0,
-						validatorID("carol"): 501,
+						validatorID("carol"): 500,
 					},
 				},
 			},
@@ -80,17 +77,17 @@ func stepsDowntime(consumerName string) []Step {
 			state: State{
 				chainID("provi"): ChainState{
 					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
+						validatorID("alice"): 500,
 						// 1% of bob's stake should be slashed as set in config.go
 						validatorID("bob"):   495,
-						validatorID("carol"): 501,
+						validatorID("carol"): 500,
 					},
 				},
 				chainID(consumerName): ChainState{
 					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
+						validatorID("alice"): 500,
 						validatorID("bob"):   0,
-						validatorID("carol"): 501,
+						validatorID("carol"): 500,
 					},
 				},
 			},
@@ -104,91 +101,94 @@ func stepsDowntime(consumerName string) []Step {
 			state: State{
 				chainID(consumerName): ChainState{
 					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
+						validatorID("alice"): 500,
 						validatorID("bob"):   495,
-						validatorID("carol"): 501,
+						validatorID("carol"): 500,
 					},
 				},
 			},
 		},
+
+		// Don't care about provider initiated slashing rn
+
 		// Now we test provider initiated downtime/slashing
-		{
-			action: downtimeSlashAction{
-				chain:     chainID("provi"),
-				validator: validatorID("carol"),
-			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						// Non faulty validators still maintain just above 2/3 power here
-						validatorID("alice"): 509,
-						validatorID("bob"):   495,
-						validatorID("carol"): 0,
-					},
-				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   495,
-						validatorID("carol"): 501,
-					},
-				},
-			},
-		},
-		{
-			action: relayPacketsAction{
-				chain:   chainID("provi"),
-				port:    "provider",
-				channel: 0,
-			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   495,
-						validatorID("carol"): 0,
-					},
-				},
-			},
-		},
-		{
-			action: unjailValidatorAction{
-				provider:  chainID("provi"),
-				validator: validatorID("carol"),
-			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   495,
-						validatorID("carol"): 495,
-					},
-				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   495,
-						validatorID("carol"): 0,
-					},
-				},
-			},
-		},
-		{
-			action: relayPacketsAction{
-				chain:   chainID("provi"),
-				port:    "provider",
-				channel: 0,
-			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   495,
-						validatorID("carol"): 495,
-					},
-				},
-			},
-		},
+		// {
+		// 	action: downtimeSlashAction{
+		// 		chain:     chainID("provi"),
+		// 		validator: validatorID("carol"),
+		// 	},
+		// 	state: State{
+		// 		chainID("provi"): ChainState{
+		// 			ValPowers: &map[validatorID]uint{
+		// 				// Non faulty validators still maintain just above 2/3 power here
+		// 				validatorID("alice"): 509,
+		// 				validatorID("bob"):   495,
+		// 				validatorID("carol"): 0,
+		// 			},
+		// 		},
+		// 		chainID(consumerName): ChainState{
+		// 			ValPowers: &map[validatorID]uint{
+		// 				validatorID("alice"): 509,
+		// 				validatorID("bob"):   495,
+		// 				validatorID("carol"): 501,
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// {
+		// 	action: relayPacketsAction{
+		// 		chain:   chainID("provi"),
+		// 		port:    "provider",
+		// 		channel: 0,
+		// 	},
+		// 	state: State{
+		// 		chainID(consumerName): ChainState{
+		// 			ValPowers: &map[validatorID]uint{
+		// 				validatorID("alice"): 509,
+		// 				validatorID("bob"):   495,
+		// 				validatorID("carol"): 0,
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// {
+		// 	action: unjailValidatorAction{
+		// 		provider:  chainID("provi"),
+		// 		validator: validatorID("carol"),
+		// 	},
+		// 	state: State{
+		// 		chainID("provi"): ChainState{
+		// 			ValPowers: &map[validatorID]uint{
+		// 				validatorID("alice"): 509,
+		// 				validatorID("bob"):   495,
+		// 				validatorID("carol"): 495,
+		// 			},
+		// 		},
+		// 		chainID(consumerName): ChainState{
+		// 			ValPowers: &map[validatorID]uint{
+		// 				validatorID("alice"): 509,
+		// 				validatorID("bob"):   495,
+		// 				validatorID("carol"): 0,
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// {
+		// 	action: relayPacketsAction{
+		// 		chain:   chainID("provi"),
+		// 		port:    "provider",
+		// 		channel: 0,
+		// 	},
+		// 	state: State{
+		// 		chainID(consumerName): ChainState{
+		// 			ValPowers: &map[validatorID]uint{
+		// 				validatorID("alice"): 509,
+		// 				validatorID("bob"):   495,
+		// 				validatorID("carol"): 495,
+		// 			},
+		// 		},
+		// 	},
+		// },
 
 		// TODO: Test full unbonding functionality, tracked as: https://github.com/cosmos/interchain-security/issues/311
 

--- a/testutil/e2e/debug_test.go
+++ b/testutil/e2e/debug_test.go
@@ -168,10 +168,6 @@ func TestSlashMeterAllowanceChanges(t *testing.T) {
 	runCCVTestByName(t, "TestSlashMeterAllowanceChanges")
 }
 
-func TestSlashSameValidator(t *testing.T) {
-	runCCVTestByName(t, "TestSlashSameValidator")
-}
-
 //
 // Unbonding tests
 //


### PR DESCRIPTION
A single integration test used for diagnosing the dec 8th halt. It might be useful to run all integration tests on the base branch `goc-december`, not sure if this has been done. 

Note: `TestSlashSameValidator` was removed because that test won't pass without #560 being cherry picked into this branch. I'm not doing the cherry pick because I want to test the version of ccv that's in the testnet. 

These integration tests could eventually be rebased onto `circuit-breaker` or main.