### PR TITLE
Throttle related panic cleanup

### DIFF
--- a/tests/e2e/stop_consumer.go
+++ b/tests/e2e/stop_consumer.go
@@ -90,8 +90,9 @@ func (s *CCVTestSuite) TestStopConsumerChain() {
 				err := providerKeeper.QueueThrottledSlashPacketData(s.providerCtx(), firstBundle.Chain.ChainID, 1,
 					ccv.SlashPacketData{ValsetUpdateId: 1})
 				suite.Require().NoError(err)
-				providerKeeper.QueueThrottledVSCMaturedPacketData(s.providerCtx(),
+				err = providerKeeper.QueueThrottledVSCMaturedPacketData(s.providerCtx(),
 					firstBundle.Chain.ChainID, 2, ccv.VSCMaturedPacketData{ValsetUpdateId: 2})
+				suite.Require().NoError(err)
 
 				// Queue slash and vsc packet data for consumer 1, these queue entries will be not be removed
 				secondBundle := s.getBundleByIdx(1)
@@ -100,8 +101,9 @@ func (s *CCVTestSuite) TestStopConsumerChain() {
 				err = providerKeeper.QueueThrottledSlashPacketData(s.providerCtx(), secondBundle.Chain.ChainID, 1,
 					ccv.SlashPacketData{ValsetUpdateId: 1})
 				suite.Require().NoError(err)
-				providerKeeper.QueueThrottledVSCMaturedPacketData(s.providerCtx(),
+				err = providerKeeper.QueueThrottledVSCMaturedPacketData(s.providerCtx(),
 					secondBundle.Chain.ChainID, 2, ccv.VSCMaturedPacketData{ValsetUpdateId: 2})
+				suite.Require().NoError(err)
 
 				return nil
 			},

--- a/tests/e2e/stop_consumer.go
+++ b/tests/e2e/stop_consumer.go
@@ -87,8 +87,9 @@ func (s *CCVTestSuite) TestStopConsumerChain() {
 				firstBundle := s.getFirstBundle()
 				globalEntry := types.NewGlobalSlashEntry(s.providerCtx().BlockTime(), firstBundle.Chain.ChainID, 7, []byte{})
 				providerKeeper.QueueGlobalSlashEntry(s.providerCtx(), globalEntry)
-				providerKeeper.QueueThrottledSlashPacketData(s.providerCtx(), firstBundle.Chain.ChainID, 1,
+				err := providerKeeper.QueueThrottledSlashPacketData(s.providerCtx(), firstBundle.Chain.ChainID, 1,
 					ccv.SlashPacketData{ValsetUpdateId: 1})
+				suite.Require().NoError(err)
 				providerKeeper.QueueThrottledVSCMaturedPacketData(s.providerCtx(),
 					firstBundle.Chain.ChainID, 2, ccv.VSCMaturedPacketData{ValsetUpdateId: 2})
 
@@ -96,8 +97,9 @@ func (s *CCVTestSuite) TestStopConsumerChain() {
 				secondBundle := s.getBundleByIdx(1)
 				globalEntry = types.NewGlobalSlashEntry(s.providerCtx().BlockTime(), secondBundle.Chain.ChainID, 7, []byte{})
 				providerKeeper.QueueGlobalSlashEntry(s.providerCtx(), globalEntry)
-				providerKeeper.QueueThrottledSlashPacketData(s.providerCtx(), secondBundle.Chain.ChainID, 1,
+				err = providerKeeper.QueueThrottledSlashPacketData(s.providerCtx(), secondBundle.Chain.ChainID, 1,
 					ccv.SlashPacketData{ValsetUpdateId: 1})
+				suite.Require().NoError(err)
 				providerKeeper.QueueThrottledVSCMaturedPacketData(s.providerCtx(),
 					secondBundle.Chain.ChainID, 2, ccv.VSCMaturedPacketData{ValsetUpdateId: 2})
 

--- a/x/ccv/provider/ibc_module.go
+++ b/x/ccv/provider/ibc_module.go
@@ -182,6 +182,7 @@ func (am AppModule) OnRecvPacket(
 		ack = &errAck
 	} else {
 		// TODO: call ValidateBasic method on consumer packet data
+		// See: https://github.com/cosmos/interchain-security/issues/634
 
 		switch consumerPacket.Type {
 		case ccv.VscMaturedPacket:

--- a/x/ccv/provider/keeper/proposal_test.go
+++ b/x/ccv/provider/keeper/proposal_test.go
@@ -510,7 +510,10 @@ func TestStopConsumerChain(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chainID", 2, testkeeper.GetNewVSCMaturedPacketData())
+				err = providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chainID", 2, testkeeper.GetNewVSCMaturedPacketData())
+				if err != nil {
+					t.Fatal(err)
+				}
 			},
 			expErr: false,
 		},

--- a/x/ccv/provider/keeper/proposal_test.go
+++ b/x/ccv/provider/keeper/proposal_test.go
@@ -506,7 +506,10 @@ func TestStopConsumerChain(t *testing.T) {
 				providerKeeper.QueueGlobalSlashEntry(ctx, providertypes.NewGlobalSlashEntry(
 					ctx.BlockTime(), "chainID", 1, cryptoutil.NewCryptoIdentityFromIntSeed(90).SDKConsAddress()))
 
-				providerKeeper.QueueThrottledSlashPacketData(ctx, "chainID", 1, testkeeper.GetNewSlashPacketData())
+				err := providerKeeper.QueueThrottledSlashPacketData(ctx, "chainID", 1, testkeeper.GetNewSlashPacketData())
+				if err != nil {
+					t.Fatal(err)
+				}
 				providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chainID", 2, testkeeper.GetNewVSCMaturedPacketData())
 			},
 			expErr: false,

--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -268,10 +268,30 @@ func (k Keeper) EndBlockCIS(ctx sdk.Context) {
 	// Replenish slash meter if necessary, BEFORE executing slash packet throttling logic.
 	// This ensures the meter value is replenished, and not greater than the allowance (max value)
 	// for the block, before the throttling logic is executed.
+	//
+	// Note: CheckForSlashMeterReplenishment contains panics for the following scenarios, any of which should never occur
+	// if the protocol is correct and external data is properly validated:
+	//
+	// - Either SlashMeter or LastSlashMeterFullTime have not been set (both of which should be set in InitGenesis, see InitializeSlashMeter).
+	// - Params not being set (all of which should be set in InitGenesis).
+	// - Marshaling and/or store corruption errors.
+	// - Setting invalid slash meter values (see SetSlashMeter).
 	k.CheckForSlashMeterReplenishment(ctx)
-	// Handle leading vsc matured packets before throttling logic
+	// Handle leading vsc matured packets before throttling logic.
+	//
+	// Note: HandleLeadingVSCMaturedPackets contains panics for the following scenarios, any of which should never occur
+	// if the protocol is correct and external data is properly validated:
+	//
+	// - Marshaling and/or store corruption errors.
 	k.HandleLeadingVSCMaturedPackets(ctx)
-	// Execute slash packet throttling logic
+	// Handle queue entries considering throttling logic.
+	//
+	// Note: HandleThrottleQueues contains panics for the following scenarios, any of which should never occur
+	// if the protocol is correct and external data is properly validated:
+	//
+	// - SlashMeter has not been set (which should be set in InitGenesis, see InitializeSlashMeter).
+	// - Marshaling and/or store corruption errors.
+	// - Setting invalid slash meter values (see SetSlashMeter).
 	k.HandleThrottleQueues(ctx)
 }
 

--- a/x/ccv/provider/keeper/relay_test.go
+++ b/x/ccv/provider/keeper/relay_test.go
@@ -117,7 +117,8 @@ func TestOnRecvVSCMaturedPacket(t *testing.T) {
 
 	// Now queue a slash packet data instance for chain-2, then confirm the on recv method
 	// queues the vsc matured behind the slash packet data
-	providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-2", 1, testkeeper.GetNewSlashPacketData())
+	err := providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-2", 1, testkeeper.GetNewSlashPacketData())
+	require.NoError(t, err)
 	ack = executeOnRecvVSCMaturedPacket(t, &providerKeeper, ctx, "channel-2", 2)
 	require.Equal(t, channeltypes.NewResultAcknowledgement([]byte{byte(1)}), ack)
 	require.Equal(t, uint64(2), providerKeeper.GetThrottledPacketDataSize(ctx, "chain-2"))
@@ -159,8 +160,10 @@ func TestHandleLeadingVSCMaturedPackets(t *testing.T) {
 	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-1", 3, vscData[2])
 
 	// Queue some trailing slash packet data (and a couple more vsc matured)
-	providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-1", 4, testkeeper.GetNewSlashPacketData())
-	providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-1", 5, testkeeper.GetNewSlashPacketData())
+	err := providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-1", 4, testkeeper.GetNewSlashPacketData())
+	require.NoError(t, err)
+	err = providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-1", 5, testkeeper.GetNewSlashPacketData())
+	require.NoError(t, err)
 	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-1", 6, vscData[3])
 	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-1", 7, vscData[4])
 
@@ -169,8 +172,10 @@ func TestHandleLeadingVSCMaturedPackets(t *testing.T) {
 	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-2", 2, vscData[6])
 
 	// And trailing slash packet data for chain-2
-	providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-2", 3, testkeeper.GetNewSlashPacketData())
-	providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-2", 4, testkeeper.GetNewSlashPacketData())
+	err = providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-2", 3, testkeeper.GetNewSlashPacketData())
+	require.NoError(t, err)
+	err = providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-2", 4, testkeeper.GetNewSlashPacketData())
+	require.NoError(t, err)
 
 	// And one more trailing vsc matured packet for chain-2
 	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-2", 5, vscData[7])

--- a/x/ccv/provider/keeper/relay_test.go
+++ b/x/ccv/provider/keeper/relay_test.go
@@ -157,9 +157,9 @@ func TestHandleLeadingVSCMaturedPackets(t *testing.T) {
 	// Queue some leading vsc matured packet data for chain-1
 	err := providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-1", 1, vscData[0])
 	require.NoError(t, err)
-	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-1", 2, vscData[1])
+	err = providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-1", 2, vscData[1])
 	require.NoError(t, err)
-	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-1", 3, vscData[2])
+	err = providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-1", 3, vscData[2])
 	require.NoError(t, err)
 
 	// Queue some trailing slash packet data (and a couple more vsc matured)

--- a/x/ccv/provider/keeper/relay_test.go
+++ b/x/ccv/provider/keeper/relay_test.go
@@ -155,21 +155,28 @@ func TestHandleLeadingVSCMaturedPackets(t *testing.T) {
 	providerKeeper.SetConsumerClientId(ctx, "chain-2", "client-2")
 
 	// Queue some leading vsc matured packet data for chain-1
-	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-1", 1, vscData[0])
+	err := providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-1", 1, vscData[0])
+	require.NoError(t, err)
 	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-1", 2, vscData[1])
+	require.NoError(t, err)
 	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-1", 3, vscData[2])
+	require.NoError(t, err)
 
 	// Queue some trailing slash packet data (and a couple more vsc matured)
-	err := providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-1", 4, testkeeper.GetNewSlashPacketData())
+	err = providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-1", 4, testkeeper.GetNewSlashPacketData())
 	require.NoError(t, err)
 	err = providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-1", 5, testkeeper.GetNewSlashPacketData())
 	require.NoError(t, err)
-	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-1", 6, vscData[3])
-	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-1", 7, vscData[4])
+	err = providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-1", 6, vscData[3])
+	require.NoError(t, err)
+	err = providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-1", 7, vscData[4])
+	require.NoError(t, err)
 
 	// Queue some leading vsc matured packet data for chain-2
-	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-2", 1, vscData[5])
-	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-2", 2, vscData[6])
+	err = providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-2", 1, vscData[5])
+	require.NoError(t, err)
+	err = providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-2", 2, vscData[6])
+	require.NoError(t, err)
 
 	// And trailing slash packet data for chain-2
 	err = providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-2", 3, testkeeper.GetNewSlashPacketData())
@@ -178,7 +185,8 @@ func TestHandleLeadingVSCMaturedPackets(t *testing.T) {
 	require.NoError(t, err)
 
 	// And one more trailing vsc matured packet for chain-2
-	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-2", 5, vscData[7])
+	err = providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-2", 5, vscData[7])
+	require.NoError(t, err)
 
 	// Set VSC Send timestamps for each recv vsc matured packet
 	providerKeeper.SetVscSendTimestamp(ctx, "chain-1", vscData[0].ValsetUpdateId, time.Now())

--- a/x/ccv/provider/keeper/throttle.go
+++ b/x/ccv/provider/keeper/throttle.go
@@ -165,7 +165,7 @@ func (k Keeper) ReplenishSlashMeter(ctx sdktypes.Context) {
 func (k Keeper) GetSlashMeterAllowance(ctx sdktypes.Context) sdktypes.Int {
 
 	strFrac := k.GetSlashMeterReplenishFraction(ctx)
-	// The below func should not panic, since the (string representation) of the slash meter replenish fraction
+	// MustNewDecFromStr should not panic, since the (string representation) of the slash meter replenish fraction
 	// is validated in ValidateGenesis and anytime the param is mutated.
 	decFrac := sdktypes.MustNewDecFromStr(strFrac)
 
@@ -227,7 +227,7 @@ func (k Keeper) GetAllGlobalSlashEntries(ctx sdktypes.Context) []providertypes.G
 	entries := []providertypes.GlobalSlashEntry{}
 
 	for ; iterator.Valid(); iterator.Next() {
-		// The below func should not panic, since we should be iterating over keys that're
+		// MustParseGlobalSlashEntryKey should not panic, since we should be iterating over keys that're
 		// assumed to be correctly serialized in QueueGlobalSlashEntry.
 		recvTime, chainID, ibcSeqNum := providertypes.MustParseGlobalSlashEntryKey(iterator.Key())
 		valAddr := iterator.Value()
@@ -335,7 +335,7 @@ func (k Keeper) QueueThrottledPacketData(
 		}
 		bz = append([]byte{vscMaturedPacketData}, bz...)
 	default:
-		// Default case would indicate a developer error, this method should only be called
+		// Indicates a developer error, this method should only be called
 		// by tests, QueueThrottledSlashPacketData, or QueueThrottledVSCMaturedPacketData.
 		panic(fmt.Sprintf("unexpected packet data type: %T", data))
 	}

--- a/x/ccv/provider/keeper/throttle.go
+++ b/x/ccv/provider/keeper/throttle.go
@@ -559,6 +559,9 @@ func (k Keeper) GetSlashMeter(ctx sdktypes.Context) sdktypes.Int {
 //
 // Note: the value of this int should always be in the range of tendermint's [-MaxTotalVotingPower, MaxTotalVotingPower]
 func (k Keeper) SetSlashMeter(ctx sdktypes.Context, value sdktypes.Int) {
+
+	// TODO: remove these invariant panics once https://github.com/cosmos/interchain-security/issues/534 is solved.
+
 	// The following panics are included since they are invariants for slash meter value.
 	//
 	// Explanation: slash meter replenish fraction is validated to be in range of [0, 1],

--- a/x/ccv/provider/keeper/throttle.go
+++ b/x/ccv/provider/keeper/throttle.go
@@ -165,10 +165,9 @@ func (k Keeper) ReplenishSlashMeter(ctx sdktypes.Context) {
 func (k Keeper) GetSlashMeterAllowance(ctx sdktypes.Context) sdktypes.Int {
 
 	strFrac := k.GetSlashMeterReplenishFraction(ctx)
-	decFrac, err := sdktypes.NewDecFromStr(strFrac)
-	if err != nil {
-		panic(fmt.Sprintf("failed to parse slash meter replenish fraction: %s", err))
-	}
+	// The below func should not panic, since the (string representation) of the slash meter replenish fraction
+	// is validated in ValidateGenesis and anytime the param is mutated.
+	decFrac := sdktypes.MustNewDecFromStr(strFrac)
 
 	// Compute allowance in units of tendermint voting power (integer),
 	// noting that total power changes over time
@@ -229,7 +228,9 @@ func (k Keeper) GetAllGlobalSlashEntries(ctx sdktypes.Context) []providertypes.G
 	entries := []providertypes.GlobalSlashEntry{}
 
 	for ; iterator.Valid(); iterator.Next() {
-		recvTime, chainID, ibcSeqNum := providertypes.ParseGlobalSlashEntryKey(iterator.Key())
+		// The below func should not panic, since we should be iterating over keys that're
+		// assumed to be correctly serialized in QueueGlobalSlashEntry.
+		recvTime, chainID, ibcSeqNum := providertypes.MustParseGlobalSlashEntryKey(iterator.Key())
 		valAddr := iterator.Value()
 		entry := providertypes.NewGlobalSlashEntry(recvTime, chainID, ibcSeqNum, valAddr)
 		entries = append(entries, entry)
@@ -270,7 +271,7 @@ func (k Keeper) SetThrottledPacketDataSize(ctx sdktypes.Context, consumerChainID
 
 	// Sanity check to ensure that the chain-specific throttled packet data queue does not grow too
 	// large for a single consumer chain. This check ensures that binaries would panic deterministically
-	// if the queue does grow too large.
+	// if the queue does grow too large. MaxThrottledPackets should be set accordingly (quite large).
 	if size >= uint64(k.GetMaxThrottledPackets(ctx)) {
 		panic(fmt.Sprintf("throttled packet data queue for chain %s is too large: %d", consumerChainID, size))
 	}
@@ -322,16 +323,22 @@ func (k Keeper) QueueThrottledPacketData(
 	case ccvtypes.SlashPacketData:
 		bz, err = data.Marshal()
 		if err != nil {
+			// Slash packet data is assumed to be validated in OnRecvPacket and/or OnRecvSlashPacket,
+			// hence an error here would indicate something is very wrong.
 			panic(fmt.Sprintf("failed to marshal slash packet data: %v", err))
 		}
 		bz = append([]byte{slashPacketData}, bz...)
 	case ccvtypes.VSCMaturedPacketData:
 		bz, err = data.Marshal()
 		if err != nil {
+			// VSC matured packet data is assumed to be validated in OnRecvPacket and/or OnRecvVSCMaturedPacket,
+			// hence an error here would indicate something is very wrong.
 			panic(fmt.Sprintf("failed to marshal vsc matured packet data: %v", err))
 		}
 		bz = append([]byte{vscMaturedPacketData}, bz...)
 	default:
+		// Default case would indicate a developer error, this method should only be called
+		// by tests, QueueThrottledSlashPacketData, or QueueThrottledVSCMaturedPacketData.
 		panic(fmt.Sprintf("unexpected packet data type: %T", data))
 	}
 
@@ -360,16 +367,22 @@ func (k Keeper) GetLeadingVSCMaturedData(ctx sdktypes.Context, consumerChainID s
 		if bz[0] == slashPacketData {
 			break
 		} else if bz[0] != vscMaturedPacketData {
+			// This case would indicate a developer error or store corruption,
+			// since QueueThrottledPacketData should only queue slash packet data or vsc matured packet data.
 			panic(fmt.Sprintf("unexpected packet data type: %d", bz[0]))
 		}
 
 		var data ccvtypes.VSCMaturedPacketData
 		err := data.Unmarshal(bz[1:])
 		if err != nil {
+			// An error here would indicate something is very wrong,
+			// vsc matured packet data is assumed to be correctly serialized in QueueThrottledPacketData.
 			panic(fmt.Sprintf("failed to unmarshal vsc matured packet data: %v", err))
 		}
 
 		vscMaturedData = append(vscMaturedData, data)
+		// The below func should not panic, since we should be iterating over keys that're
+		// assumed to be correctly serialized in QueueThrottledPacketData.
 		_, ibcSeqNum := providertypes.MustParseThrottledPacketDataKey(iterator.Key())
 		ibcSeqNums = append(ibcSeqNums, ibcSeqNum)
 	}
@@ -389,7 +402,6 @@ func (k Keeper) GetSlashAndTrailingData(ctx sdktypes.Context, consumerChainID st
 	// data after it has been handled.
 	ibcSeqNums []uint64,
 ) {
-
 	store := ctx.KVStore(k.storeKey)
 	iteratorPrefix := providertypes.ChainIdWithLenKey(providertypes.ThrottledPacketDataBytePrefix, consumerChainID)
 	iterator := sdktypes.KVStorePrefixIterator(store, iteratorPrefix)
@@ -409,20 +421,27 @@ func (k Keeper) GetSlashAndTrailingData(ctx sdktypes.Context, consumerChainID st
 				break
 			} else {
 				if err := slashData.Unmarshal(bz[1:]); err != nil {
-					panic(fmt.Sprintf("failed to unmarshal pending packet data: %v", err))
+					// An error here would indicate something is very wrong,
+					// slash packet data is assumed to be correctly serialized in QueueThrottledPacketData.
+					panic(fmt.Sprintf("failed to unmarshal slash packet data: %v", err))
 				}
 				slashFound = true
 			}
 		} else if bz[0] == vscMaturedPacketData {
 			vscMData := ccvtypes.VSCMaturedPacketData{}
 			if err := vscMData.Unmarshal(bz[1:]); err != nil {
-				panic(fmt.Sprintf("failed to unmarshal pending packet data: %v", err))
+				// An error here would indicate something is very wrong,
+				// vsc matured packet data is assumed to be correctly serialized in QueueThrottledPacketData.
+				panic(fmt.Sprintf("failed to unmarshal vsc matured packet data: %v", err))
 			}
 			vscMaturedData = append(vscMaturedData, vscMData)
 		} else {
+			// This case would indicate a developer error or store corruption,
+			// since QueueThrottledPacketData should only queue slash packet data or vsc matured packet data.
 			panic("invalid packet data type")
 		}
-
+		// The below func should not panic, since we should be iterating over keys that're
+		// assumed to be correctly serialized in QueueThrottledPacketData.
 		_, ibcSeqNum := providertypes.MustParseThrottledPacketDataKey(iterator.Key())
 		ibcSeqNums = append(ibcSeqNums, ibcSeqNum)
 	}
@@ -431,8 +450,8 @@ func (k Keeper) GetSlashAndTrailingData(ctx sdktypes.Context, consumerChainID st
 
 // GetAllThrottledPacketData returns all throttled packet data for a specific consumer chain.
 //
-// Note: This method is only used by tests, hence why it returns redundant data as different types.
-// This method is not unit tested, as it is a test util.
+// Note: This method is only used by tests and queries, hence why it returns redundant data as different types.
+// Since this method executes on query, no panics are explicitly included.
 func (k Keeper) GetAllThrottledPacketData(ctx sdktypes.Context, consumerChainID string) (
 	slashData []ccvtypes.SlashPacketData, vscMaturedData []ccvtypes.VSCMaturedPacketData,
 	rawOrderedData []interface{}, ibcSeqNums []uint64) {
@@ -453,21 +472,28 @@ func (k Keeper) GetAllThrottledPacketData(ctx sdktypes.Context, consumerChainID 
 		case slashPacketData:
 			d := ccvtypes.SlashPacketData{}
 			if err := d.Unmarshal(bz[1:]); err != nil {
-				panic(fmt.Sprintf("failed to unmarshal slash packet data: %v", err))
+				k.Logger(ctx).Error(fmt.Sprintf("failed to unmarshal slash packet data: %v", err))
+				continue
 			}
 			slashData = append(slashData, d)
 			rawOrderedData = append(rawOrderedData, d)
 		case vscMaturedPacketData:
 			d := ccvtypes.VSCMaturedPacketData{}
 			if err := d.Unmarshal(bz[1:]); err != nil {
-				panic(fmt.Sprintf("failed to unmarshal vsc matured packet data: %v", err))
+				k.Logger(ctx).Error(fmt.Sprintf("failed to unmarshal vsc matured packet data: %v", err))
+				continue
 			}
 			vscMaturedData = append(vscMaturedData, d)
 			rawOrderedData = append(rawOrderedData, d)
 		default:
-			panic(fmt.Sprintf("invalid packet data type: %v", bz[0]))
+			k.Logger(ctx).Error(fmt.Sprintf("invalid packet data type: %v", bz[0]))
+			continue
 		}
-		_, ibcSeqNum := providertypes.MustParseThrottledPacketDataKey(iterator.Key())
+		_, ibcSeqNum, err := providertypes.ParseThrottledPacketDataKey(iterator.Key())
+		if err != nil {
+			k.Logger(ctx).Error(fmt.Sprintf("failed to parse throttled packet data key: %v", err))
+			continue
+		}
 		ibcSeqNums = append(ibcSeqNums, ibcSeqNum)
 	}
 
@@ -515,11 +541,15 @@ func (k Keeper) GetSlashMeter(ctx sdktypes.Context) sdktypes.Int {
 	store := ctx.KVStore(k.storeKey)
 	bz := store.Get(providertypes.SlashMeterKey())
 	if bz == nil {
+		// Slash meter should be set as a part of InitGenesis and periodically updated by throttle logic,
+		// there is no deletion method exposed, so nil bytes would indicate something is very wrong.
 		panic("slash meter not set")
 	}
 	value := sdktypes.ZeroInt()
 	err := value.Unmarshal(bz)
 	if err != nil {
+		// We should have obtained value bytes that were serialized in SetSlashMeter,
+		// so an error here would indicate something is very wrong.
 		panic(fmt.Sprintf("failed to unmarshal slash meter: %v", err))
 	}
 	return value
@@ -527,17 +557,24 @@ func (k Keeper) GetSlashMeter(ctx sdktypes.Context) sdktypes.Int {
 
 // SetSlashMeter sets the slash meter to the given signed int value
 //
-// Note: the value of this int should always be in the range of tendermint's [-MaxVotingPower, MaxVotingPower]
+// Note: the value of this int should always be in the range of tendermint's [-MaxTotalVotingPower, MaxTotalVotingPower]
 func (k Keeper) SetSlashMeter(ctx sdktypes.Context, value sdktypes.Int) {
+	// The following panics are included since they are invariants for slash meter value.
+	//
+	// Explanation: slash meter replenish fraction is validated to be in range of [0, 1],
+	// and MaxMeterValue = MaxAllowance = MaxReplenishFrac * MaxTotalVotingPower = 1 * MaxTotalVotingPower.
 	if value.GT(sdktypes.NewInt(tmtypes.MaxTotalVotingPower)) {
 		panic("slash meter value cannot be greater than tendermint's MaxTotalVotingPower")
 	}
+	// Further, HandleThrottleQueues should never subtract more than MaxTotalVotingPower from the meter,
+	// since we cannot slash more than an entire validator set. So MinMeterValue = -1 * MaxTotalVotingPower.
 	if value.LT(sdktypes.NewInt(-tmtypes.MaxTotalVotingPower)) {
 		panic("slash meter value cannot be less than negative tendermint's MaxTotalVotingPower")
 	}
 	store := ctx.KVStore(k.storeKey)
 	bz, err := value.Marshal()
 	if err != nil {
+		// A returned error for marshaling an int would indicate something is very wrong.
 		panic(fmt.Sprintf("failed to marshal slash meter: %v", err))
 	}
 	store.Set(providertypes.SlashMeterKey(), bz)
@@ -548,11 +585,15 @@ func (k Keeper) GetLastSlashMeterFullTime(ctx sdktypes.Context) time.Time {
 	store := ctx.KVStore(k.storeKey)
 	bz := store.Get(providertypes.LastSlashMeterFullTimeKey())
 	if bz == nil {
-		panic("last slash replenish time not set")
+		// Last slash meter full time should be set as a part of InitGenesis and periodically updated by throttle logic,
+		// there is no deletion method exposed, so nil bytes would indicate something is very wrong.
+		panic("last slash meter full time not set")
 	}
 	time, err := sdktypes.ParseTimeBytes(bz)
 	if err != nil {
-		panic(fmt.Sprintf("failed to parse last slash meter replenish time: %s", err))
+		// We should have obtained value bytes that were serialized in SetLastSlashMeterFullTime,
+		// so an error here would indicate something is very wrong.
+		panic(fmt.Sprintf("failed to parse last slash meter full time: %s", err))
 	}
 	return time.UTC()
 }

--- a/x/ccv/provider/keeper/throttle_test.go
+++ b/x/ccv/provider/keeper/throttle_test.go
@@ -917,7 +917,8 @@ func TestGetLeadingVSCMaturedData(t *testing.T) {
 
 		// Queue a slash and vsc matured packet data for some random chain.
 		// These values should never be returned.
-		providerKeeper.QueueThrottledSlashPacketData(ctx, "some-rando-chain", 77, testkeeper.GetNewSlashPacketData())
+		err := providerKeeper.QueueThrottledSlashPacketData(ctx, "some-rando-chain", 77, testkeeper.GetNewSlashPacketData())
+		require.NoError(t, err)
 		providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "some-rando-chain", 97, testkeeper.GetNewVSCMaturedPacketData())
 
 		// Queue the data to test against
@@ -1020,7 +1021,8 @@ func TestGetSlashAndTrailingData(t *testing.T) {
 
 		// Queue a slash and vsc matured packet data for some random chain.
 		// These values should never be returned.
-		providerKeeper.QueueThrottledSlashPacketData(ctx, "some-rando-chain", 77, testkeeper.GetNewSlashPacketData())
+		err := providerKeeper.QueueThrottledSlashPacketData(ctx, "some-rando-chain", 77, testkeeper.GetNewSlashPacketData())
+		require.NoError(t, err)
 		providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "some-rando-chain", 97, testkeeper.GetNewVSCMaturedPacketData())
 
 		// Queue the data to test
@@ -1045,13 +1047,17 @@ func TestDeleteThrottledPacketDataForConsumer(t *testing.T) {
 	providerKeeper.SetParams(ctx, providertypes.DefaultParams())
 
 	// Queue slash and a VSC matured packet data for chain-48
-	providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-48", 0, testkeeper.GetNewSlashPacketData())
+	err := providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-48", 0, testkeeper.GetNewSlashPacketData())
+	require.NoError(t, err)
 	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-48", 1, testkeeper.GetNewVSCMaturedPacketData())
 
 	// Queue 3 slash, and 4 vsc matured packet data instances for chain-49
-	providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-49", 0, testkeeper.GetNewSlashPacketData())
-	providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-49", 1, testkeeper.GetNewSlashPacketData())
-	providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-49", 2, testkeeper.GetNewSlashPacketData())
+	err = providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-49", 0, testkeeper.GetNewSlashPacketData())
+	require.NoError(t, err)
+	err = providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-49", 1, testkeeper.GetNewSlashPacketData())
+	require.NoError(t, err)
+	err = providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-49", 2, testkeeper.GetNewSlashPacketData())
+	require.NoError(t, err)
 	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-49", 3, testkeeper.GetNewVSCMaturedPacketData())
 	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-49", 4, testkeeper.GetNewVSCMaturedPacketData())
 	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-49", 5, testkeeper.GetNewVSCMaturedPacketData())

--- a/x/ccv/provider/keeper/throttle_test.go
+++ b/x/ccv/provider/keeper/throttle_test.go
@@ -122,7 +122,8 @@ func TestHandlePacketDataForChain(t *testing.T) {
 
 		// Queue throttled packet data, where chainID is arbitrary, and ibc seq number is index of the data instance
 		for i, data := range tc.dataToQueue {
-			providerKeeper.QueueThrottledPacketData(ctx, tc.chainID, uint64(i), data)
+			err := providerKeeper.QueueThrottledPacketData(ctx, tc.chainID, uint64(i), data)
+			require.NoError(t, err)
 		}
 
 		// Define our handler callbacks to simply store the data instances that are handled
@@ -805,7 +806,8 @@ func TestThrottledPacketData(t *testing.T) {
 	// Queue all packet data at once
 	for _, chainData := range packetDataForMultipleConsumers {
 		for _, dataInstance := range chainData.instances {
-			providerKeeper.QueueThrottledPacketData(ctx, chainData.chainID, dataInstance.IbcSeqNum, dataInstance.Data)
+			err := providerKeeper.QueueThrottledPacketData(ctx, chainData.chainID, dataInstance.IbcSeqNum, dataInstance.Data)
+			require.NoError(t, err)
 		}
 	}
 
@@ -924,7 +926,8 @@ func TestGetLeadingVSCMaturedData(t *testing.T) {
 
 		// Queue the data to test against
 		for _, dataInstance := range tc.dataToQueue {
-			providerKeeper.QueueThrottledPacketData(ctx, "chain-99", dataInstance.IbcSeqNum, dataInstance.Data)
+			err := providerKeeper.QueueThrottledPacketData(ctx, "chain-99", dataInstance.IbcSeqNum, dataInstance.Data)
+			require.NoError(t, err)
 		}
 
 		// Obtain data from iterator
@@ -1029,7 +1032,8 @@ func TestGetSlashAndTrailingData(t *testing.T) {
 
 		// Queue the data to test
 		for _, dataInstance := range tc.dataToQueue {
-			providerKeeper.QueueThrottledPacketData(ctx, "chain-49", dataInstance.IbcSeqNum, dataInstance.Data)
+			err := providerKeeper.QueueThrottledPacketData(ctx, "chain-49", dataInstance.IbcSeqNum, dataInstance.Data)
+			require.NoError(t, err)
 		}
 
 		// Retrieve the data, and assert that it is correct
@@ -1113,8 +1117,10 @@ func TestPanicIfTooMuchThrottledPacketData(t *testing.T) {
 		rand.Seed(time.Now().UnixNano())
 
 		// Queuing up a couple data instances for another chain shouldn't matter
-		providerKeeper.QueueThrottledPacketData(ctx, "chain-17", 0, testkeeper.GetNewSlashPacketData())
-		providerKeeper.QueueThrottledPacketData(ctx, "chain-17", 1, testkeeper.GetNewVSCMaturedPacketData())
+		err := providerKeeper.QueueThrottledPacketData(ctx, "chain-17", 0, testkeeper.GetNewSlashPacketData())
+		require.NoError(t, err)
+		err = providerKeeper.QueueThrottledPacketData(ctx, "chain-17", 1, testkeeper.GetNewVSCMaturedPacketData())
+		require.NoError(t, err)
 
 		// Queue packet data instances until we reach the max (some slash packets, some VSC matured packets)
 		reachedMax := false
@@ -1129,11 +1135,12 @@ func TestPanicIfTooMuchThrottledPacketData(t *testing.T) {
 			// Panic only if we've reached the max
 			if i == int(tc.max-1) {
 				require.Panics(t, func() {
-					providerKeeper.QueueThrottledPacketData(ctx, "chain-88", uint64(i), data)
+					_ = providerKeeper.QueueThrottledPacketData(ctx, "chain-88", uint64(i), data)
 				})
 				reachedMax = true
 			} else {
-				providerKeeper.QueueThrottledPacketData(ctx, "chain-88", uint64(i), data)
+				err := providerKeeper.QueueThrottledPacketData(ctx, "chain-88", uint64(i), data)
+				require.NoError(t, err)
 			}
 		}
 		require.True(t, reachedMax)

--- a/x/ccv/provider/keeper/throttle_test.go
+++ b/x/ccv/provider/keeper/throttle_test.go
@@ -919,7 +919,8 @@ func TestGetLeadingVSCMaturedData(t *testing.T) {
 		// These values should never be returned.
 		err := providerKeeper.QueueThrottledSlashPacketData(ctx, "some-rando-chain", 77, testkeeper.GetNewSlashPacketData())
 		require.NoError(t, err)
-		providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "some-rando-chain", 97, testkeeper.GetNewVSCMaturedPacketData())
+		err = providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "some-rando-chain", 97, testkeeper.GetNewVSCMaturedPacketData())
+		require.NoError(t, err)
 
 		// Queue the data to test against
 		for _, dataInstance := range tc.dataToQueue {
@@ -1023,7 +1024,8 @@ func TestGetSlashAndTrailingData(t *testing.T) {
 		// These values should never be returned.
 		err := providerKeeper.QueueThrottledSlashPacketData(ctx, "some-rando-chain", 77, testkeeper.GetNewSlashPacketData())
 		require.NoError(t, err)
-		providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "some-rando-chain", 97, testkeeper.GetNewVSCMaturedPacketData())
+		err = providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "some-rando-chain", 97, testkeeper.GetNewVSCMaturedPacketData())
+		require.NoError(t, err)
 
 		// Queue the data to test
 		for _, dataInstance := range tc.dataToQueue {
@@ -1049,7 +1051,8 @@ func TestDeleteThrottledPacketDataForConsumer(t *testing.T) {
 	// Queue slash and a VSC matured packet data for chain-48
 	err := providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-48", 0, testkeeper.GetNewSlashPacketData())
 	require.NoError(t, err)
-	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-48", 1, testkeeper.GetNewVSCMaturedPacketData())
+	err = providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-48", 1, testkeeper.GetNewVSCMaturedPacketData())
+	require.NoError(t, err)
 
 	// Queue 3 slash, and 4 vsc matured packet data instances for chain-49
 	err = providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-49", 0, testkeeper.GetNewSlashPacketData())
@@ -1058,10 +1061,14 @@ func TestDeleteThrottledPacketDataForConsumer(t *testing.T) {
 	require.NoError(t, err)
 	err = providerKeeper.QueueThrottledSlashPacketData(ctx, "chain-49", 2, testkeeper.GetNewSlashPacketData())
 	require.NoError(t, err)
-	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-49", 3, testkeeper.GetNewVSCMaturedPacketData())
-	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-49", 4, testkeeper.GetNewVSCMaturedPacketData())
-	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-49", 5, testkeeper.GetNewVSCMaturedPacketData())
-	providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-49", 6, testkeeper.GetNewVSCMaturedPacketData())
+	err = providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-49", 3, testkeeper.GetNewVSCMaturedPacketData())
+	require.NoError(t, err)
+	err = providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-49", 4, testkeeper.GetNewVSCMaturedPacketData())
+	require.NoError(t, err)
+	err = providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-49", 5, testkeeper.GetNewVSCMaturedPacketData())
+	require.NoError(t, err)
+	err = providerKeeper.QueueThrottledVSCMaturedPacketData(ctx, "chain-49", 6, testkeeper.GetNewVSCMaturedPacketData())
+	require.NoError(t, err)
 
 	// Delete all packet data for chain-49, confirm they are deleted
 	providerKeeper.DeleteThrottledPacketDataForConsumer(ctx, "chain-49")

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -295,14 +295,18 @@ func ThrottledPacketDataKey(consumerChainID string, ibcSeqNum uint64) []byte {
 	return ChainIdAndUintIdKey(ThrottledPacketDataBytePrefix, consumerChainID, ibcSeqNum)
 }
 
-// MustParseThrottledPacketDataKey parses a throttled packet data key
-// or panics upon failure
+// MustParseThrottledPacketDataKey parses a throttled packet data key or panics upon failure
 func MustParseThrottledPacketDataKey(key []byte) (string, uint64) {
-	str, i, err := ParseChainIdAndUintIdKey(ThrottledPacketDataBytePrefix, key)
+	chainId, ibcSeqNum, err := ParseThrottledPacketDataKey(key)
 	if err != nil {
 		panic(fmt.Sprintf("failed to parse throttled packet data key: %s", err.Error()))
 	}
-	return str, i
+	return chainId, ibcSeqNum
+}
+
+// ParseThrottledPacketDataKey parses a throttled packet data key
+func ParseThrottledPacketDataKey(key []byte) (chainId string, ibcSeqNum uint64, err error) {
+	return ParseChainIdAndUintIdKey(ThrottledPacketDataBytePrefix, key)
 }
 
 // GlobalSlashEntryKey returns the key for storing a global slash queue entry.
@@ -320,8 +324,9 @@ func GlobalSlashEntryKey(entry GlobalSlashEntry) []byte {
 	)
 }
 
-// ParseGlobalSlashEntry returns the received time and chainID for a global slash queue entry key.
-func ParseGlobalSlashEntryKey(bz []byte) (
+// MustParseGlobalSlashEntryKey returns the received time and chainID for a global slash queue entry key,
+// or panics if the key is invalid.
+func MustParseGlobalSlashEntryKey(bz []byte) (
 	recvTime time.Time, consumerChainID string, ibcSeqNum uint64) {
 
 	// Prefix is in first byte

--- a/x/ccv/provider/types/keys_test.go
+++ b/x/ccv/provider/types/keys_test.go
@@ -161,7 +161,7 @@ func TestGlobalSlashEntryKeyAndParse(t *testing.T) {
 		require.NotEmpty(t, key)
 		// This key should be of set length: prefix + 8 + 8 + chainID
 		require.Equal(t, 1+8+8+len(entry.ConsumerChainID), len(key))
-		parsedRecvTime, parsedChainID, parsedIBCSeqNum := providertypes.ParseGlobalSlashEntryKey(key)
+		parsedRecvTime, parsedChainID, parsedIBCSeqNum := providertypes.MustParseGlobalSlashEntryKey(key)
 		require.Equal(t, entry.RecvTime, parsedRecvTime)
 		require.Equal(t, entry.ConsumerChainID, parsedChainID)
 		require.Equal(t, entry.IbcSeqNum, parsedIBCSeqNum)


### PR DESCRIPTION
# Description

For every panic in `throttle.go` or closely related files, this PR either: 
1. Clarifies with comments why the panic is still included
2. Removes the panic in favor of an error log to prevent undesirable binary behavior

## Linked issues

Works toward https://github.com/cosmos/interchain-security/issues/621

## Type of change

- [x] `Fix`: Changes and/or adds code behavior, specifically to fix a bug
- [x] `Docs`: Adds documentation

## New behavior tests

n/a, fix was small and only related to queries
