### PR TITLE
fix Slash processing on provider and consumer

### DIFF
--- a/tests/e2e/slashing.go
+++ b/tests/e2e/slashing.go
@@ -63,15 +63,14 @@ func (s *CCVTestSuite) TestRelayAndApplySlashPacket() {
 		s.Require().Nil(err)
 		consAddr := sdk.GetConsAddress(pubkey)
 		// map consumer consensus address to provider consensus address
-		if providerAddr, found := providerKeeper.GetValidatorByConsumerAddr(
+		providerAddr, found := providerKeeper.GetValidatorByConsumerAddr(
 			s.providerCtx(),
 			s.consumerChain.ChainID,
 			consAddr,
-		); found {
-			consAddr = providerAddr
-		}
+		)
+		s.Require().True(found)
 
-		valData, found := providerStakingKeeper.GetValidatorByConsAddr(s.providerCtx(), consAddr)
+		valData, found := providerStakingKeeper.GetValidatorByConsAddr(s.providerCtx(), providerAddr)
 		s.Require().True(found)
 		valOldBalance := valData.Tokens
 
@@ -154,7 +153,7 @@ func (s *CCVTestSuite) TestRelayAndApplySlashPacket() {
 		}
 
 		// check that the validator is successfully jailed on provider
-		validatorJailed, ok := providerStakingKeeper.GetValidatorByConsAddr(s.providerCtx(), consAddr)
+		validatorJailed, ok := providerStakingKeeper.GetValidatorByConsAddr(s.providerCtx(), providerAddr)
 		s.Require().True(ok)
 		s.Require().True(validatorJailed.Jailed)
 		s.Require().Equal(validatorJailed.Status, stakingtypes.Unbonding)
@@ -173,7 +172,7 @@ func (s *CCVTestSuite) TestRelayAndApplySlashPacket() {
 		s.Require().Equal(resultingTokens, validatorJailed.GetTokens())
 
 		// check that the validator's unjailing time is updated on provider
-		valSignInfo, found := providerSlashingKeeper.GetValidatorSigningInfo(s.providerCtx(), consAddr)
+		valSignInfo, found := providerSlashingKeeper.GetValidatorSigningInfo(s.providerCtx(), providerAddr)
 		s.Require().True(found)
 		s.Require().True(valSignInfo.JailedUntil.After(s.providerCtx().BlockHeader().Time))
 

--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -365,16 +365,17 @@ func (k Keeper) ValidateSlashPacket(ctx sdk.Context, chainID string,
 // a misbehaving validator according to infraction type.
 func (k Keeper) HandleSlashPacket(ctx sdk.Context, chainID string, data ccv.SlashPacketData) {
 
-	k.Logger(ctx).Debug("handling slash packet",
-		"chainID", chainID,
-		"provider cons addr", sdk.ConsAddress(data.Validator.Address).String(),
-		"vscID", data.ValsetUpdateId,
-		"infractionType", data.Infraction,
-	)
-
 	consumerConsAddr := sdk.ConsAddress(data.Validator.Address)
 	// Obtain provider chain consensus address using the consumer chain consensus address
 	providerConsAddr := k.GetProviderAddrFromConsumerAddr(ctx, chainID, consumerConsAddr)
+
+	k.Logger(ctx).Debug("handling slash packet",
+		"chainID", chainID,
+		"consumer cons addr", consumerConsAddr.String(),
+		"provider cons addr", providerConsAddr.String(),
+		"vscID", data.ValsetUpdateId,
+		"infractionType", data.Infraction,
+	)
 
 	// Obtain validator from staking keeper
 	validator, found := k.stakingKeeper.GetValidatorByConsAddr(ctx, providerConsAddr)

--- a/x/ccv/provider/keeper/relay_test.go
+++ b/x/ccv/provider/keeper/relay_test.go
@@ -558,7 +558,7 @@ func TestSlashAckAppendAfterHandleSlashPacket(t *testing.T) {
 				return testkeeper.GetMocksForHandleSlashPacket(
 					ctx, mocks, expectedPacketData, providerConsAddr, stakingtypes.Validator{Jailed: false})
 			},
-			0, // no slash acks for double - only tombstone
+			0, // no slash acks for double sign - only tombstone
 		},
 	}
 


### PR DESCRIPTION
# Description

While processing Slash packets on the provider the validator address to be slashed was translated from the address on the consumer chain to the address on the provider chain. When SlashAcks were written during `HandleSlashPacket` the address used in the SlaskAck was equal to the address on the provider - it should have been set to the address on the consumer.

This was not an issue before key assignment was introduced. Since key assignment allows validators to use different keys on consumer chains, SlashAcks needed to be refactored so the consumer chain would receive SlashAcks with validator addresses that exist on the consumer.

## Linked issues

Closes: #693 

## Type of change

If you've checked more than one of the first three boxes, consider splitting this PR into multiple PRs!

- [ ] `Feature`: Changes and/or adds code behavior, irrelevant to bug fixes
- [x] `Fix`: Changes and/or adds code behavior, specifically to fix a bug
- [ ] `Refactor`: Changes existing code style, naming, structure, etc.
- [ ] `Testing`: Adds testing
- [ ] `Docs`: Adds documentation

## Regression tests
e2e and integration tests are passing.

## New behavior tests

Added new unit test that checks SlashAcks after processing Slash packet on the provider. Updated all related mock calls to reflect the new behaviour.
