### PR TITLE
Gaia integration tests with local sdk

### DIFF
--- a/Dockerfile.gaia
+++ b/Dockerfile.gaia
@@ -13,9 +13,21 @@ ENV GOOS=linux
 ENV GOFLAGS="-buildvcs=false"
 
 # fetch gaia from tag and build it
-RUN if [  -z ${GAIA_TAG} ] ; then git clone https://github.com/cosmos/gaia.git && cd gaia && git checkout $(git tag | tail -1) && make build; else git clone https://github.com/cosmos/gaia.git && cd gaia && git checkout ${GAIA_TAG} && make build ; fi
-
-# if GAIA_TAG is not set, build the latest tagged version
+RUN git clone https://github.com/cosmos/gaia.git && \
+    cd gaia && \
+    # if GAIA_TAG is not set, build the latest tagged version
+    if [ -n "${GAIA_TAG}" ]; then \
+        git checkout "${GAIA_TAG}"; \
+    else \
+        git checkout $(git tag | tail -1); \
+    fi && \
+    # Also replace sdk version in the go.mod if specified
+    if [ -d "../cosmos-sdk" ]; then \
+        # Do not specify version here. It leads to odd replacement behavior 
+        go mod edit -replace github.com/cosmos/cosmos-sdk=../cosmos-sdk && \
+        go mod tidy; \
+    fi && \
+    make build
 
 FROM golang:1.18-alpine AS is-builder
 
@@ -30,10 +42,6 @@ ENV GOFLAGS="-buildvcs=false"
 ADD . /interchain-security
 
 WORKDIR /interchain-security
-
-# Do not specify version here. It leads to odd replacement behavior 
-RUN if [ -d "./cosmos-sdk" ]; then go mod edit -replace github.com/cosmos/cosmos-sdk=./cosmos-sdk; fi
-RUN go mod tidy
 
 # Install interchain security binary
 RUN make install

--- a/Dockerfile.gaia
+++ b/Dockerfile.gaia
@@ -1,0 +1,61 @@
+# syntax=docker/dockerfile:1
+
+# build latest tagged gaia
+FROM golang:1.18-alpine AS gaia-builder
+ARG USE_GAIA_TAG
+ENV GAIA_TAG=${USE_GAIA_TAG}
+
+ENV PACKAGES curl make git libc-dev bash gcc linux-headers
+RUN apk add --no-cache $PACKAGES
+
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOFLAGS="-buildvcs=false"
+
+# fetch gaia from tag and build it
+RUN if [  -z ${GAIA_TAG} ] ; then git clone https://github.com/cosmos/gaia.git && cd gaia && git checkout $(git tag | tail -1) && make build; else git clone https://github.com/cosmos/gaia.git && cd gaia && git checkout ${GAIA_TAG} && make build ; fi
+
+# if GAIA_TAG is not set, build the latest tagged version
+
+FROM golang:1.18-alpine AS is-builder
+
+ENV PACKAGES curl make git libc-dev bash gcc linux-headers
+RUN apk add --no-cache $PACKAGES
+
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOFLAGS="-buildvcs=false"
+
+# Copy in the repo under test
+ADD . /interchain-security
+
+WORKDIR /interchain-security
+
+# Do not specify version here. It leads to odd replacement behavior 
+RUN if [ -d "./cosmos-sdk" ]; then go mod edit -replace github.com/cosmos/cosmos-sdk=./cosmos-sdk; fi
+RUN go mod tidy
+
+# Install interchain security binary
+RUN make install
+
+# Get Hermes build
+FROM informalsystems/hermes:1.2.0 AS hermes-builder
+
+FROM --platform=linux/amd64 fedora:36
+RUN dnf update -y
+RUN dnf install -y which iproute iputils procps-ng vim-minimal tmux net-tools htop jq
+USER root
+
+COPY --from=hermes-builder /usr/bin/hermes /usr/local/bin/
+
+# swap interchain-security-pd binary with gaia binary but keep the name
+COPY --from=gaia-builder /go/gaia/build/gaiad /usr/local/bin/interchain-security-pd
+COPY --from=is-builder /go/bin/interchain-security-cd /usr/local/bin/interchain-security-cd
+COPY --from=is-builder /go/bin/interchain-security-cdd /usr/local/bin/interchain-security-cdd
+
+
+# Copy in the shell scripts that run the testnet
+ADD ./tests/integration/testnet-scripts /testnet-scripts
+
+# Copy in the hermes config
+ADD ./tests/integration/testnet-scripts/hermes-config.toml /root/.hermes/config.toml

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,18 @@ test-integration:
 test-integration-parallel:
 	go run ./tests/integration/... --include-multi-consumer --parallel
 
