### PR TITLE
Refactor: `Packets` -> `VSCPackets`

### DIFF
--- a/tests/e2e/expired_client.go
+++ b/tests/e2e/expired_client.go
@@ -33,7 +33,7 @@ func (s *CCVTestSuite) TestVSCPacketSendExpiredClient() {
 	s.providerChain.NextBlock()
 
 	// check that the packet was added to the list of pending VSC packets
-	packets := providerKeeper.GetPendingPackets(s.providerCtx(), s.consumerChain.ChainID)
+	packets := providerKeeper.GetPendingVSCPackets(s.providerCtx(), s.consumerChain.ChainID)
 	s.Require().NotEmpty(packets, "no pending VSC packets found")
 	s.Require().Equal(1, len(packets), "unexpected number of pending VSC packets")
 
@@ -41,7 +41,7 @@ func (s *CCVTestSuite) TestVSCPacketSendExpiredClient() {
 	s.providerChain.NextBlock()
 
 	// check that the packet is still in the list of pending VSC packets
-	packets = providerKeeper.GetPendingPackets(s.providerCtx(), s.consumerChain.ChainID)
+	packets = providerKeeper.GetPendingVSCPackets(s.providerCtx(), s.consumerChain.ChainID)
 	s.Require().NotEmpty(packets, "no pending VSC packets found")
 	s.Require().Equal(1, len(packets), "unexpected number of pending VSC packets")
 
@@ -52,7 +52,7 @@ func (s *CCVTestSuite) TestVSCPacketSendExpiredClient() {
 	s.providerChain.NextBlock()
 
 	// check that the packets are still in the list of pending VSC packets
-	packets = providerKeeper.GetPendingPackets(s.providerCtx(), s.consumerChain.ChainID)
+	packets = providerKeeper.GetPendingVSCPackets(s.providerCtx(), s.consumerChain.ChainID)
 	s.Require().NotEmpty(packets, "no pending VSC packets found")
 	s.Require().Equal(2, len(packets), "unexpected number of pending VSC packets")
 
@@ -63,7 +63,7 @@ func (s *CCVTestSuite) TestVSCPacketSendExpiredClient() {
 	s.providerChain.NextBlock()
 
 	// check that the packets are not in the list of pending VSC packets
-	packets = providerKeeper.GetPendingPackets(s.providerCtx(), s.consumerChain.ChainID)
+	packets = providerKeeper.GetPendingVSCPackets(s.providerCtx(), s.consumerChain.ChainID)
 	s.Require().Empty(packets, "unexpected pending VSC packets found")
 
 	// check that validator updates work
@@ -102,7 +102,7 @@ func (s *CCVTestSuite) TestConsumerPacketSendExpiredClient() {
 	s.providerChain.NextBlock()
 
 	// check that the packets are not in the list of pending VSC packets
-	providerPackets := providerKeeper.GetPendingPackets(s.providerCtx(), s.consumerChain.ChainID)
+	providerPackets := providerKeeper.GetPendingVSCPackets(s.providerCtx(), s.consumerChain.ChainID)
 	s.Require().Empty(providerPackets, "pending VSC packets found")
 
 	// relay all VSC packet from provider to consumer

--- a/tests/e2e/key_assignment.go
+++ b/tests/e2e/key_assignment.go
@@ -28,7 +28,7 @@ func (s *CCVTestSuite) TestKeyAssignment() {
 
 				// check that a VSCPacket is queued
 				s.providerChain.NextBlock()
-				pendingPackets := pk.GetPendingPackets(s.providerCtx(), s.consumerChain.ChainID)
+				pendingPackets := pk.GetPendingVSCPackets(s.providerCtx(), s.consumerChain.ChainID)
 				s.Require().Len(pendingPackets, 1)
 
 				// establish CCV channel

--- a/tests/e2e/stop_consumer.go
+++ b/tests/e2e/stop_consumer.go
@@ -76,7 +76,7 @@ func (s *CCVTestSuite) TestStopConsumerChain() {
 		{
 			func(suite *CCVTestSuite) error {
 				providerKeeper.SetSlashAcks(s.providerCtx(), consumerChainID, []string{"validator-1", "validator-2", "validator-3"})
-				providerKeeper.AppendPendingPackets(s.providerCtx(), consumerChainID, ccv.ValidatorSetChangePacketData{ValsetUpdateId: 1})
+				providerKeeper.AppendPendingVSCPackets(s.providerCtx(), consumerChainID, ccv.ValidatorSetChangePacketData{ValsetUpdateId: 1})
 				return nil
 			},
 		},
@@ -167,7 +167,7 @@ func (s *CCVTestSuite) checkConsumerChainIsRemoved(chainID string, checkChannel 
 
 	s.Require().Nil(providerKeeper.GetSlashAcks(s.providerCtx(), chainID))
 	s.Require().Zero(providerKeeper.GetInitChainHeight(s.providerCtx(), chainID))
-	s.Require().Empty(providerKeeper.GetPendingPackets(s.providerCtx(), chainID))
+	s.Require().Empty(providerKeeper.GetPendingVSCPackets(s.providerCtx(), chainID))
 }
 
 // TestProviderChannelClosed checks that a consumer chain panics

--- a/tests/e2e/unbonding.go
+++ b/tests/e2e/unbonding.go
@@ -233,7 +233,7 @@ func (s *CCVTestSuite) TestUndelegationDuringInit() {
 		s.providerChain.NextBlock()
 
 		// check that the VSC packet is stored in state as pending
-		pendingVSCs := providerKeeper.GetPendingPackets(s.providerCtx(), s.consumerChain.ChainID)
+		pendingVSCs := providerKeeper.GetPendingVSCPackets(s.providerCtx(), s.consumerChain.ChainID)
 		s.Require().Lenf(pendingVSCs, 1, "no pending VSC packet found; test: %s", tc.name)
 
 		// delegate again to create another VSC packet
@@ -243,7 +243,7 @@ func (s *CCVTestSuite) TestUndelegationDuringInit() {
 		s.providerChain.NextBlock()
 
 		// check that the VSC packet is stored in state as pending
-		pendingVSCs = providerKeeper.GetPendingPackets(s.providerCtx(), s.consumerChain.ChainID)
+		pendingVSCs = providerKeeper.GetPendingVSCPackets(s.providerCtx(), s.consumerChain.ChainID)
 		s.Require().Lenf(pendingVSCs, 2, "only one pending VSC packet found; test: %s", tc.name)
 
 		// increment time so that the unbonding period ends on the provider

--- a/x/ccv/provider/keeper/genesis.go
+++ b/x/ccv/provider/keeper/genesis.go
@@ -68,7 +68,7 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 				k.SetUnbondingOpIndex(ctx, chainID, ubdOpIndex.ValsetUpdateId, ubdOpIndex.UnbondingOpIndex)
 			}
 		} else {
-			k.AppendPendingPackets(ctx, chainID, cs.PendingValsetChanges...)
+			k.AppendPendingVSCPackets(ctx, chainID, cs.PendingValsetChanges...)
 		}
 	}
 
@@ -124,7 +124,7 @@ func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 			})
 		}
 
-		cs.PendingValsetChanges = k.GetPendingPackets(ctx, chainID)
+		cs.PendingValsetChanges = k.GetPendingVSCPackets(ctx, chainID)
 		consumerStates = append(consumerStates, cs)
 		return false // do not stop the iteration
 	})

--- a/x/ccv/provider/keeper/genesis_test.go
+++ b/x/ccv/provider/keeper/genesis_test.go
@@ -174,7 +174,7 @@ func assertConsumerChainStates(ctx sdk.Context, t *testing.T, pk keeper.Keeper, 
 		}
 
 		if expVSC := cs.GetPendingValsetChanges(); expVSC != nil {
-			gotVSC := pk.GetPendingPackets(ctx, chainID)
+			gotVSC := pk.GetPendingVSCPackets(ctx, chainID)
 			require.Equal(t, expVSC, gotVSC)
 		}
 

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -680,8 +680,8 @@ func (k Keeper) DeleteInitChainHeight(ctx sdk.Context, chainID string) {
 	store.Delete(types.InitChainHeightKey(chainID))
 }
 
-// GetPendingPackets returns the list of pending ValidatorSetChange packets stored under chain ID
-func (k Keeper) GetPendingPackets(ctx sdk.Context, chainID string) []ccv.ValidatorSetChangePacketData {
+// GetPendingVSCPackets returns the list of pending ValidatorSetChange packets stored under chain ID
+func (k Keeper) GetPendingVSCPackets(ctx sdk.Context, chainID string) []ccv.ValidatorSetChangePacketData {
 	var packets ccv.ValidatorSetChangePackets
 
 	store := ctx.KVStore(k.storeKey)
@@ -695,10 +695,10 @@ func (k Keeper) GetPendingPackets(ctx sdk.Context, chainID string) []ccv.Validat
 	return packets.GetList()
 }
 
-// AppendPendingPackets adds the given ValidatorSetChange packet to the list
+// AppendPendingVSCPackets adds the given ValidatorSetChange packet to the list
 // of pending ValidatorSetChange packets stored under chain ID
-func (k Keeper) AppendPendingPackets(ctx sdk.Context, chainID string, newPackets ...ccv.ValidatorSetChangePacketData) {
-	pds := append(k.GetPendingPackets(ctx, chainID), newPackets...)
+func (k Keeper) AppendPendingVSCPackets(ctx sdk.Context, chainID string, newPackets ...ccv.ValidatorSetChangePacketData) {
+	pds := append(k.GetPendingVSCPackets(ctx, chainID), newPackets...)
 
 	store := ctx.KVStore(k.storeKey)
 	packets := ccv.ValidatorSetChangePackets{List: pds}
@@ -709,8 +709,8 @@ func (k Keeper) AppendPendingPackets(ctx sdk.Context, chainID string, newPackets
 	store.Set(types.PendingVSCsKey(chainID), buf)
 }
 
-// DeletePendingPackets deletes the list of pending ValidatorSetChange packets for chain ID
-func (k Keeper) DeletePendingPackets(ctx sdk.Context, chainID string) {
+// DeletePendingVSCPackets deletes the list of pending ValidatorSetChange packets for chain ID
+func (k Keeper) DeletePendingVSCPackets(ctx sdk.Context, chainID string) {
 	store := ctx.KVStore(k.storeKey)
 	store.Delete(types.PendingVSCsKey(chainID))
 }

--- a/x/ccv/provider/keeper/keeper_test.go
+++ b/x/ccv/provider/keeper/keeper_test.go
@@ -114,7 +114,7 @@ func TestPendingVSCs(t *testing.T) {
 
 	chainID := "consumer"
 
-	pending := providerKeeper.GetPendingPackets(ctx, chainID)
+	pending := providerKeeper.GetPendingVSCPackets(ctx, chainID)
 	require.Len(t, pending, 0)
 
 	pks := ibcsimapp.CreateTestPubKeys(4)
@@ -138,9 +138,9 @@ func TestPendingVSCs(t *testing.T) {
 			ValsetUpdateId: 2,
 		},
 	}
-	providerKeeper.AppendPendingPackets(ctx, chainID, packetList...)
+	providerKeeper.AppendPendingVSCPackets(ctx, chainID, packetList...)
 
-	packets := providerKeeper.GetPendingPackets(ctx, chainID)
+	packets := providerKeeper.GetPendingVSCPackets(ctx, chainID)
 	require.Len(t, packets, 2)
 
 	newPacket := ccv.ValidatorSetChangePacketData{
@@ -149,14 +149,14 @@ func TestPendingVSCs(t *testing.T) {
 		},
 		ValsetUpdateId: 3,
 	}
-	providerKeeper.AppendPendingPackets(ctx, chainID, newPacket)
-	vscs := providerKeeper.GetPendingPackets(ctx, chainID)
+	providerKeeper.AppendPendingVSCPackets(ctx, chainID, newPacket)
+	vscs := providerKeeper.GetPendingVSCPackets(ctx, chainID)
 	require.Len(t, vscs, 3)
 	require.True(t, vscs[len(vscs)-1].ValsetUpdateId == 3)
 	require.True(t, vscs[len(vscs)-1].GetValidatorUpdates()[0].PubKey.String() == ppks[3].String())
 
-	providerKeeper.DeletePendingPackets(ctx, chainID)
-	pending = providerKeeper.GetPendingPackets(ctx, chainID)
+	providerKeeper.DeletePendingVSCPackets(ctx, chainID)
+	pending = providerKeeper.GetPendingVSCPackets(ctx, chainID)
 	require.Len(t, pending, 0)
 }
 

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -163,7 +163,7 @@ func (k Keeper) StopConsumerChain(ctx sdk.Context, chainID string, closeChan boo
 
 	k.DeleteInitChainHeight(ctx, chainID)
 	k.ConsumeSlashAcks(ctx, chainID)
-	k.DeletePendingPackets(ctx, chainID)
+	k.DeletePendingVSCPackets(ctx, chainID)
 
 	// release unbonding operations
 	var vscIDs []uint64

--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -159,7 +159,7 @@ func (k Keeper) SendVSCPackets(ctx sdk.Context) {
 	})
 }
 
-// SendPacketsToChain sends all queued VSC packets to the specified chain
+// SendVSCPacketsToChain sends all queued VSC packets to the specified chain
 func (k Keeper) SendVSCPacketsToChain(ctx sdk.Context, chainID, channelID string) {
 	pendingPackets := k.GetPendingVSCPackets(ctx, chainID)
 	for _, data := range pendingPackets {

--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -139,29 +139,29 @@ func (k Keeper) EndBlockVSU(ctx sdk.Context) {
 	// collect validator updates
 	k.QueueVSCPackets(ctx)
 
-	// try sending packets to all chains
+	// try sending VSC packets to all chains
 	// if CCV channel is not established for consumer chain
 	// the updates will remain queued until the channel is established
-	k.SendPackets(ctx)
+	k.SendVSCPackets(ctx)
 }
 
-// SendPackets iterates over chains and sends pending packets (VSCs) to
+// SendVSCPackets iterates over chains and sends pending VSC packets to
 // consumer chains with established CCV channels
 // if CCV channel is not established for consumer chain
 // the updates will remain queued until the channel is established
-func (k Keeper) SendPackets(ctx sdk.Context) {
+func (k Keeper) SendVSCPackets(ctx sdk.Context) {
 	k.IterateConsumerChains(ctx, func(ctx sdk.Context, chainID, clientID string) (stop bool) {
 		// check if CCV channel is established and send
 		if channelID, found := k.GetChainToChannel(ctx, chainID); found {
-			k.SendPacketsToChain(ctx, chainID, channelID)
+			k.SendVSCPacketsToChain(ctx, chainID, channelID)
 		}
 		return false // continue iterating chains
 	})
 }
 
-// SendPacketsToChain sends all queued packets to the specified chain
-func (k Keeper) SendPacketsToChain(ctx sdk.Context, chainID, channelID string) {
-	pendingPackets := k.GetPendingPackets(ctx, chainID)
+// SendPacketsToChain sends all queued VSC packets to the specified chain
+func (k Keeper) SendVSCPacketsToChain(ctx sdk.Context, chainID, channelID string) {
+	pendingPackets := k.GetPendingVSCPackets(ctx, chainID)
 	for _, data := range pendingPackets {
 		// send packet over IBC
 		err := utils.SendIBCPacket(
@@ -188,7 +188,7 @@ func (k Keeper) SendPacketsToChain(ctx sdk.Context, chainID, channelID string) {
 		// are actually sent over IBC
 		k.SetVscSendTimestamp(ctx, chainID, data.ValsetUpdateId, ctx.BlockTime())
 	}
-	k.DeletePendingPackets(ctx, chainID)
+	k.DeletePendingVSCPackets(ctx, chainID)
 }
 
 // QueueVSCPackets queues latest validator updates for every registered consumer chain
@@ -211,7 +211,7 @@ func (k Keeper) QueueVSCPackets(ctx sdk.Context) {
 		if len(valUpdates) != 0 || len(unbondingOps) != 0 {
 			// construct validator set change packet data
 			packet := ccv.NewValidatorSetChangePacketData(valUpdates, valUpdateID, k.ConsumeSlashAcks(ctx, chainID))
-			k.AppendPendingPackets(ctx, chainID, packet)
+			k.AppendPendingVSCPackets(ctx, chainID, packet)
 		}
 		return false // do not stop the iteration
 	})

--- a/x/ccv/provider/keeper/relay_test.go
+++ b/x/ccv/provider/keeper/relay_test.go
@@ -72,10 +72,10 @@ func TestQueueVSCPackets(t *testing.T) {
 
 		pk := testkeeper.NewInMemProviderKeeper(keeperParams, mocks)
 		// no-op if tc.packets is empty
-		pk.AppendPendingPackets(ctx, chainID, tc.packets...)
+		pk.AppendPendingVSCPackets(ctx, chainID, tc.packets...)
 
 		pk.QueueVSCPackets(ctx)
-		pending := pk.GetPendingPackets(ctx, chainID)
+		pending := pk.GetPendingVSCPackets(ctx, chainID)
 		require.Len(t, pending, tc.expectedQueueSize, "pending vsc queue mismatch (%v != %v) in case: '%s'", tc.expectedQueueSize, len(pending), tc.name)
 
 		// next valset update ID -> default value in tests is 0


### PR DESCRIPTION
## Description

Changes instances where "packets" is used on the provider to refer to VSC packets. 

## Reasoning

#462 will queue VSC Matured packets and Slash packets on the provider. So we now need to be more granular when using the term "packets". There are also places where e2e or diff tests refer to "packets" when talking about any type of IBC packet.

## Type of change

Entirely refactor

