### PR TITLE
add sorting into AccumulateChanges and add a unit test for it

### DIFF
--- a/x/ccv/utils/utils.go
+++ b/x/ccv/utils/utils.go
@@ -35,8 +35,8 @@ func AccumulateChanges(currentChanges, newChanges []abci.ValidatorUpdate) []abci
 	// The list of tendermint updates should hash the same across all consensus nodes
 	// that means it is necessary to sort for determinism.
 	sort.Slice(out, func(i, j int) bool {
-		if out[i].Power > out[j].Power {
-			return true
+		if out[i].Power != out[j].Power {
+			return out[i].Power > out[j].Power
 		}
 		return out[i].PubKey.String() > out[j].PubKey.String()
 	})

--- a/x/ccv/utils/utils.go
+++ b/x/ccv/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"sort"
 	"time"
 
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
@@ -30,6 +31,16 @@ func AccumulateChanges(currentChanges, newChanges []abci.ValidatorUpdate) []abci
 	for _, update := range m {
 		out = append(out, update)
 	}
+
+	// The list of tendermint updates should hash the same across all consensus nodes
+	// that means it is necessary to sort for determinism.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Power > out[j].Power {
+			return true
+		}
+		return out[i].PubKey.String() > out[j].PubKey.String()
+	})
+
 	return out
 }
 

--- a/x/ccv/utils/utils_test.go
+++ b/x/ccv/utils/utils_test.go
@@ -1,0 +1,87 @@
+package utils_test
+
+import (
+	"testing"
+
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	ibcsimapp "github.com/cosmos/ibc-go/v3/testing/simapp"
+	"github.com/cosmos/interchain-security/x/ccv/utils"
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+func TestAccumulateChanges(t *testing.T) {
+	testKeys := ibcsimapp.CreateTestPubKeys(2)
+
+	tmPubKey, _ := cryptocodec.ToTmProtoPublicKey(testKeys[0])
+	tmPubKey2, _ := cryptocodec.ToTmProtoPublicKey(testKeys[1])
+
+	testCases := []struct {
+		name     string
+		changes1 []abci.ValidatorUpdate
+		changes2 []abci.ValidatorUpdate
+		expected []abci.ValidatorUpdate
+	}{
+		{
+			name:     "no changes",
+			changes1: []abci.ValidatorUpdate{},
+			changes2: []abci.ValidatorUpdate{},
+			expected: []abci.ValidatorUpdate(nil),
+		},
+		{
+			name: "one change",
+			changes1: []abci.ValidatorUpdate{
+				{PubKey: tmPubKey, Power: 1},
+			},
+			changes2: []abci.ValidatorUpdate{},
+			expected: []abci.ValidatorUpdate{
+				{PubKey: tmPubKey, Power: 1},
+			},
+		},
+		{
+			name: "two changes",
+			changes1: []abci.ValidatorUpdate{
+				{PubKey: tmPubKey, Power: 1},
+			},
+			changes2: []abci.ValidatorUpdate{
+				{PubKey: tmPubKey, Power: 2},
+			},
+			expected: []abci.ValidatorUpdate{
+				{PubKey: tmPubKey, Power: 2},
+			},
+		},
+		{
+			name: "two changes with different pubkeys",
+			changes1: []abci.ValidatorUpdate{
+				{PubKey: tmPubKey, Power: 1},
+			},
+			changes2: []abci.ValidatorUpdate{
+				{PubKey: tmPubKey2, Power: 2},
+			},
+			expected: []abci.ValidatorUpdate{
+				{PubKey: tmPubKey2, Power: 2},
+				{PubKey: tmPubKey, Power: 1},
+			},
+		},
+		{
+			name: "two changes with different pubkeys and same power",
+			changes1: []abci.ValidatorUpdate{
+				{PubKey: tmPubKey, Power: 1},
+			},
+			changes2: []abci.ValidatorUpdate{
+				{PubKey: tmPubKey2, Power: 1},
+			},
+			expected: []abci.ValidatorUpdate{
+				{PubKey: tmPubKey2, Power: 1},
+				{PubKey: tmPubKey, Power: 1},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			changes := utils.AccumulateChanges(tc.changes1, tc.changes2)
+			require.Equal(t, tc.expected, changes)
+		})
+	}
+}


### PR DESCRIPTION
# Description

This adds sorting to the AccumulateChanges function to stop relying on Go map iteration order.


# Linked issues

Closes: #505


# Type of change

Please delete options that are not relevant.

- [x] Non-breaking changes
- [ ] New feature (adding functionality)
- [ ] Breaking change (fix, feature or refactoring that changes existing functionality)
- [ ] Requires state migrations
- [ ] Proto files changes
- [ ] Updates in store keepers or store keys
- [ ] Changes in genesis (import/export)
- [ ] Testing
- [ ] Dependency management (updates dependencies, adds replace calls in go.mod, go mod tidy)
- [ ] Documentation updates


# How was the feature tested?

- [x] Unit tests
- [ ] E2E tests
- [ ] Integration tests/simulation
- [ ] Custom difference tests


# Issues and further questions

Is not tested under actual map iteration nondeterminism because this is hard to trigger intentionally. Still, the code is simple enough that this probably is ok.


# Other information


# Checklist:

Please delete options that are not relevant.

- [x] Relevant issus are linked
- [ ] PR depends on other features: `#<issue>`
- [ ] Other PRs depend on this feature: `#<issue>`
- [x] Tests are passing (`make test`)
- [ ] `make proto-gen` was run (for changes in `.proto` files)
- [ ] `make proto-lint` was run (for changes in `.proto` files)
- [x] PR satisfies closing criteria defined in issue (remove if not applicable or issue has no criteria)
- [ ] Added iterators follow SDK pattern (`IterateX(ctx sdk.Context, cb func(arg1, arg2) (stop bool))`)
- [ ] testutil/e2e/debug_test.go is up-to-date with additional or changed e2e test names
- [ ] Documentation has been updated
