### PR TITLE
Stop consumer when too many queued packets

### DIFF
--- a/proto/interchain_security/ccv/provider/v1/provider.proto
+++ b/proto/interchain_security/ccv/provider/v1/provider.proto
@@ -123,8 +123,8 @@ message Params {
   // This param also serves as a maximum fraction of total voting power that the slash meter can hold.
   string slash_meter_replenish_fraction = 7;
 
-  // The maximum amount of throttled slash or vsc matured packets 
-  // that can be queued for a single consumer before the provider chain halts.
+  // The maximum amount of throttled slash or vsc matured packets
+  // that can be queued for a single consumer before the provider removes that consumer.
   int64 max_throttled_packets = 8;
 }
 

--- a/x/ccv/provider/keeper/params.go
+++ b/x/ccv/provider/keeper/params.go
@@ -70,7 +70,7 @@ func (k Keeper) GetSlashMeterReplenishFraction(ctx sdk.Context) string {
 }
 
 // GetMaxThrottledPackets returns the maximum amount of throttled slash or vsc matured packets
-// that can be queued for a single consumer before the provider chain halts.
+// that can be queued for a single consumer before the provider removes that consumer.
 func (k Keeper) GetMaxThrottledPackets(ctx sdk.Context) int64 {
 	var p int64
 	k.paramSpace.Get(ctx, types.KeyMaxThrottledPackets, &p)

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -205,6 +205,7 @@ func (k Keeper) StopConsumerChain(ctx sdk.Context, chainID string, closeChan boo
 	// since all unbonding operations for this consumer are release above.
 	k.DeleteThrottledPacketDataForConsumer(ctx, chainID)
 
+	k.Logger(ctx).Info("Consumer chain state has been removed from provider!", "chainID", chainID)
 	return nil
 }
 

--- a/x/ccv/provider/keeper/throttle.go
+++ b/x/ccv/provider/keeper/throttle.go
@@ -259,7 +259,10 @@ func (k Keeper) SetThrottledPacketDataSize(ctx sdktypes.Context, consumerChainID
 	// large for a single consumer chain. This check ensures that binaries would remove a consumer
 	// deterministically if the queue does grow too large.
 	if size >= uint64(k.GetMaxThrottledPackets(ctx)) {
-		k.StopConsumerChain(ctx, consumerChainID, true)
+		err := k.StopConsumerChain(ctx, consumerChainID, true)
+		if err != nil {
+			k.Logger(ctx).Error(fmt.Sprintf("failed to stop consumer chain %s: %s", consumerChainID, err))
+		}
 		// All consumer related data should be deleted in the above call, so return
 		return
 	}

--- a/x/ccv/provider/types/provider.pb.go
+++ b/x/ccv/provider/types/provider.pb.go
@@ -280,7 +280,7 @@ type Params struct {
 	// This param also serves as a maximum fraction of total voting power that the slash meter can hold.
 	SlashMeterReplenishFraction string `protobuf:"bytes,7,opt,name=slash_meter_replenish_fraction,json=slashMeterReplenishFraction,proto3" json:"slash_meter_replenish_fraction,omitempty"`
 	// The maximum amount of throttled slash or vsc matured packets
-	// that can be queued for a single consumer before the provider chain halts.
+	// that can be queued for a single consumer before the provider removes that consumer.
 	MaxThrottledPackets int64 `protobuf:"varint,8,opt,name=max_throttled_packets,json=maxThrottledPackets,proto3" json:"max_throttled_packets,omitempty"`
 }
 


### PR DESCRIPTION
# Description

Stops a consumer instead of panicking the provider in the event that a consumer's chain-specific throttle queue becomes too large.

TODO: Update default MaxThrottledPackets from 1k -> 10k
TODO: e2e test because this change is risky

## Linked issues

Closes: `#<issue>`

## Type of change

If you've checked more than one of the first three boxes, consider splitting this PR into multiple PRs!

- [x] `Feature`: Changes and/or adds code behavior, irrelevant to bug fixes

## Regression tests

If `Refactor`, describe the new or existing tests that verify no behavior was changed or added where refactors were introduced.

## New behavior tests

If `Feature` or `Fix`, describe the new or existing tests that verify the new behavior is correct and expected.
