### PR TITLE
Key assignment related panic cleanup

### DIFF
--- a/tests/e2e/slashing.go
+++ b/tests/e2e/slashing.go
@@ -691,7 +691,8 @@ func (suite *CCVTestSuite) TestSlashUndelegation() {
 		// slash validator on consumer chain
 		consumerKey, found := providerKeeper.GetValidatorConsumerPubKey(suite.providerCtx(), suite.consumerChain.ChainID, valConsAddr)
 		suite.Require().True(found)
-		consumerAddr := utils.TMCryptoPublicKeyToConsAddr(consumerKey)
+		consumerAddr, err := utils.TMCryptoPublicKeyToConsAddr(consumerKey)
+		suite.Require().NoError(err)
 		tc.slash(consumerAddr)
 
 		// increment time so that the unbonding period ends on the provider

--- a/x/ccv/provider/keeper/grpc_query.go
+++ b/x/ccv/provider/keeper/grpc_query.go
@@ -102,8 +102,13 @@ func (k Keeper) QueryValidatorConsumerAddr(goCtx context.Context, req *types.Que
 		return &types.QueryValidatorConsumerAddrResponse{}, nil
 	}
 
+	consumerAddr, err := utils.TMCryptoPublicKeyToConsAddr(consumerKey)
+	if err != nil {
+		return nil, err
+	}
+
 	return &types.QueryValidatorConsumerAddrResponse{
-		ConsumerAddress: utils.TMCryptoPublicKeyToConsAddr(consumerKey).String(),
+		ConsumerAddress: consumerAddr.String(),
 	}, nil
 }
 

