### PR TITLE
Fix: Change keys for storing proposals

### DIFF
--- a/x/ccv/provider/keeper/genesis.go
+++ b/x/ccv/provider/keeper/genesis.go
@@ -34,7 +34,8 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState *types.GenesisState) {
 		k.SetPendingConsumerAdditionProp(ctx, &p)
 	}
 	for _, prop := range genState.ConsumerRemovalProposals {
-		k.SetPendingConsumerRemovalProp(ctx, prop.ChainId, prop.StopTime)
+		p := prop
+		k.SetPendingConsumerRemovalProp(ctx, &p)
 	}
 	for _, ubdOp := range genState.UnbondingOps {
 		k.SetUnbondingOp(ctx, ubdOp)

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -304,11 +304,10 @@ func (k Keeper) MakeConsumerGenesis(ctx sdk.Context, prop *types.ConsumerAdditio
 // the same time, then only the last one will be stored.
 func (k Keeper) SetPendingConsumerAdditionProp(ctx sdk.Context, prop *types.ConsumerAdditionProposal) {
 	store := ctx.KVStore(k.storeKey)
-	bz, err := k.cdc.Marshal(prop)
+	bz, err := prop.Marshal()
 	if err != nil {
-		panic(fmt.Errorf("consumer addition proposal could not be marshaled: %w", err))
+		panic(fmt.Errorf("failed to marshal consumer addition proposal: %w", err))
 	}
-
 	store.Set(types.PendingCAPKey(prop.SpawnTime, prop.ChainId), bz)
 }
 
@@ -320,10 +319,13 @@ func (k Keeper) GetPendingConsumerAdditionProp(ctx sdk.Context, spawnTime time.T
 	chainID string) (prop types.ConsumerAdditionProposal, found bool) {
 	store := ctx.KVStore(k.storeKey)
 	bz := store.Get(types.PendingCAPKey(spawnTime, chainID))
-	if len(bz) == 0 {
+	if bz == nil {
 		return prop, false
 	}
-	k.cdc.MustUnmarshal(bz, &prop)
+	err := prop.Unmarshal(bz)
+	if err != nil {
+		panic(fmt.Errorf("failed to unmarshal consumer addition proposal: %w", err))
+	}
 
 	return prop, true
 }
@@ -366,7 +368,10 @@ func (k Keeper) GetConsumerAdditionPropsToExecute(ctx sdk.Context) (propsToExecu
 
 	for ; iterator.Valid(); iterator.Next() {
 		var prop types.ConsumerAdditionProposal
-		k.cdc.MustUnmarshal(iterator.Value(), &prop)
+		err := prop.Unmarshal(iterator.Value())
+		if err != nil {
+			panic(fmt.Errorf("failed to unmarshal consumer addition proposal: %w", err))
+		}
 
 		if !ctx.BlockTime().Before(prop.SpawnTime) {
 			propsToExecute = append(propsToExecute, prop)
@@ -391,7 +396,10 @@ func (k Keeper) GetAllPendingConsumerAdditionProps(ctx sdk.Context) (props []typ
 
 	for ; iterator.Valid(); iterator.Next() {
 		var prop types.ConsumerAdditionProposal
-		k.cdc.MustUnmarshal(iterator.Value(), &prop)
+		err := prop.Unmarshal(iterator.Value())
+		if err != nil {
+			panic(fmt.Errorf("failed to unmarshal consumer addition proposal: %w", err))
+		}
 
 		props = append(props, prop)
 	}
@@ -416,9 +424,9 @@ func (k Keeper) DeletePendingConsumerAdditionProps(ctx sdk.Context, proposals ..
 // the same time, then only the last one will be stored.
 func (k Keeper) SetPendingConsumerRemovalProp(ctx sdk.Context, prop *types.ConsumerRemovalProposal) {
 	store := ctx.KVStore(k.storeKey)
-	bz, err := k.cdc.Marshal(prop)
+	bz, err := prop.Marshal()
 	if err != nil {
-		panic(fmt.Errorf("consumer removal proposal could not be marshaled: %w", err))
+		panic(fmt.Errorf("failed to marshal consumer removal proposal: %w", err))
 	}
 	store.Set(types.PendingCRPKey(prop.StopTime, prop.ChainId), bz)
 }
@@ -488,7 +496,10 @@ func (k Keeper) GetConsumerRemovalPropsToExecute(ctx sdk.Context) []types.Consum
 
 	for ; iterator.Valid(); iterator.Next() {
 		var prop types.ConsumerRemovalProposal
-		k.cdc.MustUnmarshal(iterator.Value(), &prop)
+		err := prop.Unmarshal(iterator.Value())
+		if err != nil {
+			panic(fmt.Errorf("failed to unmarshal consumer removal proposal: %w", err))
+		}
 
 		if !ctx.BlockTime().Before(prop.StopTime) {
 			propsToExecute = append(propsToExecute, prop)
@@ -513,7 +524,10 @@ func (k Keeper) GetAllPendingConsumerRemovalProps(ctx sdk.Context) (props []type
 
 	for ; iterator.Valid(); iterator.Next() {
 		var prop types.ConsumerRemovalProposal
-		k.cdc.MustUnmarshal(iterator.Value(), &prop)
+		err := prop.Unmarshal(iterator.Value())
+		if err != nil {
+			panic(fmt.Errorf("failed to unmarshal consumer removal proposal: %w", err))
+		}
 
 		props = append(props, prop)
 	}

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -501,6 +501,7 @@ func (k Keeper) GetConsumerRemovalPropsToExecute(ctx sdk.Context) []types.Consum
 			panic(fmt.Errorf("failed to unmarshal consumer removal proposal: %w", err))
 		}
 
+		// If current block time is equal to or after stop time, proposal is ready to be executed
 		if !ctx.BlockTime().Before(prop.StopTime) {
 			propsToExecute = append(propsToExecute, prop)
 		} else {

--- a/x/ccv/provider/keeper/proposal_test.go
+++ b/x/ccv/provider/keeper/proposal_test.go
@@ -1,7 +1,9 @@
 package keeper_test
 
 import (
+	"bytes"
 	"encoding/json"
+	"sort"
 	"testing"
 	"time"
 
@@ -254,50 +256,65 @@ func TestPendingConsumerAdditionPropDeletion(t *testing.T) {
 	}
 }
 
-// TestPendingConsumerAdditionPropOrder tests that pending consumer addition proposals
-// are accessed in order by timestamp via the iterator
-func TestPendingConsumerAdditionPropOrder(t *testing.T) {
+// TestGetConsumerAdditionPropsToExecute tests that pending consumer addition proposals
+// that are ready to execute are accessed in order by timestamp via the iterator
+func TestGetConsumerAdditionPropsToExecute(t *testing.T) {
 
 	now := time.Now().UTC()
+	sampleProp1 := providertypes.ConsumerAdditionProposal{ChainId: "chain-2", SpawnTime: now}
+	sampleProp2 := providertypes.ConsumerAdditionProposal{ChainId: "chain-1", SpawnTime: now.Add(time.Hour)}
+	sampleProp3 := providertypes.ConsumerAdditionProposal{ChainId: "chain-4", SpawnTime: now.Add(-time.Hour)}
+	sampleProp4 := providertypes.ConsumerAdditionProposal{ChainId: "chain-3", SpawnTime: now}
+	sampleProp5 := providertypes.ConsumerAdditionProposal{ChainId: "chain-1", SpawnTime: now.Add(2 * time.Hour)}
 
-	// props with unique chain ids and spawn times
-	sampleProp1 := providertypes.ConsumerAdditionProposal{ChainId: "1", SpawnTime: now}
-	sampleProp2 := providertypes.ConsumerAdditionProposal{ChainId: "2", SpawnTime: now.Add(1 * time.Hour)}
-	sampleProp3 := providertypes.ConsumerAdditionProposal{ChainId: "3", SpawnTime: now.Add(2 * time.Hour)}
-	sampleProp4 := providertypes.ConsumerAdditionProposal{ChainId: "4", SpawnTime: now.Add(3 * time.Hour)}
-	sampleProp5 := providertypes.ConsumerAdditionProposal{ChainId: "5", SpawnTime: now.Add(4 * time.Hour)}
+	getExpectedOrder := func(props []providertypes.ConsumerAdditionProposal, accessTime time.Time) []providertypes.ConsumerAdditionProposal {
+		expectedOrder := []providertypes.ConsumerAdditionProposal{}
+		for _, prop := range props {
+			if !accessTime.Before(prop.SpawnTime) {
+				expectedOrder = append(expectedOrder, prop)
+			}
+		}
+		if len(expectedOrder) == 0 {
+			return nil
+		}
+		// sorting by SpawnTime.UnixNano()
+		sort.Slice(expectedOrder, func(i, j int) bool {
+			if expectedOrder[i].SpawnTime.UTC() == expectedOrder[j].SpawnTime.UTC() {
+				// proposals with same SpawnTime
+				return expectedOrder[i].ChainId < expectedOrder[j].ChainId
+			}
+			return expectedOrder[i].SpawnTime.UTC().Before(expectedOrder[j].SpawnTime.UTC())
+		})
+		return expectedOrder
+	}
 
 	testCases := []struct {
-		propSubmitOrder      []providertypes.ConsumerAdditionProposal
-		accessTime           time.Time
-		expectedOrderedProps []providertypes.ConsumerAdditionProposal
+		propSubmitOrder []providertypes.ConsumerAdditionProposal
+		accessTime      time.Time
 	}{
 		{
 			propSubmitOrder: []providertypes.ConsumerAdditionProposal{
 				sampleProp1, sampleProp2, sampleProp3, sampleProp4, sampleProp5,
 			},
-			accessTime: now.Add(30 * time.Minute),
-			expectedOrderedProps: []providertypes.ConsumerAdditionProposal{
-				sampleProp1,
-			},
+			accessTime: now,
 		},
 		{
 			propSubmitOrder: []providertypes.ConsumerAdditionProposal{
 				sampleProp3, sampleProp2, sampleProp1, sampleProp5, sampleProp4,
 			},
-			accessTime: now.Add(3 * time.Hour).Add(30 * time.Minute),
-			expectedOrderedProps: []providertypes.ConsumerAdditionProposal{
-				sampleProp1, sampleProp2, sampleProp3, sampleProp4,
-			},
+			accessTime: now.Add(time.Hour),
 		},
 		{
 			propSubmitOrder: []providertypes.ConsumerAdditionProposal{
 				sampleProp5, sampleProp4, sampleProp3, sampleProp2, sampleProp1,
 			},
-			accessTime: now.Add(5 * time.Hour),
-			expectedOrderedProps: []providertypes.ConsumerAdditionProposal{
-				sampleProp1, sampleProp2, sampleProp3, sampleProp4, sampleProp5,
+			accessTime: now.Add(-2 * time.Hour),
+		},
+		{
+			propSubmitOrder: []providertypes.ConsumerAdditionProposal{
+				sampleProp5, sampleProp4, sampleProp3, sampleProp2, sampleProp1,
 			},
+			accessTime: now.Add(3 * time.Hour),
 		},
 	}
 
@@ -305,14 +322,52 @@ func TestPendingConsumerAdditionPropOrder(t *testing.T) {
 		providerKeeper, ctx, ctrl, _ := testkeeper.GetProviderKeeperAndCtx(t, testkeeper.NewInMemKeeperParams(t))
 		defer ctrl.Finish()
 
-		ctx = ctx.WithBlockTime(tc.accessTime)
+		expectedOrderedProps := getExpectedOrder(tc.propSubmitOrder, tc.accessTime)
 
 		for _, prop := range tc.propSubmitOrder {
-			providerKeeper.SetPendingConsumerAdditionProp(ctx, &prop)
+			cpProp := prop
+			providerKeeper.SetPendingConsumerAdditionProp(ctx, &cpProp)
 		}
-		propsToExecute := providerKeeper.GetConsumerAdditionPropsToExecute(ctx)
-		require.Equal(t, tc.expectedOrderedProps, propsToExecute)
+		propsToExecute := providerKeeper.GetConsumerAdditionPropsToExecute(ctx.WithBlockTime(tc.accessTime))
+		require.Equal(t, expectedOrderedProps, propsToExecute)
 	}
+}
+
+// Test getting both matured and pending consumer addition proposals
+func TestGetAllConsumerAdditionProps(t *testing.T) {
+	pk, ctx, ctrl, _ := testkeeper.GetProviderKeeperAndCtx(t, testkeeper.NewInMemKeeperParams(t))
+	defer ctrl.Finish()
+
+	now := time.Now().UTC()
+	props := []providertypes.ConsumerAdditionProposal{
+		{ChainId: "chain-2", SpawnTime: now},
+		{ChainId: "chain-1", SpawnTime: now.Add(2 * time.Hour)},
+		{ChainId: "chain-4", SpawnTime: now.Add(-time.Hour)},
+		{ChainId: "chain-3", SpawnTime: now.Add(4 * time.Hour)},
+		{ChainId: "chain-1", SpawnTime: now},
+	}
+	expectedGetAllOrder := props
+	// sorting by SpawnTime.UnixNano()
+	sort.Slice(expectedGetAllOrder, func(i, j int) bool {
+		tsi := uint64(expectedGetAllOrder[i].SpawnTime.UTC().UnixNano())
+		tsj := uint64(expectedGetAllOrder[j].SpawnTime.UTC().UnixNano())
+		cmpTimestamps := bytes.Compare(sdk.Uint64ToBigEndian(tsi), sdk.Uint64ToBigEndian(tsj))
+		if cmpTimestamps == 0 {
+			// proposals with same SpawnTime
+			return expectedGetAllOrder[i].ChainId < expectedGetAllOrder[j].ChainId
+		}
+		return cmpTimestamps == -1
+	})
+
+	for _, prop := range props {
+		cpProp := prop // bring into loop scope - avoids using iterator pointer instead of value pointer
+		pk.SetPendingConsumerAdditionProp(ctx, &cpProp)
+	}
+
+	// iterate and check all results are returned in the expected order
+	result := pk.GetAllPendingConsumerAdditionProps(ctx.WithBlockTime(now))
+	require.Len(t, result, len(props))
+	require.Equal(t, expectedGetAllOrder, result)
 }
 
 //
@@ -545,7 +600,7 @@ func TestPendingConsumerRemovalPropDeletion(t *testing.T) {
 	defer ctrl.Finish()
 
 	for _, tc := range testCases {
-		providerKeeper.SetPendingConsumerRemovalProp(ctx, tc.ChainId, tc.StopTime)
+		providerKeeper.SetPendingConsumerRemovalProp(ctx, &tc.ConsumerRemovalProposal)
 	}
 
 	ctx = ctx.WithBlockTime(time.Now().UTC())
@@ -566,63 +621,114 @@ func TestPendingConsumerRemovalPropDeletion(t *testing.T) {
 	}
 }
 
-// Tests that pending consumer removal proposals are accessed in order by timestamp via the iterator
-func TestPendingConsumerRemovalPropOrder(t *testing.T) {
-
+// TestGetConsumerRemovalPropsToExecute tests that pending consumer removal proposals
+// that are ready to execute are accessed in order by timestamp via the iterator
+func TestGetConsumerRemovalPropsToExecute(t *testing.T) {
 	now := time.Now().UTC()
+	sampleProp1 := providertypes.ConsumerRemovalProposal{ChainId: "chain-2", StopTime: now}
+	sampleProp2 := providertypes.ConsumerRemovalProposal{ChainId: "chain-1", StopTime: now.Add(time.Hour)}
+	sampleProp3 := providertypes.ConsumerRemovalProposal{ChainId: "chain-4", StopTime: now.Add(-time.Hour)}
+	sampleProp4 := providertypes.ConsumerRemovalProposal{ChainId: "chain-3", StopTime: now}
+	sampleProp5 := providertypes.ConsumerRemovalProposal{ChainId: "chain-1", StopTime: now.Add(2 * time.Hour)}
 
-	// props with unique chain ids and spawn times
-	sampleProp1 := providertypes.ConsumerRemovalProposal{ChainId: "1", StopTime: now}
-	sampleProp2 := providertypes.ConsumerRemovalProposal{ChainId: "2", StopTime: now.Add(1 * time.Hour)}
-	sampleProp3 := providertypes.ConsumerRemovalProposal{ChainId: "3", StopTime: now.Add(2 * time.Hour)}
-	sampleProp4 := providertypes.ConsumerRemovalProposal{ChainId: "4", StopTime: now.Add(3 * time.Hour)}
-	sampleProp5 := providertypes.ConsumerRemovalProposal{ChainId: "5", StopTime: now.Add(4 * time.Hour)}
+	getExpectedOrder := func(props []providertypes.ConsumerRemovalProposal, accessTime time.Time) []providertypes.ConsumerRemovalProposal {
+		expectedOrder := []providertypes.ConsumerRemovalProposal{}
+		for _, prop := range props {
+			if !accessTime.Before(prop.StopTime) {
+				expectedOrder = append(expectedOrder, prop)
+			}
+		}
+		// sorting by SpawnTime.UnixNano()
+		sort.Slice(expectedOrder, func(i, j int) bool {
+			if expectedOrder[i].StopTime.UTC() == expectedOrder[j].StopTime.UTC() {
+				// proposals with same StopTime
+				return expectedOrder[i].ChainId < expectedOrder[j].ChainId
+			}
+			return expectedOrder[i].StopTime.UTC().Before(expectedOrder[j].StopTime.UTC())
+		})
+		return expectedOrder
+	}
 
 	testCases := []struct {
-		propSubmitOrder      []providertypes.ConsumerRemovalProposal
-		accessTime           time.Time
-		expectedOrderedProps []providertypes.ConsumerRemovalProposal
+		propSubmitOrder []providertypes.ConsumerRemovalProposal
+		accessTime      time.Time
 	}{
 		{
 			propSubmitOrder: []providertypes.ConsumerRemovalProposal{
 				sampleProp1, sampleProp2, sampleProp3, sampleProp4, sampleProp5,
 			},
-			accessTime: now.Add(30 * time.Minute),
-			expectedOrderedProps: []providertypes.ConsumerRemovalProposal{
-				sampleProp1,
-			},
+			accessTime: now,
 		},
 		{
 			propSubmitOrder: []providertypes.ConsumerRemovalProposal{
 				sampleProp3, sampleProp2, sampleProp1, sampleProp5, sampleProp4,
 			},
-			accessTime: now.Add(3 * time.Hour).Add(30 * time.Minute),
-			expectedOrderedProps: []providertypes.ConsumerRemovalProposal{
-				sampleProp1, sampleProp2, sampleProp3, sampleProp4,
-			},
+			accessTime: now.Add(time.Hour),
 		},
 		{
 			propSubmitOrder: []providertypes.ConsumerRemovalProposal{
 				sampleProp5, sampleProp4, sampleProp3, sampleProp2, sampleProp1,
 			},
-			accessTime: now.Add(5 * time.Hour),
-			expectedOrderedProps: []providertypes.ConsumerRemovalProposal{
-				sampleProp1, sampleProp2, sampleProp3, sampleProp4, sampleProp5,
+			accessTime: now.Add(-2 * time.Hour),
+		},
+		{
+			propSubmitOrder: []providertypes.ConsumerRemovalProposal{
+				sampleProp5, sampleProp4, sampleProp3, sampleProp2, sampleProp1,
 			},
+			accessTime: now.Add(3 * time.Hour),
 		},
 	}
 
 	for _, tc := range testCases {
 		providerKeeper, ctx, ctrl, _ := testkeeper.GetProviderKeeperAndCtx(t, testkeeper.NewInMemKeeperParams(t))
 		defer ctrl.Finish()
-		ctx = ctx.WithBlockTime(tc.accessTime)
+
+		expectedOrderedProps := getExpectedOrder(tc.propSubmitOrder, tc.accessTime)
 
 		for _, prop := range tc.propSubmitOrder {
-			providerKeeper.SetPendingConsumerRemovalProp(ctx, prop.ChainId, prop.StopTime)
+			cpProp := prop
+			providerKeeper.SetPendingConsumerRemovalProp(ctx, &cpProp)
 		}
-		propsToExecute := providerKeeper.GetConsumerRemovalPropsToExecute(ctx)
-		require.Equal(t, tc.expectedOrderedProps, propsToExecute)
+		propsToExecute := providerKeeper.GetConsumerRemovalPropsToExecute(ctx.WithBlockTime(tc.accessTime))
+		require.Equal(t, expectedOrderedProps, propsToExecute)
 	}
+}
+
+// Test getting both matured and pending consumer removal proposals
+func TestGetAllConsumerRemovalProps(t *testing.T) {
+	pk, ctx, ctrl, _ := testkeeper.GetProviderKeeperAndCtx(t, testkeeper.NewInMemKeeperParams(t))
+	defer ctrl.Finish()
+
+	now := time.Now().UTC()
+	props := []providertypes.ConsumerRemovalProposal{
+		{ChainId: "chain-2", StopTime: now},
+		{ChainId: "chain-1", StopTime: now.Add(2 * time.Hour)},
+		{ChainId: "chain-4", StopTime: now.Add(-time.Hour)},
+		{ChainId: "chain-3", StopTime: now.Add(4 * time.Hour)},
+		{ChainId: "chain-1", StopTime: now},
+	}
+	expectedGetAllOrder := props
+	// sorting by StopTime.UnixNano()
+	sort.Slice(expectedGetAllOrder, func(i, j int) bool {
+		tsi := uint64(expectedGetAllOrder[i].StopTime.UTC().UnixNano())
+		tsj := uint64(expectedGetAllOrder[j].StopTime.UTC().UnixNano())
+		cmpTimestamps := bytes.Compare(sdk.Uint64ToBigEndian(tsi), sdk.Uint64ToBigEndian(tsj))
+		if cmpTimestamps == 0 {
+			// proposals with same StopTime
+			return expectedGetAllOrder[i].ChainId < expectedGetAllOrder[j].ChainId
+		}
+		return cmpTimestamps == -1
+	})
+
+	for _, prop := range props {
+		cpProp := prop // bring into loop scope - avoids using iterator pointer instead of value pointer
+		pk.SetPendingConsumerRemovalProp(ctx, &cpProp)
+	}
+
+	// iterate and check all results are returned in the expected order
+	result := pk.GetAllPendingConsumerRemovalProps(ctx.WithBlockTime(now))
+	require.Len(t, result, len(props))
+	require.Equal(t, expectedGetAllOrder, result)
 }
 
 // TestMakeConsumerGenesis tests the MakeConsumerGenesis keeper method.
@@ -870,14 +976,14 @@ func TestBeginBlockCCR(t *testing.T) {
 		require.NoError(t, err)
 
 		// Set removal props for all consumer chains
-		providerKeeper.SetPendingConsumerRemovalProp(ctx, prop.ChainId, prop.StopTime)
+		providerKeeper.SetPendingConsumerRemovalProp(ctx, prop)
 	}
 
 	// Add an invalid prop to the store with an non-existing chain id
 	invalidProp := providertypes.NewConsumerRemovalProposal(
 		"title", "description", "chain4", now.Add(-time.Hour).UTC(),
 	).(*providertypes.ConsumerRemovalProposal)
-	providerKeeper.SetPendingConsumerRemovalProp(ctx, invalidProp.ChainId, invalidProp.StopTime)
+	providerKeeper.SetPendingConsumerRemovalProp(ctx, invalidProp)
 
 	//
 	// Test execution
@@ -897,59 +1003,4 @@ func TestBeginBlockCCR(t *testing.T) {
 	found = providerKeeper.PendingConsumerRemovalPropExists(
 		ctx, invalidProp.ChainId, invalidProp.StopTime)
 	require.False(t, found)
-}
-
-// Test getting both matured and pending comnsumer addition proposals
-func TestGetAllConsumerAdditionProps(t *testing.T) {
-	now := time.Now().UTC()
-
-	props := []providertypes.ConsumerAdditionProposal{
-		{ChainId: "1", SpawnTime: now.Add(1 * time.Hour)},
-		{ChainId: "2", SpawnTime: now.Add(2 * time.Hour)},
-		{ChainId: "3", SpawnTime: now.Add(3 * time.Hour)},
-		{ChainId: "4", SpawnTime: now.Add(4 * time.Hour)},
-	}
-
-	keeperParams := testkeeper.NewInMemKeeperParams(t)
-	providerKeeper, ctx, ctrl, _ := testkeeper.GetProviderKeeperAndCtx(t, keeperParams)
-	defer ctrl.Finish()
-
-	for _, prop := range props {
-		cpProp := prop // bring into loop scope - avoids using iterator pointer instead of value pointer
-		providerKeeper.SetPendingConsumerAdditionProp(ctx, &cpProp)
-	}
-
-	// advance the clock to be 1 minute after first proposal
-	ctx = ctx.WithBlockTime(now.Add(time.Minute))
-	res := providerKeeper.GetAllPendingConsumerAdditionProps(ctx)
-	require.NotEmpty(t, res, "GetAllConsumerAdditionProps returned empty result")
-	require.Len(t, res, 4, "wrong len for pending addition props")
-	require.Equal(t, props[0].ChainId, res[0].ChainId, "wrong chain ID for pending addition prop")
-}
-
-// Test getting both matured and pending consumer removal proposals
-func TestGetAllConsumerRemovalProps(t *testing.T) {
-	now := time.Now().UTC()
-
-	props := []providertypes.ConsumerRemovalProposal{
-		{ChainId: "1", StopTime: now.Add(1 * time.Hour)},
-		{ChainId: "2", StopTime: now.Add(2 * time.Hour)},
-		{ChainId: "3", StopTime: now.Add(3 * time.Hour)},
-		{ChainId: "4", StopTime: now.Add(4 * time.Hour)},
-	}
-
-	keeperParams := testkeeper.NewInMemKeeperParams(t)
-	providerKeeper, ctx, ctrl, _ := testkeeper.GetProviderKeeperAndCtx(t, keeperParams)
-	defer ctrl.Finish()
-
-	for _, prop := range props {
-		providerKeeper.SetPendingConsumerRemovalProp(ctx, prop.ChainId, prop.StopTime)
-	}
-
-	// advance the clock to be 1 minute after first proposal
-	ctx = ctx.WithBlockTime(now.Add(time.Minute))
-	res := providerKeeper.GetAllPendingConsumerRemovalProps(ctx)
-	require.NotEmpty(t, res, "GetAllConsumerRemovalProps returned empty result")
-	require.Len(t, res, 4, "wrong len for pending removal props")
-	require.Equal(t, props[0].ChainId, res[0].ChainId, "wrong chain ID for pending removal prop")
 }

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -169,19 +169,32 @@ func InitTimeoutTimestampKey(chainID string) []byte {
 	return append([]byte{InitTimeoutTimestampBytePrefix}, []byte(chainID)...)
 }
 
-// PendingCAPKey returns the key under which a pending consumer addition proposal is stored
+// PendingCAPKey returns the key under which a pending consumer addition proposal is stored.
+// The key has the following format: PendingCAPBytePrefix | timestamp.UnixNano() | chainID
 func PendingCAPKey(timestamp time.Time, chainID string) []byte {
-	return TsAndChainIdKey(PendingCAPBytePrefix, timestamp, chainID)
+	ts := uint64(timestamp.UTC().UnixNano())
+	return AppendMany(
+		// Append the prefix
+		[]byte{PendingCAPBytePrefix},
+		// Append the time
+		sdk.Uint64ToBigEndian(ts),
+		// Append the chainId
+		[]byte(chainID),
+	)
 }
 
-// PendingCRPKey returns the key under which pending consumer removal proposals are stored
+// PendingCRPKey returns the key under which pending consumer removal proposals are stored.
+// The key has the following format: PendingCRPBytePrefix | timestamp.UnixNano() | chainID
 func PendingCRPKey(timestamp time.Time, chainID string) []byte {
-	return TsAndChainIdKey(PendingCRPBytePrefix, timestamp, chainID)
-}
-
-// ParsePendingCRPKey returns the time and chain ID for a pending consumer removal proposal key or an error if unparseable
-func ParsePendingCRPKey(bz []byte) (time.Time, string, error) {
-	return ParseTsAndChainIdKey(PendingCRPBytePrefix, bz)
+	ts := uint64(timestamp.UTC().UnixNano())
+	return AppendMany(
+		// Append the prefix
+		[]byte{PendingCRPBytePrefix},
+		// Append the time
+		sdk.Uint64ToBigEndian(ts),
+		// Append the chainId
+		[]byte(chainID),
+	)
 }
 
 // UnbondingOpIndexKey returns an unbonding op index key

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -349,42 +349,6 @@ func AppendMany(byteses ...[]byte) (out []byte) {
 	return out
 }
 
-// TsAndChainIdKey returns the key with the following format:
-// bytePrefix | len(timestamp) | timestamp | chainID
-func TsAndChainIdKey(prefix byte, timestamp time.Time, chainID string) []byte {
-	timeBz := sdk.FormatTimeBytes(timestamp)
-	timeBzL := len(timeBz)
-
-	return AppendMany(
-		// Append the prefix
-		[]byte{prefix},
-		// Append the time length
-		sdk.Uint64ToBigEndian(uint64(timeBzL)),
-		// Append the time bytes
-		timeBz,
-		// Append the chainId
-		[]byte(chainID),
-	)
-}
-
-// ParseTsAndChainIdKey returns the time and chain ID for a TsAndChainId key
-func ParseTsAndChainIdKey(prefix byte, bz []byte) (time.Time, string, error) {
-	expectedPrefix := []byte{prefix}
-	prefixL := len(expectedPrefix)
-	if prefix := bz[:prefixL]; !bytes.Equal(prefix, expectedPrefix) {
-		return time.Time{}, "", fmt.Errorf("invalid prefix; expected: %X, got: %X", expectedPrefix, prefix)
-	}
-
-	timeBzL := sdk.BigEndianToUint64(bz[prefixL : prefixL+8])
-	timestamp, err := sdk.ParseTimeBytes(bz[prefixL+8 : prefixL+8+int(timeBzL)])
-	if err != nil {
-		return time.Time{}, "", err
-	}
-
-	chainID := string(bz[prefixL+8+int(timeBzL):])
-	return timestamp, chainID, nil
-}
-
 // ChainIdAndTsKey returns the key with the following format:
 // bytePrefix | len(chainID) | chainID | timestamp
 func ChainIdAndTsKey(prefix byte, chainID string, timestamp time.Time) []byte {

--- a/x/ccv/provider/types/keys_test.go
+++ b/x/ccv/provider/types/keys_test.go
@@ -70,32 +70,6 @@ func getSingleByteKeys() [][]byte {
 	return keys[:i]
 }
 
-// Tests the construction and parsing of TsAndChainId keys
-func TestTsAndChainIdKeyAndParse(t *testing.T) {
-	tests := []struct {
-		prefix    byte
-		timestamp time.Time
-		chainID   string
-	}{
-		{prefix: 0x01, timestamp: time.Now(), chainID: "1"},
-		{prefix: 0x02, timestamp: time.Date(
-			2003, 11, 17, 20, 34, 58, 651387237, time.UTC), chainID: "some other ID"},
-		{prefix: 0x03, timestamp: time.Now().Add(5000 * time.Hour), chainID: "some other other chain ID"},
-	}
-
-	for _, test := range tests {
-		key := providertypes.TsAndChainIdKey(test.prefix, test.timestamp, test.chainID)
-		require.NotEmpty(t, key)
-		// Expected bytes = prefix + time length + time bytes + length of chainID
-		expectedLen := 1 + 8 + len(sdk.FormatTimeBytes(time.Time{})) + len(test.chainID)
-		require.Equal(t, expectedLen, len(key))
-		parsedTime, parsedID, err := providertypes.ParseTsAndChainIdKey(test.prefix, key)
-		require.Equal(t, test.timestamp.UTC(), parsedTime.UTC())
-		require.Equal(t, test.chainID, parsedID)
-		require.NoError(t, err)
-	}
-}
-
 // Tests the construction and parsing of ChainIdAndTs keys
 func TestChainIdAndTsKeyAndParse(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
# Description

Store both consumer addition proposals and consumer removal proposals under keys with the format `prefix | timestamp.UnixNano() | chainID` to enable the iteration in order of timestamps.  

- [ ] Based on https://github.com/cosmos/interchain-security/pull/596

## Linked issues

Closes:  https://github.com/cosmos/interchain-security/issues/537

## Type of change

If you've checked more than one of the first three boxes, consider splitting this PR into multiple PRs!

- [x] `Fix`: Changes and/or adds code behavior, specifically to fix a bug
- [x] `Testing`: Adds testing

## New behavior tests

Updated the tests to check that the iteration is in the expected order, see `TestGetConsumerAdditionPropsToExecute`, `TestGetAllConsumerAdditionProps`, `TestGetConsumerRemovalPropsToExecute`, `TestGetAllConsumerRemovalProps`.
