### PR TITLE
Remove RegisterSdkCryptoCodecInterfaces

### DIFF
--- a/testutil/keeper/unit_test_helpers.go
+++ b/testutil/keeper/unit_test_helpers.go
@@ -56,6 +56,7 @@ func NewInMemKeeperParams(tb testing.TB) InMemKeeperParams {
 	require.NoError(tb, stateStore.LoadLatestVersion())
 
 	registry := codectypes.NewInterfaceRegistry()
+	cryptocodec.RegisterInterfaces(registry) // Public key implementation registered here
 	cdc := codec.NewProtoCodec(registry)
 
 	paramsSubspace := paramstypes.NewSubspace(cdc,
@@ -171,18 +172,6 @@ func GetConsumerKeeperAndCtx(t *testing.T, params InMemKeeperParams) (
 	ctrl := gomock.NewController(t)
 	mocks := NewMockedKeepers(ctrl)
 	return NewInMemConsumerKeeper(params, mocks), params.Ctx, ctrl, mocks
-}
-
-// Registers proto interfaces for params.Cdc
-//
-// For now, we explicitly force certain unit tests to register sdk crypto interfaces.
-// TODO: This function will be executed automatically once https://github.com/cosmos/interchain-security/issues/273 is solved.
-func (params *InMemKeeperParams) RegisterSdkCryptoCodecInterfaces() {
-	ir := codectypes.NewInterfaceRegistry()
-	// Public key implementation registered here
-	cryptocodec.RegisterInterfaces(ir)
-	// Replace default cdc, with a custom (registered) codec
-	params.Cdc = codec.NewProtoCodec(ir)
 }
 
 type PrivateKey struct {

--- a/x/ccv/consumer/keeper/changeover_test.go
+++ b/x/ccv/consumer/keeper/changeover_test.go
@@ -88,7 +88,6 @@ func TestChangeoverToConsumer(t *testing.T) {
 	for _, tc := range testCases {
 
 		keeperParams := uthelpers.NewInMemKeeperParams(t)
-		keeperParams.RegisterSdkCryptoCodecInterfaces()
 		consumerKeeper, ctx, ctrl, mocks := uthelpers.GetConsumerKeeperAndCtx(t, keeperParams)
 		defer ctrl.Finish()
 

--- a/x/ccv/consumer/keeper/genesis_test.go
+++ b/x/ccv/consumer/keeper/genesis_test.go
@@ -203,8 +203,6 @@ func TestInitGenesis(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			keeperParams := testkeeper.NewInMemKeeperParams(t)
-			// explicitly register codec with public key interface
-			keeperParams.RegisterSdkCryptoCodecInterfaces()
 			consumerKeeper, ctx, ctrl, mocks := testkeeper.GetConsumerKeeperAndCtx(t, keeperParams)
 			defer ctrl.Finish()
 
@@ -348,8 +346,6 @@ func TestExportGenesis(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			keeperParams := testkeeper.NewInMemKeeperParams(t)
-			// Explicitly register codec with public key interface
-			keeperParams.RegisterSdkCryptoCodecInterfaces()
 			consumerKeeper, ctx, ctrl, mocks := testkeeper.GetConsumerKeeperAndCtx(t, keeperParams)
 			defer ctrl.Finish()
 			consumerKeeper.SetParams(ctx, params)

--- a/x/ccv/consumer/keeper/keeper_test.go
+++ b/x/ccv/consumer/keeper/keeper_test.go
@@ -249,8 +249,6 @@ func TestPacketMaturityTime(t *testing.T) {
 // TestCrossChainValidator tests the getter, setter, and deletion method for cross chain validator records
 func TestCrossChainValidator(t *testing.T) {
 	keeperParams := testkeeper.NewInMemKeeperParams(t)
-	// Explicitly register codec with public key interface
-	keeperParams.RegisterSdkCryptoCodecInterfaces()
 	consumerKeeper, ctx, ctrl, _ := testkeeper.GetConsumerKeeperAndCtx(t, keeperParams)
 	defer ctrl.Finish()
 
@@ -290,8 +288,6 @@ func TestCrossChainValidator(t *testing.T) {
 // TestGetAllCCValidator tests GetAllCCValidator behaviour correctness
 func TestGetAllCCValidator(t *testing.T) {
 	keeperParams := testkeeper.NewInMemKeeperParams(t)
-	// Explicitly register codec with public key interface
-	keeperParams.RegisterSdkCryptoCodecInterfaces()
 	ck, ctx, ctrl, _ := testkeeper.GetConsumerKeeperAndCtx(t, keeperParams)
 	defer ctrl.Finish()
 

--- a/x/ccv/consumer/keeper/validators_test.go
+++ b/x/ccv/consumer/keeper/validators_test.go
@@ -18,8 +18,6 @@ import (
 // TestApplyCCValidatorChanges tests the ApplyCCValidatorChanges method for a consumer keeper
 func TestApplyCCValidatorChanges(t *testing.T) {
 	keeperParams := testkeeper.NewInMemKeeperParams(t)
-	// Explicitly register cdc with public key interface
-	keeperParams.RegisterSdkCryptoCodecInterfaces()
 	consumerKeeper, ctx, ctrl, _ := testkeeper.GetConsumerKeeperAndCtx(t, keeperParams)
 	defer ctrl.Finish()
 
@@ -109,8 +107,6 @@ func TestApplyCCValidatorChanges(t *testing.T) {
 // Tests the getter and setter behavior for historical info
 func TestHistoricalInfo(t *testing.T) {
 	keeperParams := testkeeper.NewInMemKeeperParams(t)
-	// Explicitly register cdc with public key interface
-	keeperParams.RegisterSdkCryptoCodecInterfaces()
 	consumerKeeper, ctx, ctrl, _ := testkeeper.GetConsumerKeeperAndCtx(t, keeperParams)
 	defer ctrl.Finish()
 	ctx = ctx.WithBlockHeight(15)


### PR DESCRIPTION
# Description

Removes `RegisterSdkCryptoCodecInterfaces` from the unit testing helpers file, and associated TODO comment. To replace this functionality `cryptocodec.RegisterInterfaces(ir)` is called for every unit test. 

A previous issue https://github.com/cosmos/interchain-security/issues/273 made it seem like we had to do these calls explicitly, but that's not the case.  

## Linked issues

n/a

## Type of change

- [ ] `Feature`: Changes and/or adds code behavior, irrelevant to bug fixes
- [ ] `Fix`: Changes and/or adds code behavior, specifically to fix a bug
- [x] `Refactor`: Changes existing code style, naming, structure, etc.
- [ ] `Testing`: Adds testing
- [ ] `Docs`: Adds documentation

## Regression tests

n/a

## New behavior tests

n/a

## Versioning Implications

- [ ] This PR will affect [semantic versioning as defined for ICS](../CONTRIBUTING.md#semantic-versioning)

If the above box is checked, which version should be bumped?

- [ ] `MAJOR`: Consensus breaking changes to both the provider and consumers(s), including updates/breaking changes to IBC communication between provider and consumer(s)
- [ ] `MINOR`: Consensus breaking changes which affect either only the provider or only the consumer(s)
- [ ] `PATCH`: Non consensus breaking changes

## Targeting

Please select one of the following:

- [x] This PR is only relevant to main
- [ ] This PR is relevant to main, and should also be back-ported to ____ (ex: v1.0.0 and v1.1.0)
- [ ] This PR is only relevant to ____ (ex: v1.0.0, v1.1.0, and v1.2.0)
