### PR TITLE
add manual integration tests GH workflow

### DIFF
--- a/.github/workflows/manual-integration.yml
+++ b/.github/workflows/manual-integration.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: "1.18.0" # The Go version to download (if necessary) and use.
+          go-version: "1.18" # The Go version to download (if necessary) and use.
 
       - name: Integration tests
         run: make test-integration

--- a/.github/workflows/manual-integration.yml
+++ b/.github/workflows/manual-integration.yml
@@ -1,0 +1,26 @@
+# manually run full integration test suite
+# all tests are run sequentially
+name: manual-integration-main
+on:
+  workflow_dispatch:
+
+jobs:
+  manual-integration-main:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
+      - uses: actions/checkout@v3
+
+      - name: Checkout LFS objects
+        run: git lfs checkout
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.18.0" # The Go version to download (if necessary) and use.
+
+      - name: Integration tests
+        run: make test-integration

--- a/.github/workflows/nightly-integration.yml
+++ b/.github/workflows/nightly-integration.yml
@@ -5,7 +5,7 @@
 name: nightly-integration-main
 on:
   schedule:
-    # run every day at 03:00 (AM)
+    # run every day at 03:00 UTC
     #        ┌───────────── minute (0 - 59)
     #        │  ┌───────────── hour (0 - 23)
     #        │  │ ┌───────────── day of the month (1 - 31)

--- a/.github/workflows/nightly-integration.yml
+++ b/.github/workflows/nightly-integration.yml
@@ -1,0 +1,68 @@
+# Run integration tests nightly on main
+
+# !! Relevant changes to this file should be propagated manual-integration.yml
+
+name: nightly-integration-main
+on:
+  schedule:
+    # run every day at 03:00 (AM)
+    #        ┌───────────── minute (0 - 59)
+    #        │  ┌───────────── hour (0 - 23)
+    #        │  │ ┌───────────── day of the month (1 - 31)
+    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        *  * * * *
+    - cron: '0 3 * * *'
+
+jobs:
+  nightly-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
+
+      - uses: actions/checkout@v3
+
+      - name: Integration tests
+        run: make test-integration
+
+
+  nightly-test-fail:
+    needs: nightly-test
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack on failure
+        uses: slackapi/slack-github-action@v1.23.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          BRANCH: ${{ github.ref_name }}
+          RUN_URL: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          COMMITS_URL: "${{ github.server_url }}/${{ github.repository }}/commits/${{ github.ref_name }}"
+        with:
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "❗Integration tests failed❗",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":skull: Nightly E2E tests for `${{ env.BRANCH }}` failed.\n\nSee the <${{ env.RUN_URL }}|run details> and the <${{ env.COMMITS_URL }}|latest commits> possibly related to the failure."
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
# Description

Add `nightly` test run which includes all integration tests and executes them using a cronjob. The test will be performed every night at 03:00 (AM).

The `nightly` test run will notify a selected slack channel via a webhook configured for this repo.

Add manual trigger for integration tests running on `main` branch.

## Linked issues

Closes: #514 #631 
Depends on: #659 

## Type of change

If you've checked more than one of the first three boxes, consider splitting this PR into multiple PRs!

- [ ] `Feature`: Changes and/or adds code behavior, irrelevant to bug fixes
- [ ] `Fix`: Changes and/or adds code behavior, specifically to fix a bug
- [x] `Refactor`: Changes existing code style, naming, structure, etc.
- [x] `Testing`: Adds testing
- [ ] `Docs`: Adds documentation