--- a/x/ccv/provider/keeper/hooks.go
+++ b/x/ccv/provider/keeper/hooks.go
@@ -93,7 +93,11 @@ func (h Hooks) AfterValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) {
 func (h Hooks) AfterValidatorRemoved(ctx sdk.Context, valConsAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
 	for _, validatorConsumerPubKey := range h.k.GetAllValidatorConsumerPubKeys(ctx, nil) {
 		if sdk.ConsAddress(validatorConsumerPubKey.ProviderAddr).Equals(valConsAddr) {
-			consumerAddr := utils.TMCryptoPublicKeyToConsAddr(*validatorConsumerPubKey.ConsumerKey)
+			consumerAddr, err := utils.TMCryptoPublicKeyToConsAddr(*validatorConsumerPubKey.ConsumerKey)
+			if err != nil {
+				// An error here would indicate something is very wrong
+				panic("cannot get address of consumer key")
+			}
 			h.k.DeleteValidatorByConsumerAddr(ctx, validatorConsumerPubKey.ChainId, consumerAddr)
 			h.k.DeleteValidatorConsumerPubKey(ctx, validatorConsumerPubKey.ChainId, validatorConsumerPubKey.ProviderAddr)
 		}

--- a/x/ccv/provider/keeper/key_assignment.go
+++ b/x/ccv/provider/keeper/key_assignment.go
@@ -46,7 +46,6 @@ func (k Keeper) SetValidatorConsumerPubKey(
 	if err != nil {
 		// An error here would indicate something is very wrong,
 		// the consumer key is obtained from GetValidatorConsumerPubKey, called from
-		// TODO: not sure that consumerKey is actually validated by all possible code paths
 		panic(fmt.Sprintf("failed to marshal consumer key: %v", err))
 	}
 	store.Set(types.ConsumerValidatorsKey(chainID, providerAddr), bz)

--- a/x/ccv/provider/keeper/key_assignment.go
+++ b/x/ccv/provider/keeper/key_assignment.go
@@ -302,7 +302,6 @@ func (k Keeper) AppendConsumerAddrsToPrune(ctx sdk.Context, chainID string, vscI
 			panic(err)
 		}
 	}
-	// TODO: do we need to validate the consumerAddr we're appending here?
 	consumerAddrsToPrune.Addresses = append(consumerAddrsToPrune.Addresses, consumerAddr)
 	bz, err := consumerAddrsToPrune.Marshal()
 	if err != nil {
@@ -425,6 +424,9 @@ func (k Keeper) AssignConsumerKey(
 				ctx,
 				chainID,
 				k.GetValidatorSetUpdateId(ctx),
+
+				// it is assumed that the old consumer key has been previously validated in AssignConsumerKey,
+				// so TMCryptoPublicKeyToConsAddr should not panic.
 				utils.TMCryptoPublicKeyToConsAddr(oldConsumerKey),
 			)
 		} else {

--- a/x/ccv/provider/keeper/key_assignment_test.go
+++ b/x/ccv/provider/keeper/key_assignment_test.go
@@ -241,16 +241,19 @@ func TestConsumerAddrsToPruneCRUD(t *testing.T) {
 	keeper, ctx, ctrl, _ := testkeeper.GetProviderKeeperAndCtx(t, testkeeper.NewInMemKeeperParams(t))
 	defer ctrl.Finish()
 
+	addrsToPrune := keeper.GetConsumerAddrsToPrune(ctx, chainID, vscID).Addresses
+	require.Empty(t, addrsToPrune)
+
 	keeper.AppendConsumerAddrsToPrune(ctx, chainID, vscID, consumerAddr)
 
-	addrToPrune := keeper.GetConsumerAddrsToPrune(ctx, chainID, vscID).Addresses
-	require.NotEmpty(t, addrToPrune, "address to prune is empty")
-	require.Len(t, addrToPrune, 1, "address to prune is not len 1")
-	require.Equal(t, sdk.ConsAddress(addrToPrune[0]), consumerAddr)
+	addrsToPrune = keeper.GetConsumerAddrsToPrune(ctx, chainID, vscID).Addresses
+	require.NotEmpty(t, addrsToPrune, "addresses to prune is empty")
+	require.Len(t, addrsToPrune, 1, "addresses to prune is not len 1")
+	require.Equal(t, sdk.ConsAddress(addrsToPrune[0]), consumerAddr)
 
 	keeper.DeleteConsumerAddrsToPrune(ctx, chainID, vscID)
-	addrToPrune = keeper.GetConsumerAddrsToPrune(ctx, chainID, vscID).Addresses
-	require.Empty(t, addrToPrune, "address to prune was returned")
+	addrsToPrune = keeper.GetConsumerAddrsToPrune(ctx, chainID, vscID).Addresses
+	require.Empty(t, addrsToPrune, "addresses to prune was returned")
 }
 
 func TestGetAllConsumerAddrsToPrune(t *testing.T) {

--- a/x/ccv/provider/keeper/key_assignment_test.go
+++ b/x/ccv/provider/keeper/key_assignment_test.go
@@ -339,7 +339,8 @@ func checkCorrectPruningProperty(ctx sdk.Context, k providerkeeper.Keeper, chain
 		// Try to find a validator who has this consumer address currently assigned
 		isCurrentlyAssigned := false
 		for _, valconsPubKey := range k.GetAllValidatorConsumerPubKeys(ctx, &valByConsAddr.ChainId) {
-			if utils.TMCryptoPublicKeyToConsAddr(*valconsPubKey.ConsumerKey).Equals(sdk.ConsAddress(valByConsAddr.ConsumerAddr)) {
+			consumerAddr, _ := utils.TMCryptoPublicKeyToConsAddr(*valconsPubKey.ConsumerKey)
+			if consumerAddr.Equals(sdk.ConsAddress(valByConsAddr.ConsumerAddr)) {
 				isCurrentlyAssigned = true
 				break
 			}
@@ -622,7 +623,7 @@ func (vs *ValSet) apply(updates []abci.ValidatorUpdate) {
 	for _, u := range updates {
 		for i, id := range vs.identities { // n2 looping but n is tiny
 			// cons := sdk.ConsAddress(utils.GetChangePubKeyAddress(u))
-			cons := utils.TMCryptoPublicKeyToConsAddr(u.PubKey)
+			cons, _ := utils.TMCryptoPublicKeyToConsAddr(u.PubKey)
 			if id.SDKConsAddress().Equals(cons) {
 				vs.power[i] = u.Power
 			}
@@ -825,7 +826,8 @@ func TestSimulatedAssignmentsAndUpdateApplication(t *testing.T) {
 						// Use default if unassigned
 						ck = idP.TMProtoCryptoPublicKey()
 					}
-					consC := utils.TMCryptoPublicKeyToConsAddr(ck)
+					consC, err := utils.TMCryptoPublicKeyToConsAddr(ck)
+					require.NoError(t, err)
 					// Find the corresponding consumer validator (must always be found)
 					for j, idC := range consumerValset.identities {
 						if consC.Equals(idC.SDKConsAddress()) {

--- a/x/ccv/provider/types/genesis.go
+++ b/x/ccv/provider/types/genesis.go
@@ -85,13 +85,6 @@ func (gs GenesisState) Validate() error {
 		return err
 	}
 
-	for _, pk := range gs.ValidatorConsumerPubkeys {
-		if err := sdk.VerifyAddressFormat(pk.ProviderAddr); err != nil {
-			return sdkerrors.Wrap(ccv.ErrInvalidGenesis, fmt.Sprintf("invalid provider address: %s", pk.ProviderAddr))
-		}
-		// TODO: do we need to validate the consumer key?
-	}
-
 	return nil
 }
 

--- a/x/ccv/provider/types/genesis.go
+++ b/x/ccv/provider/types/genesis.go
@@ -85,6 +85,13 @@ func (gs GenesisState) Validate() error {
 		return err
 	}
 
+	for _, pk := range gs.ValidatorConsumerPubkeys {
+		if err := sdk.VerifyAddressFormat(pk.ProviderAddr); err != nil {
+			return sdkerrors.Wrap(ccv.ErrInvalidGenesis, fmt.Sprintf("invalid provider address: %s", pk.ProviderAddr))
+		}
+		// TODO: do we need to validate the consumer key?
+	}
+
 	return nil
 }
 

--- a/x/ccv/utils/utils.go
+++ b/x/ccv/utils/utils.go
@@ -53,12 +53,14 @@ func GetChangePubKeyAddress(change abci.ValidatorUpdate) (addr []byte) {
 	return pk.Address()
 }
 
-func TMCryptoPublicKeyToConsAddr(k tmprotocrypto.PublicKey) sdk.ConsAddress {
+// TMCryptoPublicKeyToConsAddr converts a TM public key to an SDK public key
+// and returns the associated consensus address
+func TMCryptoPublicKeyToConsAddr(k tmprotocrypto.PublicKey) (sdk.ConsAddress, error) {
 	sdkK, err := cryptocodec.FromTmProtoPublicKey(k)
 	if err != nil {
-		panic("could not get public key from tm proto public key")
+		return nil, err
 	}
-	return sdk.GetConsAddress(sdkK)
+	return sdk.GetConsAddress(sdkK), nil
 }
 
 // SendIBCPacket sends an IBC packet with packetData


### PR DESCRIPTION
# Description

WIP, optionally we can audit the key related panics in `x/ccv/utils/utils.go` in this PR as well.

**_EDIT:_** 

- [x] `utils.TMCryptoPublicKeyToConsAddr` should return an error instead. 

## Linked issues

Works toward https://github.com/cosmos/interchain-security/issues/621

## Type of change

If you've checked more than one of the first three boxes, consider splitting this PR into multiple PRs!

- [ ] `Feature`: Changes and/or adds code behavior, irrelevant to bug fixes
- [ ] `Fix`: Changes and/or adds code behavior, specifically to fix a bug
- [ ] `Refactor`: Changes existing code style, naming, structure, etc.
- [ ] `Testing`: Adds testing
- [ ] `Docs`: Adds documentation

## Regression tests

If `Refactor`, describe the new or existing tests that verify no behavior was changed or added where refactors were introduced.

## New behavior tests

If `Feature` or `Fix`, describe the new or existing tests that verify the new behavior is correct and expected.