+# run full integration tests in sequence (including multiconsumer) using latest tagged gaia
+test-gaia-integration:
+	go run ./tests/integration/... --include-multi-consumer --use-gaia
+
+# run only happy path integration tests using latest tagged gaia
+test-gaia-integration-short:
+	go run ./tests/integration/... --happy-path-only --use-gaia
+
+# run full integration tests in parallel (including multiconsumer) using latest tagged gaia
+test-gaia-integration-parallel:
+	go run ./tests/integration/... --include-multi-consumer --parallel --use-gaia
+
 # run all tests with caching disabled
 test-no-cache:
 	go test ./... -count=1 && go run ./tests/integration/...

--- a/tests/integration/config.go
+++ b/tests/integration/config.go
@@ -67,6 +67,8 @@ type TestRun struct {
 	// lengthening the timeout_commit increases the test runtime because blocks are produced slower but the test is more reliable
 	tendermintConfigOverride string
 	localSdkPath             string
+	useGaia                  bool
+	gaiaTag                  string
 
 	name string
 }
@@ -315,11 +317,17 @@ func MultiConsumerTestRun() TestRun {
 	}
 }
 
-func (s *TestRun) SetLocalSDKPath(path string) {
-	if path != "" {
-		fmt.Println("USING LOCAL SDK", path)
+func (s *TestRun) SetDockerConfig(localSdkPath string, useGaia bool, gaiaTag string) {
+	if localSdkPath != "" {
+		fmt.Println("USING LOCAL SDK", localSdkPath)
 	}
-	s.localSdkPath = path
+	if useGaia {
+		fmt.Println("USING GAIA INSTEAD OF ICS provider app", gaiaTag)
+	}
+
+	s.useGaia = useGaia
+	s.gaiaTag = gaiaTag
+	s.localSdkPath = localSdkPath
 }
 
 // validateStringLiterals enforces that configs follow the constraints

--- a/tests/integration/testnet-scripts/start-docker.sh
+++ b/tests/integration/testnet-scripts/start-docker.sh
@@ -7,6 +7,8 @@ set -eux
 CONTAINER_NAME=$1
 INSTANCE_NAME=$2
 LOCAL_SDK_PATH=${3:-"default"} # Sets this var to default if null or unset
+USE_GAIA_PROVIDER=${4:-"false"} # if true, use gaia as provider; if false, use ICS app
+USE_GAIA_TAG=${5:-""} # gaia tag to use if using gaia as provider; by default the latest tag is used
 
 # Remove existing container instance
 set +e
@@ -28,7 +30,15 @@ else
 fi
 
 # Build the Docker container
-docker build -t "$CONTAINER_NAME" .
+if [[ "$USE_GAIA_PROVIDER" = "true" ]]
+then
+    printf "\n\nUsing gaia as provider\n\n"
+    printf "\n\nUsing gaia tag %s\n\n" "$USE_GAIA_TAG"
+    docker build  -f Dockerfile.gaia -t "$CONTAINER_NAME" --build-arg USE_GAIA_TAG="$USE_GAIA_TAG" .
+else
+    printf "\n\nUsing ICS provider app as provider\n\n\n"
+    docker build -f Dockerfile -t "$CONTAINER_NAME"  .
+fi
 
 # Remove copied sdk directory
 rm -rf ./cosmos-sdk/


### PR DESCRIPTION
# Description

Expands on #735, with the ability to set the `--local-sdk-path` flag

The following command worked for me, where I've checked out [this branch](https://github.com/cosmos/cosmos-sdk/tree/v0.45.13-ics) to `path` locally. We can local debug prints as needed and inspect them in docker
```bash
go run ./tests/integration/... --happy-path-only --use-gaia --local-sdk-path "path"
```

## Linked issues

Closes: `#<issue>`

## Type of change

- [x] `Testing`: Adds testing

## Regression tests

n/a

## New behavior tests

n/a
