### PR TITLE
Adds ValidateBasic for key assignment related state in provider genesis

### DIFF
--- a/x/ccv/provider/keeper/key_assignment.go
+++ b/x/ccv/provider/keeper/key_assignment.go
@@ -1,13 +1,9 @@
 package keeper
 
 import (
-	"fmt"
-	"strings"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	ccvtypes "github.com/cosmos/interchain-security/x/ccv/types"
 
 	"github.com/cosmos/interchain-security/x/ccv/provider/types"
 	utils "github.com/cosmos/interchain-security/x/ccv/utils"
@@ -570,46 +566,4 @@ func (k Keeper) DeleteKeyAssignments(ctx sdk.Context, chainID string) {
 	for _, consumerAddrsToPrune := range k.GetAllConsumerAddrsToPrune(ctx, chainID) {
 		k.DeleteConsumerAddrsToPrune(ctx, chainID, consumerAddrsToPrune.VscId)
 	}
-}
-
-// KeyAssignmentValidateBasic validates all the genesis state for key assignment
-func KeyAssignmentValidateBasic(
-	assignedKeys []types.ValidatorConsumerPubKey,
-	byConsumerAddrs []types.ValidatorByConsumerAddr,
-	consumerAddrsToPrune []types.ConsumerAddrsToPrune,
-) error {
-	for _, e := range assignedKeys {
-		if strings.TrimSpace(e.ChainId) == "" {
-			return sdkerrors.Wrap(ccvtypes.ErrInvalidGenesis, "consumer chain id must not be blank")
-		}
-		if err := sdk.VerifyAddressFormat(e.ProviderAddr); err != nil {
-			return sdkerrors.Wrap(ccvtypes.ErrInvalidGenesis, fmt.Sprintf("invalid provider address: %s", e.ProviderAddr))
-		}
-		if e.ConsumerKey == nil {
-			return sdkerrors.Wrap(ccvtypes.ErrInvalidGenesis, fmt.Sprintf("invalid consumer key: %s", e.ConsumerKey))
-		}
-	}
-	for _, e := range byConsumerAddrs {
-		if strings.TrimSpace(e.ChainId) == "" {
-			return sdkerrors.Wrap(ccvtypes.ErrInvalidGenesis, "consumer chain id must not be blank")
-		}
-		if err := sdk.VerifyAddressFormat(e.ProviderAddr); err != nil {
-			return sdkerrors.Wrap(ccvtypes.ErrInvalidGenesis, fmt.Sprintf("invalid provider address: %s", e.ProviderAddr))
-		}
-		if err := sdk.VerifyAddressFormat(e.ConsumerAddr); err != nil {
-			return sdkerrors.Wrap(ccvtypes.ErrInvalidGenesis, fmt.Sprintf("invalid consumer address: %s", e.ConsumerAddr))
-		}
-	}
-	for _, e := range consumerAddrsToPrune {
-		if strings.TrimSpace(e.ChainId) == "" {
-			return sdkerrors.Wrap(ccvtypes.ErrInvalidGenesis, "consumer chain id must not be blank")
-		}
-		// Don't check e.vscid, it's an unsigned integer
-		for _, a := range e.ConsumerAddrs.Addresses {
-			if err := sdk.VerifyAddressFormat(a); err != nil {
-				return sdkerrors.Wrap(ccvtypes.ErrInvalidGenesis, fmt.Sprintf("invalid consumer address: %s", a))
-			}
-		}
-	}
-	return nil
 }

--- a/x/ccv/provider/types/genesis.go
+++ b/x/ccv/provider/types/genesis.go
@@ -85,6 +85,13 @@ func (gs GenesisState) Validate() error {
 		return err
 	}
 
+	if err := KeyAssignmentValidateBasic(gs.ValidatorConsumerPubkeys,
+		gs.ValidatorsByConsumerAddr,
+		gs.ConsumerAddrsToPrune,
+	); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/x/ccv/provider/types/key_assignment.go
+++ b/x/ccv/provider/types/key_assignment.go
@@ -1,0 +1,54 @@
+package types
+
+import (
+	"fmt"
+	"strings"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	ccvtypes "github.com/cosmos/interchain-security/x/ccv/types"
+)
+
+// KeyAssignmentValidateBasic validates all the genesis state for key assignment
+// This is a utility. Key Assignment does not define any new proto types, but
+// has a lot of nested data.
+func KeyAssignmentValidateBasic(
+	assignedKeys []ValidatorConsumerPubKey,
+	byConsumerAddrs []ValidatorByConsumerAddr,
+	consumerAddrsToPrune []ConsumerAddrsToPrune,
+) error {
+	for _, e := range assignedKeys {
+		if strings.TrimSpace(e.ChainId) == "" {
+			return sdkerrors.Wrap(ccvtypes.ErrInvalidGenesis, "consumer chain id must not be blank")
+		}
+		if err := sdk.VerifyAddressFormat(e.ProviderAddr); err != nil {
+			return sdkerrors.Wrap(ccvtypes.ErrInvalidGenesis, fmt.Sprintf("invalid provider address: %s", e.ProviderAddr))
+		}
+		if e.ConsumerKey == nil {
+			return sdkerrors.Wrap(ccvtypes.ErrInvalidGenesis, fmt.Sprintf("invalid consumer key: %s", e.ConsumerKey))
+		}
+	}
+	for _, e := range byConsumerAddrs {
+		if strings.TrimSpace(e.ChainId) == "" {
+			return sdkerrors.Wrap(ccvtypes.ErrInvalidGenesis, "consumer chain id must not be blank")
+		}
+		if err := sdk.VerifyAddressFormat(e.ProviderAddr); err != nil {
+			return sdkerrors.Wrap(ccvtypes.ErrInvalidGenesis, fmt.Sprintf("invalid provider address: %s", e.ProviderAddr))
+		}
+		if err := sdk.VerifyAddressFormat(e.ConsumerAddr); err != nil {
+			return sdkerrors.Wrap(ccvtypes.ErrInvalidGenesis, fmt.Sprintf("invalid consumer address: %s", e.ConsumerAddr))
+		}
+	}
+	for _, e := range consumerAddrsToPrune {
+		if strings.TrimSpace(e.ChainId) == "" {
+			return sdkerrors.Wrap(ccvtypes.ErrInvalidGenesis, "consumer chain id must not be blank")
+		}
+		// Don't check e.vscid, it's an unsigned integer
+		for _, a := range e.ConsumerAddrs.Addresses {
+			if err := sdk.VerifyAddressFormat(a); err != nil {
+				return sdkerrors.Wrap(ccvtypes.ErrInvalidGenesis, fmt.Sprintf("invalid consumer address: %s", a))
+			}
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
# Description

Adds a ValidateBasic util function in /provider/types for KeyAssignment data. Uses it in ValidateGenesis. 

It's a bit verbose, but simple. Note that the vscid's are not checked! They are uints

## Linked issues

- https://github.com/cosmos/interchain-security/issues/645

## Type of change

If you've checked more than one of the first three boxes, consider splitting this PR into multiple PRs!

- [x] `Fix`: Changes and/or adds code behavior, specifically to fix a bug

