### PR TITLE
chore: disable sonarcloud on dependabot PRs and forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   sonarcloud:
+    # skip this on forks or dependabot PRs
+    if: env.SONAR_TOKEN != null
     name: SonarCloud
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description
This PR attempts to exclude forks and dependabot from running sonarcloud.

## Type of change

If you've checked more than one of the first three boxes, consider splitting this PR into multiple PRs!

- [ ] `Feature`: Changes and/or adds code behavior, irrelevant to bug fixes
- [x] `Fix`: Changes and/or adds code behavior, specifically to fix a bug
- [ ] `Refactor`: Changes existing code style, naming, structure, etc.
- [ ] `Testing`: Adds testing
- [ ] `Docs`: Adds documentation

## Regression tests

No code changes made.

## New behavior tests

No code changes made.

## Versioning Implications

- [ ] This PR will affect [semantic versioning as defined for ICS](../CONTRIBUTING.md#semantic-versioning)

If the above box is checked, which version should be bumped?

- [ ] `MAJOR`: Consensus breaking changes to both the provider and consumers(s), including updates/breaking changes to IBC communication between provider and consumer(s)
- [ ] `MINOR`: Consensus breaking changes which affect either only the provider or only the consumer(s)
- [ ] `PATCH`: Non consensus breaking changes

## Targeting

Please select one of the following:

- [ ] This PR is only relevant to main
- [ ] This PR is relevant to main, and should also be back-ported to ____ (ex: v1.0.0 and v1.1.0)
- [ ] This PR is only relevant to ____ (ex: v1.0.0, v1.1.0, and v1.2.0)
