### PR TITLE
Improved assign consumer key msg validation

### DIFF
--- a/x/ccv/provider/types/errors.go
+++ b/x/ccv/provider/types/errors.go
@@ -17,4 +17,5 @@ var (
 	ErrNoValidatorProviderAddress      = sdkerrors.Register(ModuleName, 9, "error getting validator provider address")
 	ErrConsumerKeyInUse                = sdkerrors.Register(ModuleName, 10, "consumer key is already in use by a validator")
 	ErrInvalidConsumerParams           = sdkerrors.Register(ModuleName, 11, "invalid consumer params")
+	ErrInvalidProviderAddress          = sdkerrors.Register(ModuleName, 12, "invalid provider address")
 )

--- a/x/ccv/provider/types/msg.go
+++ b/x/ccv/provider/types/msg.go
@@ -6,7 +6,6 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 // provider message types
@@ -76,8 +75,9 @@ func (msg MsgAssignConsumerKey) ValidateBasic() error {
 	if 128 < len(msg.ChainId) {
 		return ErrBlankConsumerChainID
 	}
-	if msg.ProviderAddr == "" {
-		return stakingtypes.ErrEmptyValidatorAddr
+	_, err := sdk.ValAddressFromBech32(msg.ProviderAddr)
+	if err != nil {
+		return err
 	}
 	if msg.ConsumerKey == nil {
 		return ErrInvalidConsumerConsensusPubKey

--- a/x/ccv/provider/types/msg.go
+++ b/x/ccv/provider/types/msg.go
@@ -77,7 +77,7 @@ func (msg MsgAssignConsumerKey) ValidateBasic() error {
 	}
 	_, err := sdk.ValAddressFromBech32(msg.ProviderAddr)
 	if err != nil {
-		return err
+		return ErrInvalidProviderAddress
 	}
 	if msg.ConsumerKey == nil {
 		return ErrInvalidConsumerConsensusPubKey


### PR DESCRIPTION
This is a tiny fix to make sure the AssignConsumerKey message is validated properly. The pattern is similar what they use in the staking module for the CreateValidatorMsg.

https://github.com/cosmos/cosmos-sdk/blob/main/x/staking/types/msg.go#L89

See comment

https://github.com/cosmos/interchain-security/pull/642#discussion_r1063385536