### PR TITLE
Ser correct byte prefix for SlashLogKey 

### DIFF
--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -446,5 +446,5 @@ func ParseChainIdAndConsAddrKey(prefix byte, bz []byte) (string, sdk.ConsAddress
 
 // SlashLogKey returns the key to a validator's slash log
 func SlashLogKey(providerAddr ProviderConsAddress) []byte {
-	return append([]byte{SlashAcksBytePrefix}, providerAddr.ToSdkConsAddr().Bytes()...)
+	return append([]byte{SlashLogBytePrefix}, providerAddr.ToSdkConsAddr().Bytes()...)
 }

--- a/x/ccv/provider/types/keys_test.go
+++ b/x/ccv/provider/types/keys_test.go
@@ -66,6 +66,7 @@ func getSingleByteKeys() [][]byte {
 	keys[i], i = []byte{providertypes.ThrottledPacketDataSizeBytePrefix}, i+1
 	keys[i], i = []byte{providertypes.ThrottledPacketDataBytePrefix}, i+1
 	keys[i], i = []byte{providertypes.GlobalSlashEntryBytePrefix}, i+1
+	keys[i], i = []byte{providertypes.SlashLogBytePrefix}, i+1
 
 	return keys[:i]
 }


### PR DESCRIPTION
# Description

Replace `SlashAcksBytePrefix` with `SlashLogBytePrefix`

## Linked issues

Closes: https://github.com/cosmos/interchain-security/issues/785

## Type of change

If you've checked more than one of the first three boxes, consider splitting this PR into multiple PRs!

- [ ] `Feature`: Changes and/or adds code behavior, irrelevant to bug fixes
- [x] `Fix`: Changes and/or adds code behavior, specifically to fix a bug
- [ ] `Refactor`: Changes existing code style, naming, structure, etc.
- [ ] `Testing`: Adds testing
- [ ] `Docs`: Adds documentation

## New behavior tests

If `Feature` or `Fix`, describe the new or existing tests that verify the new behavior is correct and expected.

## Versioning Implications

- [x] This PR will affect [semantic versioning as defined for ICS](../CONTRIBUTING.md#semantic-versioning)

If the above box is checked, which version should be bumped?

- [ ] `MAJOR`: Consensus breaking changes to both the provider and consumers(s), including updates/breaking changes to IBC communication between provider and consumer(s)
- [x] `MINOR`: Consensus breaking changes which affect either only the provider or only the consumer(s)
- [ ] `PATCH`: Non consensus breaking changes

## Targeting

Please select one of the following:

- [x] This PR is only relevant to main
- [ ] This PR is relevant to main, and should also be back-ported to ____ (ex: v1.0.0 and v1.1.0)
- [ ] This PR is only relevant to ____ (ex: v1.0.0, v1.1.0, and v1.2.0)
