### PR TITLE
#533 throttle normal operation diff testing PR rebase 2

### DIFF
--- a/tests/difference/core/driver/core_test.go
+++ b/tests/difference/core/driver/core_test.go
@@ -22,6 +22,8 @@ import (
 
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	consumerkeeper "github.com/cosmos/interchain-security/x/ccv/consumer/keeper"
+	providerkeeper "github.com/cosmos/interchain-security/x/ccv/provider/keeper"
+	abcitypes "github.com/tendermint/tendermint/abci/types"
 )
 
 type CoreSuite struct {
@@ -70,6 +72,10 @@ func (b *CoreSuite) providerStakingKeeper() stakingkeeper.Keeper {
 
 func (b *CoreSuite) providerSlashingKeeper() slashingkeeper.Keeper {
 	return b.providerChain().App.(*appProvider.App).SlashingKeeper
+}
+
+func (b *CoreSuite) providerKeeper() providerkeeper.Keeper {
+	return b.providerChain().App.(*appProvider.App).ProviderKeeper
 }
 
 func (b *CoreSuite) consumerKeeper() consumerkeeper.Keeper {
@@ -240,7 +246,9 @@ func (s *CoreSuite) matchState() {
 		// TODO: delegations
 		s.Require().Equalf(int64(s.traces.DelegatorTokens()), s.delegatorBalance(), diagnostic+"P del balance mismatch")
 		for j := 0; j < initState.NumValidators; j++ {
-			s.Require().Equalf(s.traces.Jailed(j) != nil, s.isJailed(int64(j)), diagnostic+"P jail status mismatch for val %d", j)
+			a := s.traces.Jailed(j) != nil
+			b := s.isJailed(int64(j))
+			s.Require().Equalf(a, b, diagnostic+"P jail status mismatch for val %d", j)
 		}
 	}
 	if chain == C {
@@ -258,7 +266,22 @@ func (s *CoreSuite) matchState() {
 	}
 }
 
+// TODO:  debug util, delete before merging to main
+func printValidatorConsAddress(s *CoreSuite, validator int64) {
+	v, found := s.providerStakingKeeper().GetValidator(s.ctx(P), s.validator(validator))
+	if !found {
+		panic("bad")
+	}
+	cons, err := v.GetConsAddr()
+	if err != nil {
+		panic("bad")
+	}
+	vx := abcitypes.Validator{Address: cons.Bytes(), Power: 0}
+	fmt.Println(vx.String())
+}
+
 func (s *CoreSuite) executeTrace() {
+
 	for i := range s.traces.Actions() {
 		s.traces.CurrentActionIx = i
 
@@ -309,6 +332,8 @@ func (s *CoreSuite) TestAssumptions() {
 	if maxValsE != maxVals {
 		s.T().Fatal(FAIL_MSG)
 	}
+
+	// TODO: write assumption that checks that throttle params are appropriate
 
 	// Delegator balance is correct
 	s.Require().Equal(int64(initState.InitialDelegatorTokens), s.delegatorBalance())
@@ -428,9 +453,10 @@ func (s *CoreSuite) TestTraces() {
 	s.traces = Traces{
 		Data: LoadTraces("traces.json"),
 	}
-	// s.traces.Data = []TraceData{s.traces.Data[69]}
+	shortest := -1
+	shortestLen := 10000000000
 	for i := range s.traces.Data {
-		s.Run(fmt.Sprintf("Trace num: %d", i), func() {
+		if !s.Run(fmt.Sprintf("Trace num: %d", i), func() {
 			// Setup a new pair of chains for each trace
 			s.SetupTest()
 
@@ -448,13 +474,19 @@ func (s *CoreSuite) TestTraces() {
 			// Record information about the trace, for debugging
 			// diagnostics.
 			s.executeTrace()
-		})
+		}) {
+			if s.traces.CurrentActionIx < shortestLen {
+				shortest = s.traces.CurrentTraceIx
+				shortestLen = s.traces.CurrentActionIx
+			}
+		}
 	}
+	fmt.Println("Shortest [traceIx, actionIx]:", shortest, shortestLen)
+
 }
 
 func TestCoreSuite(t *testing.T) {
-	// TODO: Reenable diff tests once model is updated
-	// suite.Run(t, new(CoreSuite))
+	suite.Run(t, new(CoreSuite))
 }
 
 // SetupTest sets up the test suite in a 'zero' state which matches

--- a/tests/difference/core/driver/core_test.go
+++ b/tests/difference/core/driver/core_test.go
@@ -22,8 +22,6 @@ import (
 
 	slashingkeeper "github.com/cosmos/cosmos-sdk/x/slashing/keeper"
 	consumerkeeper "github.com/cosmos/interchain-security/x/ccv/consumer/keeper"
-	providerkeeper "github.com/cosmos/interchain-security/x/ccv/provider/keeper"
-	abcitypes "github.com/tendermint/tendermint/abci/types"
 )
 
 type CoreSuite struct {
@@ -72,10 +70,6 @@ func (b *CoreSuite) providerStakingKeeper() stakingkeeper.Keeper {
 
 func (b *CoreSuite) providerSlashingKeeper() slashingkeeper.Keeper {
 	return b.providerChain().App.(*appProvider.App).SlashingKeeper
-}
-
-func (b *CoreSuite) providerKeeper() providerkeeper.Keeper {
-	return b.providerChain().App.(*appProvider.App).ProviderKeeper
 }
 
 func (b *CoreSuite) consumerKeeper() consumerkeeper.Keeper {
@@ -264,20 +258,6 @@ func (s *CoreSuite) matchState() {
 		}
 		// TODO: outstanding downtime
 	}
-}
-
-// TODO:  debug util, delete before merging to main
-func printValidatorConsAddress(s *CoreSuite, validator int64) {
-	v, found := s.providerStakingKeeper().GetValidator(s.ctx(P), s.validator(validator))
-	if !found {
-		panic("bad")
-	}
-	cons, err := v.GetConsAddr()
-	if err != nil {
-		panic("bad")
-	}
-	vx := abcitypes.Validator{Address: cons.Bytes(), Power: 0}
-	fmt.Println(vx.String())
 }
 
 func (s *CoreSuite) executeTrace() {

--- a/tests/difference/core/driver/setup.go
+++ b/tests/difference/core/driver/setup.go
@@ -678,6 +678,13 @@ func (b *Builder) build() {
 
 	b.setSlashParams()
 
+	// TODO: tidy up before merging into main
+	prams := b.providerKeeper().GetParams(b.ctx(P))
+	prams.SlashMeterReplenishFraction = "1.0"
+	prams.SlashMeterReplenishPeriod = time.Second * 1
+	b.providerKeeper().SetParams(b.ctx(P), prams)
+	b.providerKeeper().InitializeSlashMeter(b.ctx(P))
+
 	// Set light client params to match model
 	tmConfig := ibctesting.NewTendermintConfig()
 	tmConfig.UnbondingPeriod = b.initState.UnbondingP

--- a/tests/difference/core/model/src/common.ts
+++ b/tests/difference/core/model/src/common.ts
@@ -181,6 +181,7 @@ type ModelInitState = {
     downtimeSlashAcks: number[];
     tombstoned: boolean[];
     matureUnbondingOps: number[];
+    queue: (Slash | VscMatured)[];
   };
 };
 

--- a/tests/difference/core/model/src/constants.ts
+++ b/tests/difference/core/model/src/constants.ts
@@ -56,6 +56,7 @@ const MODEL_INIT_STATE: ModelInitState = {
     downtimeSlashAcks: [],
     tombstoned: [false, false, false, false],
     matureUnbondingOps: [],
+    queue: [],
   },
   staking: {
     delegation: [4000, 3000, 2000, 1000],


### PR DESCRIPTION
Adjusts the diff tests core model to tests scenarios where the throttle `fraction=1.0` and the throttle is replenished every block.

```
	prams.SlashMeterReplenishFraction = "1.0"
	prams.SlashMeterReplenishPeriod = time.Second * 1
```

This should allow all slashes to occur as per the spec as if the throttle didn't exist. This is a good baseline to get into the testnet and main until the full spec can be flesh out and more throttle scenarios can be tested (#534)

Issue

- https://github.com/cosmos/interchain-security/issues/533