### PR TITLE
Throttle integration test fixes

### DIFF
--- a/tests/integration/actions.go
+++ b/tests/integration/actions.go
@@ -1227,7 +1227,7 @@ func (tr TestRun) waitForSlashThrottleDequeue(
 		}
 
 		if globalQueueSize == chainQueueSize && globalQueueSize == action.nextQueueSize {
-			return
+			break
 		}
 
 		if time.Now().After(timeout) {
@@ -1236,6 +1236,8 @@ func (tr TestRun) waitForSlashThrottleDequeue(
 
 		time.Sleep(500 * time.Millisecond)
 	}
+	// Sleep 20 seconds to pass a block, allowing the jailing to be incorporated into voting power
+	time.Sleep(20 * time.Second)
 }
 
 func uintPointer(i uint) *uint {

--- a/tests/integration/steps_downtime.go
+++ b/tests/integration/steps_downtime.go
@@ -281,7 +281,10 @@ func stepsThrottledDowntime(consumerName string) []Step {
 				chain:            chainID(consumerName),
 				currentQueueSize: 1,
 				nextQueueSize:    0,
-				timeout:          time.Minute, // panic after reaching timeout
+				// Slash meter replenish fraction is set to 10%, replenish period is 20 seconds, see config.go
+				// Meter is initially at 10%, decremented to -23% from bob being jailed. It'll then take three replenishments
+				// for meter to become positive again. 3*20 = 60 seconds + buffer = 80 seconds
+				timeout: 80 * time.Second,
 			},
 			state: State{
 				// no changes in state should occur
@@ -289,7 +292,7 @@ func stepsThrottledDowntime(consumerName string) []Step {
 					ValPowers: &map[validatorID]uint{
 						validatorID("alice"): 511,
 						validatorID("bob"):   0,
-						validatorID("carol"): 500,
+						validatorID("carol"): 500, // should be 0
 					},
 					GlobalSlashQueueSize: uintPointer(0), // slash packets dequeued
 					ConsumerChainQueueSizes: &map[chainID]uint{

--- a/tests/integration/steps_downtime.go
+++ b/tests/integration/steps_downtime.go
@@ -287,12 +287,11 @@ func stepsThrottledDowntime(consumerName string) []Step {
 				timeout: 80 * time.Second,
 			},
 			state: State{
-				// no changes in state should occur
 				chainID("provi"): ChainState{
 					ValPowers: &map[validatorID]uint{
 						validatorID("alice"): 511,
 						validatorID("bob"):   0,
-						validatorID("carol"): 500, // should be 0
+						validatorID("carol"): 0, // Carol is jailed upon packet being handled on provider
 					},
 					GlobalSlashQueueSize: uintPointer(0), // slash packets dequeued
 					ConsumerChainQueueSizes: &map[chainID]uint{


### PR DESCRIPTION
# Description

The diffs in #687 caused integration tests to fail, which is actually good and proves that the patch changed behavior. This PR fixes integration tests to be a bit more granular with the throttle behavior that's expected.

## Type of change

- [x] `Testing`: Adds testing

## New Behavior Testing

Full integration tests pass locally for me, `make test-integration`
