### PR TITLE
wait after sending unjail tx in integration tests

### DIFF
--- a/tests/integration/actions.go
+++ b/tests/integration/actions.go
@@ -1010,9 +1010,9 @@ func (tr TestRun) unjailValidator(action unjailValidatorAction, verbose bool) {
 		log.Fatal(err, "\n", string(bz))
 	}
 
-	// wait a bit so the tx get included in a block
+	// wait for 2 blocks to be sure that tx got included in a block
 	// and packets commited before proceeding
-	time.Sleep(20 * time.Second)
+	tr.waitBlocks(action.provider, 2, time.Minute)
 }
 
 type registerRepresentativeAction struct {
@@ -1241,8 +1241,9 @@ func (tr TestRun) waitForSlashThrottleDequeue(
 
 		time.Sleep(500 * time.Millisecond)
 	}
-	// Sleep 20 seconds to pass a block, allowing the jailing to be incorporated into voting power
-	time.Sleep(20 * time.Second)
+	// wair for 2 blocks to be created
+	// allowing the jailing to be incorporated into voting power
+	tr.waitBlocks(action.chain, 2, time.Minute)
 }
 
 func uintPointer(i uint) *uint {

--- a/tests/integration/actions.go
+++ b/tests/integration/actions.go
@@ -996,6 +996,7 @@ func (tr TestRun) unjailValidator(action unjailValidatorAction, verbose bool) {
 		`--chain-id`, string(tr.chainConfigs[action.provider].chainId),
 		`--home`, tr.getValidatorHome(action.provider, action.validator),
 		`--node`, tr.getValidatorNode(action.provider, action.validator),
+		`--gas`, "900000",
 		`--keyring-backend`, `test`,
 		`-b`, `block`,
 		`-y`,
@@ -1008,6 +1009,10 @@ func (tr TestRun) unjailValidator(action unjailValidatorAction, verbose bool) {
 	if err != nil {
 		log.Fatal(err, "\n", string(bz))
 	}
+
+	// wait a bit so the tx get included in a block
+	// and packets commited before proceeding
+	time.Sleep(20 * time.Second)
 }
 
 type registerRepresentativeAction struct {


### PR DESCRIPTION
# Description

Adding a wait time after sending an unjail tx so it has a chance to be included in a block and the required packets to be commited.

Previously, when making state assertions after unjailing the validator's jailed state sould not change and their power would not be refreshed. 

## Linked issues

Closes: #631 

## Type of change

If you've checked more than one of the first three boxes, consider splitting this PR into multiple PRs!

- [ ] `Feature`: Changes and/or adds code behavior, irrelevant to bug fixes
- [x] `Fix`: Changes and/or adds code behavior, specifically to fix a bug
- [ ] `Refactor`: Changes existing code style, naming, structure, etc.
- [x] `Testing`: Adds testing
- [ ] `Docs`: Adds documentation
