### PR TITLE
Use SDK utility function instead of encoding/binary

### DIFF
--- a/x/ccv/consumer/keeper/keeper.go
+++ b/x/ccv/consumer/keeper/keeper.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"encoding/binary"
 	"fmt"
 
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -214,10 +213,8 @@ func (k Keeper) IteratePacketMaturityTime(ctx sdk.Context, cb func(vscId, timeNs
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
 		// Extract bytes following the 1 byte prefix
-		seqBytes := iterator.Key()[1:]
-		seq := binary.BigEndian.Uint64(seqBytes)
-
-		timeNs := binary.BigEndian.Uint64(iterator.Value())
+		seq := sdk.BigEndianToUint64(iterator.Key()[1:])
+		timeNs := sdk.BigEndianToUint64(iterator.Value())
 
 		stop := cb(seq, timeNs)
 		if stop {
@@ -229,9 +226,7 @@ func (k Keeper) IteratePacketMaturityTime(ctx sdk.Context, cb func(vscId, timeNs
 // SetPacketMaturityTime sets the maturity time for a given received VSC packet id
 func (k Keeper) SetPacketMaturityTime(ctx sdk.Context, vscId, maturityTime uint64) {
 	store := ctx.KVStore(k.storeKey)
-	timeBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(timeBytes, maturityTime)
-	store.Set(types.PacketMaturityTimeKey(vscId), timeBytes)
+	store.Set(types.PacketMaturityTimeKey(vscId), sdk.Uint64ToBigEndian(maturityTime))
 }
 
 // GetPacketMaturityTime gets the maturity time for a given received VSC packet id
@@ -241,7 +236,7 @@ func (k Keeper) GetPacketMaturityTime(ctx sdk.Context, vscId uint64) uint64 {
 	if bz == nil {
 		return 0
 	}
-	return binary.BigEndian.Uint64(bz)
+	return sdk.BigEndianToUint64(bz)
 }
 
 // DeletePacketMaturityTimes deletes the packet maturity time for given received VSC packet ids
@@ -278,9 +273,7 @@ func (k Keeper) VerifyProviderChain(ctx sdk.Context, connectionHops []string) er
 // SetHeightValsetUpdateID sets the vscID for a given block height
 func (k Keeper) SetHeightValsetUpdateID(ctx sdk.Context, height, vscID uint64) {
 	store := ctx.KVStore(k.storeKey)
-	valBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(valBytes, vscID)
-	store.Set(types.HeightValsetUpdateIDKey(height), valBytes)
+	store.Set(types.HeightValsetUpdateIDKey(height), sdk.Uint64ToBigEndian(vscID))
 }
 
 // GetHeightValsetUpdateID gets the vscID recorded for a given block height
@@ -290,7 +283,7 @@ func (k Keeper) GetHeightValsetUpdateID(ctx sdk.Context, height uint64) uint64 {
 	if bz == nil {
 		return 0
 	}
-	return binary.BigEndian.Uint64(bz)
+	return sdk.BigEndianToUint64(bz)
 }
 
 // DeleteHeightValsetUpdateID deletes the vscID for a given block height
@@ -310,10 +303,8 @@ func (k Keeper) IterateHeightToValsetUpdateID(ctx sdk.Context, cb func(height, v
 
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
-		heightBytes := iterator.Key()[1:]
-		height := binary.BigEndian.Uint64(heightBytes)
-
-		vscID := binary.BigEndian.Uint64(iterator.Value())
+		height := sdk.BigEndianToUint64(iterator.Key()[1:])
+		vscID := sdk.BigEndianToUint64(iterator.Value())
 
 		stop := cb(height, vscID)
 		if stop {

--- a/x/ccv/consumer/keeper/relay.go
+++ b/x/ccv/consumer/keeper/relay.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"encoding/binary"
 	"fmt"
 	"strconv"
 
@@ -95,7 +94,7 @@ func (k Keeper) QueueVSCMaturedPackets(ctx sdk.Context) {
 	maturedVscIds := []uint64{}
 	for maturityIterator.Valid() {
 		vscId := types.IdFromPacketMaturityTimeKey(maturityIterator.Key())
-		if currentTime >= binary.BigEndian.Uint64(maturityIterator.Value()) {
+		if currentTime >= sdk.BigEndianToUint64(maturityIterator.Value()) {
 			// construct validator set change packet data
 			vscPacket := ccv.NewVSCMaturedPacketData(vscId)
 

--- a/x/ccv/consumer/types/keys.go
+++ b/x/ccv/consumer/types/keys.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"encoding/binary"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
@@ -101,22 +99,18 @@ func PendingChangesKey() []byte {
 
 // PacketMaturityTimeKey returns the key for storing maturity time for a given received VSC packet id
 func PacketMaturityTimeKey(id uint64) []byte {
-	seqBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(seqBytes, id)
-	return append([]byte{PacketMaturityTimeBytePrefix}, seqBytes...)
+	return append([]byte{PacketMaturityTimeBytePrefix}, sdk.Uint64ToBigEndian(id)...)
 }
 
 // IdFromPacketMaturityTimeKey returns the packet id corresponding to a maturity time full key (including prefix)
 func IdFromPacketMaturityTimeKey(key []byte) uint64 {
 	// Bytes after single byte prefix are converted to uin64
-	return binary.BigEndian.Uint64(key[1:])
+	return sdk.BigEndianToUint64(key[1:])
 }
 
 // HeightValsetUpdateIDKey returns the key to a valset update ID for a given block height
 func HeightValsetUpdateIDKey(height uint64) []byte {
-	hBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(hBytes, height)
-	return append([]byte{HeightValsetUpdateIDBytePrefix}, hBytes...)
+	return append([]byte{HeightValsetUpdateIDBytePrefix}, sdk.Uint64ToBigEndian(height)...)
 }
 
 // OutstandingDowntimeKey returns the key to a validators' outstanding downtime by consensus address
@@ -131,7 +125,5 @@ func CrossChainValidatorKey(addr []byte) []byte {
 
 // HistoricalInfoKey returns the key to historical info to a given block height
 func HistoricalInfoKey(height int64) []byte {
-	hBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(hBytes, uint64(height))
-	return append([]byte{HistoricalInfoBytePrefix}, hBytes...)
+	return append([]byte{HistoricalInfoBytePrefix}, sdk.Uint64ToBigEndian(uint64(height))...)
 }

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"encoding/binary"
 	"fmt"
 	"time"
 
@@ -344,7 +343,7 @@ func (k Keeper) IterateUnbondingOps(ctx sdk.Context, cb func(id uint64, ubdOp cc
 
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
-		id := binary.BigEndian.Uint64(iterator.Key()[1:])
+		id := sdk.BigEndianToUint64(iterator.Key()[1:])
 		bz := iterator.Value()
 		if bz == nil {
 			panic(fmt.Errorf("unbonding operation is nil for id %d", id))
@@ -544,12 +543,7 @@ func (k Keeper) IncrementValidatorSetUpdateId(ctx sdk.Context) {
 
 func (k Keeper) SetValidatorSetUpdateId(ctx sdk.Context, vscID uint64) {
 	store := ctx.KVStore(k.storeKey)
-
-	// Convert back into bytes for storage
-	bz := make([]byte, 8)
-	binary.BigEndian.PutUint64(bz, vscID)
-
-	store.Set(types.ValidatorSetUpdateIdKey(), bz)
+	store.Set(types.ValidatorSetUpdateIdKey(), sdk.Uint64ToBigEndian(vscID))
 }
 
 func (k Keeper) GetValidatorSetUpdateId(ctx sdk.Context) (vscID uint64) {
@@ -560,7 +554,7 @@ func (k Keeper) GetValidatorSetUpdateId(ctx sdk.Context) (vscID uint64) {
 		vscID = 0
 	} else {
 		// Unmarshal
-		vscID = binary.BigEndian.Uint64(bz)
+		vscID = sdk.BigEndianToUint64(bz)
 	}
 
 	return vscID
@@ -569,9 +563,7 @@ func (k Keeper) GetValidatorSetUpdateId(ctx sdk.Context) (vscID uint64) {
 // SetValsetUpdateBlockHeight sets the block height for a given vscID
 func (k Keeper) SetValsetUpdateBlockHeight(ctx sdk.Context, vscID, blockHeight uint64) {
 	store := ctx.KVStore(k.storeKey)
-	heightBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(heightBytes, blockHeight)
-	store.Set(types.ValsetUpdateBlockHeightKey(vscID), heightBytes)
+	store.Set(types.ValsetUpdateBlockHeightKey(vscID), sdk.Uint64ToBigEndian(blockHeight))
 }
 
 // GetValsetUpdateBlockHeight gets the block height for a given vscID
@@ -581,7 +573,7 @@ func (k Keeper) GetValsetUpdateBlockHeight(ctx sdk.Context, vscID uint64) (uint6
 	if bz == nil {
 		return 0, false
 	}
-	return binary.BigEndian.Uint64(bz), true
+	return sdk.BigEndianToUint64(bz), true
 }
 
 // IterateValsetUpdateBlockHeight iterates through the mapping from vscIDs to block heights.
@@ -595,8 +587,8 @@ func (k Keeper) IterateValsetUpdateBlockHeight(ctx sdk.Context, cb func(vscID, h
 
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
-		vscID := binary.BigEndian.Uint64(iterator.Key()[1:])
-		height := binary.BigEndian.Uint64(iterator.Value())
+		vscID := sdk.BigEndianToUint64(iterator.Key()[1:])
+		height := sdk.BigEndianToUint64(iterator.Value())
 
 		stop := cb(vscID, height)
 		if stop {
@@ -690,10 +682,7 @@ func (k Keeper) AppendSlashAck(ctx sdk.Context, chainID, ack string) {
 // SetInitChainHeight sets the provider block height when the given consumer chain was initiated
 func (k Keeper) SetInitChainHeight(ctx sdk.Context, chainID string, height uint64) {
 	store := ctx.KVStore(k.storeKey)
-	heightBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(heightBytes, height)
-
-	store.Set(types.InitChainHeightKey(chainID), heightBytes)
+	store.Set(types.InitChainHeightKey(chainID), sdk.Uint64ToBigEndian(height))
 }
 
 // GetInitChainHeight returns the provider block height when the given consumer chain was initiated
@@ -704,7 +693,7 @@ func (k Keeper) GetInitChainHeight(ctx sdk.Context, chainID string) (uint64, boo
 		return 0, false
 	}
 
-	return binary.BigEndian.Uint64(bz), true
+	return sdk.BigEndianToUint64(bz), true
 }
 
 // DeleteInitChainHeight deletes the block height value for which the given consumer chain's channel was established
@@ -773,9 +762,7 @@ func (k Keeper) DeleteConsumerClientId(ctx sdk.Context, chainID string) {
 // SetInitTimeoutTimestamp sets the init timeout timestamp for the given chain ID
 func (k Keeper) SetInitTimeoutTimestamp(ctx sdk.Context, chainID string, ts uint64) {
 	store := ctx.KVStore(k.storeKey)
-	tsBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(tsBytes, ts)
-	store.Set(types.InitTimeoutTimestampKey(chainID), tsBytes)
+	store.Set(types.InitTimeoutTimestampKey(chainID), sdk.Uint64ToBigEndian(ts))
 }
 
 // GetInitTimeoutTimestamp returns the init timeout timestamp for the given chain ID.
@@ -786,7 +773,7 @@ func (k Keeper) GetInitTimeoutTimestamp(ctx sdk.Context, chainID string) (uint64
 	if bz == nil {
 		return 0, false
 	}
-	return binary.BigEndian.Uint64(bz), true
+	return sdk.BigEndianToUint64(bz), true
 }
 
 // DeleteInitTimeoutTimestamp removes from the store the init timeout timestamp for the given chainID.
@@ -807,7 +794,7 @@ func (k Keeper) IterateInitTimeoutTimestamp(ctx sdk.Context, cb func(chainID str
 	defer iterator.Close()
 	for ; iterator.Valid(); iterator.Next() {
 		chainID := string(iterator.Key()[1:])
-		ts := binary.BigEndian.Uint64(iterator.Value())
+		ts := sdk.BigEndianToUint64(iterator.Value())
 
 		stop := cb(chainID, ts)
 		if stop {

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 	"time"
 
@@ -186,16 +185,12 @@ func ParseUnbondingOpIndexKey(key []byte) (string, uint64, error) {
 // UnbondingOpKey returns the key that stores a record of all the ids of consumer chains that
 // need to unbond before a given unbonding operation can complete
 func UnbondingOpKey(id uint64) []byte {
-	bz := make([]byte, 8)
-	binary.BigEndian.PutUint64(bz, id)
-	return append([]byte{UnbondingOpBytePrefix}, bz...)
+	return append([]byte{UnbondingOpBytePrefix}, sdk.Uint64ToBigEndian(id)...)
 }
 
 // ValsetUpdateBlockHeightKey returns the key that storing the mapping from valset update ID to block height
 func ValsetUpdateBlockHeightKey(valsetUpdateId uint64) []byte {
-	vuidBytes := make([]byte, 8)
-	binary.BigEndian.PutUint64(vuidBytes, valsetUpdateId)
-	return append([]byte{ValsetUpdateBlockHeightBytePrefix}, vuidBytes...)
+	return append([]byte{ValsetUpdateBlockHeightBytePrefix}, sdk.Uint64ToBigEndian(valsetUpdateId)...)
 }
 
 // ConsumerGenesisKey returns the key corresponding to consumer genesis state material


### PR DESCRIPTION
# Description

Replaces 

- `binary.BigEndian.Uint64` with `sdk.BigEndianToUint64`
- `binary.BigEndian.PutUint64` with `sdk.Uint64ToBigEndian`

## Type of change

If you've checked more than one of the first three boxes, consider splitting this PR into multiple PRs!

- [x] `Refactor`: Changes existing code style, naming, structure, etc.

## Regression tests

NA
