### PR TITLE
Add test for GetSlashAndTrailingData

### DIFF
--- a/x/ccv/provider/keeper/throttle.go
+++ b/x/ccv/provider/keeper/throttle.go
@@ -201,7 +201,11 @@ func (k Keeper) DeleteGlobalSlashEntriesForConsumer(ctx sdktypes.Context, consum
 	k.DeleteGlobalSlashEntries(ctx, entriesToDel...)
 }
 
-// GetAllGlobalSlashEntries returns all global slash entries from the queue
+// GetAllGlobalSlashEntries returns all global slash entries from the queue.
+//
+// Note global slash entries are stored under keys with the following format:
+// GlobalSlashEntryBytePrefix | uint64 recv time | ibc seq num | consumer chain id
+// Thus, the returned array is ordered by recv time, then ibc seq num.
 func (k Keeper) GetAllGlobalSlashEntries(ctx sdktypes.Context) []providertypes.GlobalSlashEntry {
 
 	store := ctx.KVStore(k.storeKey)
@@ -320,8 +324,9 @@ func (k Keeper) QueueThrottledPacketData(
 // GetSlashAndTrailingData returns the first slash packet data instance and any
 // trailing vsc matured packet data instances in the chain-specific throttled packet data queue.
 //
-// Note: this method is not tested directly, but is covered indirectly
-// by TestHandlePacketDataForChain and e2e tests.
+// Note that throttled packet data is stored under keys with the following format:
+// Prefix | len(chainID) | chainID | ibcSeqNum
+// Thus, the returned array is in ascending order of ibc seq numbers.
 func (k Keeper) GetSlashAndTrailingData(ctx sdktypes.Context, consumerChainID string) (
 	slashFound bool, slashData ccvtypes.SlashPacketData, vscMaturedData []ccvtypes.VSCMaturedPacketData,
 	// Note: this slice contains the IBC sequence numbers of the slash packet data

--- a/x/ccv/provider/keeper/throttle.go
+++ b/x/ccv/provider/keeper/throttle.go
@@ -372,6 +372,7 @@ func (k Keeper) GetSlashAndTrailingData(ctx sdktypes.Context, consumerChainID st
 // GetAllThrottledPacketData returns all throttled packet data for a specific consumer chain.
 //
 // Note: This method is only used by tests, hence why it returns redundant data as different types.
+// This method is not unit tested, as it is a test util.
 func (k Keeper) GetAllThrottledPacketData(ctx sdktypes.Context, consumerChainID string) (
 	slashData []ccvtypes.SlashPacketData, vscMaturedData []ccvtypes.VSCMaturedPacketData,
 	rawOrderedData []interface{}, ibcSeqNums []uint64) {

--- a/x/ccv/provider/keeper/throttle.go
+++ b/x/ccv/provider/keeper/throttle.go
@@ -325,7 +325,7 @@ func (k Keeper) QueueThrottledPacketData(
 // trailing vsc matured packet data instances in the chain-specific throttled packet data queue.
 //
 // Note that throttled packet data is stored under keys with the following format:
-// Prefix | len(chainID) | chainID | ibcSeqNum
+// ThrottledPacketDataBytePrefix | len(chainID) | chainID | ibcSeqNum
 // Thus, the returned array is in ascending order of ibc seq numbers.
 func (k Keeper) GetSlashAndTrailingData(ctx sdktypes.Context, consumerChainID string) (
 	slashFound bool, slashData ccvtypes.SlashPacketData, vscMaturedData []ccvtypes.VSCMaturedPacketData,


### PR DESCRIPTION
# Description

Adds test for `GetSlashAndTrailingData`, to make sure all iteration methods from https://github.com/cosmos/interchain-security/issues/454 are tested in #596. @mpoke feel free to merge whenever

## Type of change

- [x] `Testing`: Adds testing
