### PR TITLE
refactor: move utils to /types

### DIFF
--- a/x/ccv/consumer/keeper/keeper.go
+++ b/x/ccv/consumer/keeper/keeper.go
@@ -20,7 +20,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/interchain-security/x/ccv/consumer/types"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
-	"github.com/cosmos/interchain-security/x/ccv/utils"
 	tmtypes "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 )
@@ -109,20 +108,20 @@ func (k Keeper) mustValidateFields() {
 	// hooks are explicitly set after the constructor,
 	// stakingKeeper is optionally set after the constructor,
 
-	utils.PanicIfZeroOrNil(k.storeKey, "storeKey")                   // 1
-	utils.PanicIfZeroOrNil(k.cdc, "cdc")                             // 2
-	utils.PanicIfZeroOrNil(k.paramStore, "paramStore")               // 3
-	utils.PanicIfZeroOrNil(k.scopedKeeper, "scopedKeeper")           // 4
-	utils.PanicIfZeroOrNil(k.channelKeeper, "channelKeeper")         // 5
-	utils.PanicIfZeroOrNil(k.portKeeper, "portKeeper")               // 6
-	utils.PanicIfZeroOrNil(k.connectionKeeper, "connectionKeeper")   // 7
-	utils.PanicIfZeroOrNil(k.clientKeeper, "clientKeeper")           // 8
-	utils.PanicIfZeroOrNil(k.slashingKeeper, "slashingKeeper")       // 9
-	utils.PanicIfZeroOrNil(k.bankKeeper, "bankKeeper")               // 10
-	utils.PanicIfZeroOrNil(k.authKeeper, "authKeeper")               // 11
-	utils.PanicIfZeroOrNil(k.ibcTransferKeeper, "ibcTransferKeeper") // 12
-	utils.PanicIfZeroOrNil(k.ibcCoreKeeper, "ibcCoreKeeper")         // 13
-	utils.PanicIfZeroOrNil(k.feeCollectorName, "feeCollectorName")   // 14
+	ccv.PanicIfZeroOrNil(k.storeKey, "storeKey")                   // 1
+	ccv.PanicIfZeroOrNil(k.cdc, "cdc")                             // 2
+	ccv.PanicIfZeroOrNil(k.paramStore, "paramStore")               // 3
+	ccv.PanicIfZeroOrNil(k.scopedKeeper, "scopedKeeper")           // 4
+	ccv.PanicIfZeroOrNil(k.channelKeeper, "channelKeeper")         // 5
+	ccv.PanicIfZeroOrNil(k.portKeeper, "portKeeper")               // 6
+	ccv.PanicIfZeroOrNil(k.connectionKeeper, "connectionKeeper")   // 7
+	ccv.PanicIfZeroOrNil(k.clientKeeper, "clientKeeper")           // 8
+	ccv.PanicIfZeroOrNil(k.slashingKeeper, "slashingKeeper")       // 9
+	ccv.PanicIfZeroOrNil(k.bankKeeper, "bankKeeper")               // 10
+	ccv.PanicIfZeroOrNil(k.authKeeper, "authKeeper")               // 11
+	ccv.PanicIfZeroOrNil(k.ibcTransferKeeper, "ibcTransferKeeper") // 12
+	ccv.PanicIfZeroOrNil(k.ibcCoreKeeper, "ibcCoreKeeper")         // 13
+	ccv.PanicIfZeroOrNil(k.feeCollectorName, "feeCollectorName")   // 14
 }
 
 // Logger returns a module-specific logger.

--- a/x/ccv/consumer/keeper/relay.go
+++ b/x/ccv/consumer/keeper/relay.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cosmos/ibc-go/v4/modules/core/exported"
 	"github.com/cosmos/interchain-security/x/ccv/consumer/types"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
-	ccvtypes "github.com/cosmos/interchain-security/x/ccv/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
@@ -53,7 +52,7 @@ func (k Keeper) OnRecvVSCPacket(ctx sdk.Context, packet channeltypes.Packet, new
 	if exists {
 		currentValUpdates = currentChanges.ValidatorUpdates
 	}
-	pendingChanges := ccvtypes.AccumulateChanges(currentValUpdates, newChanges.ValidatorUpdates)
+	pendingChanges := ccv.AccumulateChanges(currentValUpdates, newChanges.ValidatorUpdates)
 
 	k.SetPendingChanges(ctx, ccv.ValidatorSetChangePacketData{
 		ValidatorUpdates: pendingChanges,
@@ -186,7 +185,7 @@ func (k Keeper) SendPackets(ctx sdk.Context) {
 	for _, p := range pending.GetList() {
 
 		// send packet over IBC
-		err := ccvtypes.SendIBCPacket(
+		err := ccv.SendIBCPacket(
 			ctx,
 			k.scopedKeeper,
 			k.channelKeeper,

--- a/x/ccv/consumer/keeper/relay.go
+++ b/x/ccv/consumer/keeper/relay.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cosmos/ibc-go/v4/modules/core/exported"
 	"github.com/cosmos/interchain-security/x/ccv/consumer/types"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
-	utils "github.com/cosmos/interchain-security/x/ccv/utils"
+	ccvtypes "github.com/cosmos/interchain-security/x/ccv/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
 
@@ -53,7 +53,7 @@ func (k Keeper) OnRecvVSCPacket(ctx sdk.Context, packet channeltypes.Packet, new
 	if exists {
 		currentValUpdates = currentChanges.ValidatorUpdates
 	}
-	pendingChanges := utils.AccumulateChanges(currentValUpdates, newChanges.ValidatorUpdates)
+	pendingChanges := ccvtypes.AccumulateChanges(currentValUpdates, newChanges.ValidatorUpdates)
 
 	k.SetPendingChanges(ctx, ccv.ValidatorSetChangePacketData{
 		ValidatorUpdates: pendingChanges,
@@ -186,7 +186,7 @@ func (k Keeper) SendPackets(ctx sdk.Context) {
 	for _, p := range pending.GetList() {
 
 		// send packet over IBC
-		err := utils.SendIBCPacket(
+		err := ccvtypes.SendIBCPacket(
 			ctx,
 			k.scopedKeeper,
 			k.channelKeeper,

--- a/x/ccv/consumer/types/keys.go
+++ b/x/ccv/consumer/types/keys.go
@@ -5,8 +5,7 @@ import (
 	time "time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-
-	utils "github.com/cosmos/interchain-security/x/ccv/utils"
+	ccvtypes "github.com/cosmos/interchain-security/x/ccv/types"
 )
 
 const (
@@ -153,7 +152,7 @@ func HistoricalInfoKey(height int64) []byte {
 // PacketMaturityTimeKey returns the key for storing the maturity time for a given received VSC packet id
 func PacketMaturityTimeKey(vscID uint64, maturityTime time.Time) []byte {
 	ts := uint64(maturityTime.UTC().UnixNano())
-	return utils.AppendMany(
+	return ccvtypes.AppendMany(
 		// Append the prefix
 		[]byte{PacketMaturityTimeBytePrefix},
 		// Append the time

--- a/x/ccv/provider/keeper/grpc_query.go
+++ b/x/ccv/provider/keeper/grpc_query.go
@@ -8,7 +8,6 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/interchain-security/x/ccv/provider/types"
 	ccvtypes "github.com/cosmos/interchain-security/x/ccv/types"
-	"github.com/cosmos/interchain-security/x/ccv/utils"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -103,7 +102,7 @@ func (k Keeper) QueryValidatorConsumerAddr(goCtx context.Context, req *types.Que
 		return &types.QueryValidatorConsumerAddrResponse{}, nil
 	}
 
-	consumerAddr, err := utils.TMCryptoPublicKeyToConsAddr(consumerKey)
+	consumerAddr, err := ccvtypes.TMCryptoPublicKeyToConsAddr(consumerKey)
 	if err != nil {
 		return nil, err
 	}

--- a/x/ccv/provider/keeper/hooks.go
+++ b/x/ccv/provider/keeper/hooks.go
@@ -7,7 +7,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	providertypes "github.com/cosmos/interchain-security/x/ccv/provider/types"
-	"github.com/cosmos/interchain-security/x/ccv/utils"
+	ccvtypes "github.com/cosmos/interchain-security/x/ccv/types"
 )
 
 // Wrapper struct
@@ -104,7 +104,7 @@ func (h Hooks) AfterValidatorCreated(ctx sdk.Context, valAddr sdk.ValAddress) {
 func (h Hooks) AfterValidatorRemoved(ctx sdk.Context, valConsAddr sdk.ConsAddress, valAddr sdk.ValAddress) {
 	for _, validatorConsumerPubKey := range h.k.GetAllValidatorConsumerPubKeys(ctx, nil) {
 		if validatorConsumerPubKey.ProviderAddr.ToSdkConsAddr().Equals(valConsAddr) {
-			consumerAddrTmp, err := utils.TMCryptoPublicKeyToConsAddr(*validatorConsumerPubKey.ConsumerKey)
+			consumerAddrTmp, err := ccvtypes.TMCryptoPublicKeyToConsAddr(*validatorConsumerPubKey.ConsumerKey)
 			if err != nil {
 				// An error here would indicate something is very wrong
 				panic("cannot get address of consumer key")

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -22,7 +22,6 @@ import (
 	consumertypes "github.com/cosmos/interchain-security/x/ccv/consumer/types"
 	"github.com/cosmos/interchain-security/x/ccv/provider/types"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
-	"github.com/cosmos/interchain-security/x/ccv/utils"
 
 	"github.com/tendermint/tendermint/libs/log"
 )
@@ -86,19 +85,19 @@ func (k Keeper) mustValidateFields() {
 		panic("number of fields in provider keeper is not 13")
 	}
 
-	utils.PanicIfZeroOrNil(k.cdc, "cdc")                           // 1
-	utils.PanicIfZeroOrNil(k.storeKey, "storeKey")                 // 2
-	utils.PanicIfZeroOrNil(k.paramSpace, "paramSpace")             // 3
-	utils.PanicIfZeroOrNil(k.scopedKeeper, "scopedKeeper")         // 4
-	utils.PanicIfZeroOrNil(k.channelKeeper, "channelKeeper")       // 5
-	utils.PanicIfZeroOrNil(k.portKeeper, "portKeeper")             // 6
-	utils.PanicIfZeroOrNil(k.connectionKeeper, "connectionKeeper") // 7
-	utils.PanicIfZeroOrNil(k.accountKeeper, "accountKeeper")       // 8
-	utils.PanicIfZeroOrNil(k.clientKeeper, "clientKeeper")         // 9
-	utils.PanicIfZeroOrNil(k.stakingKeeper, "stakingKeeper")       // 10
-	utils.PanicIfZeroOrNil(k.slashingKeeper, "slashingKeeper")     // 11
-	utils.PanicIfZeroOrNil(k.evidenceKeeper, "evidenceKeeper")     // 12
-	utils.PanicIfZeroOrNil(k.feeCollectorName, "feeCollectorName") // 13
+	ccv.PanicIfZeroOrNil(k.cdc, "cdc")                           // 1
+	ccv.PanicIfZeroOrNil(k.storeKey, "storeKey")                 // 2
+	ccv.PanicIfZeroOrNil(k.paramSpace, "paramSpace")             // 3
+	ccv.PanicIfZeroOrNil(k.scopedKeeper, "scopedKeeper")         // 4
+	ccv.PanicIfZeroOrNil(k.channelKeeper, "channelKeeper")       // 5
+	ccv.PanicIfZeroOrNil(k.portKeeper, "portKeeper")             // 6
+	ccv.PanicIfZeroOrNil(k.connectionKeeper, "connectionKeeper") // 7
+	ccv.PanicIfZeroOrNil(k.accountKeeper, "accountKeeper")       // 8
+	ccv.PanicIfZeroOrNil(k.clientKeeper, "clientKeeper")         // 9
+	ccv.PanicIfZeroOrNil(k.stakingKeeper, "stakingKeeper")       // 10
+	ccv.PanicIfZeroOrNil(k.slashingKeeper, "slashingKeeper")     // 11
+	ccv.PanicIfZeroOrNil(k.evidenceKeeper, "evidenceKeeper")     // 12
+	ccv.PanicIfZeroOrNil(k.feeCollectorName, "feeCollectorName") // 13
 }
 
 // Logger returns a module-specific logger.

--- a/x/ccv/provider/keeper/key_assignment.go
+++ b/x/ccv/provider/keeper/key_assignment.go
@@ -8,7 +8,7 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"github.com/cosmos/interchain-security/x/ccv/provider/types"
-	utils "github.com/cosmos/interchain-security/x/ccv/utils"
+	ccvtypes "github.com/cosmos/interchain-security/x/ccv/types"
 
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmprotocrypto "github.com/tendermint/tendermint/proto/tendermint/crypto"
@@ -391,7 +391,7 @@ func (k Keeper) AssignConsumerKey(
 	validator stakingtypes.Validator,
 	consumerKey tmprotocrypto.PublicKey,
 ) error {
-	consAddrTmp, err := utils.TMCryptoPublicKeyToConsAddr(consumerKey)
+	consAddrTmp, err := ccvtypes.TMCryptoPublicKeyToConsAddr(consumerKey)
 	if err != nil {
 		return err
 	}
@@ -439,7 +439,7 @@ func (k Keeper) AssignConsumerKey(
 			// mark this old consumer key as prunable once the VSCMaturedPacket
 			// for the current VSC ID is received;
 			// note: this state is removed on receiving the VSCMaturedPacket
-			oldConsumerAddrTmp, err := utils.TMCryptoPublicKeyToConsAddr(oldConsumerKey)
+			oldConsumerAddrTmp, err := ccvtypes.TMCryptoPublicKeyToConsAddr(oldConsumerKey)
 			if err != nil {
 				return err
 			}
@@ -482,7 +482,7 @@ func (k Keeper) AssignConsumerKey(
 		// from the old consumer address to the provider address (if any)
 		// get the previous key assigned for this validator on this consumer chain
 		if oldConsumerKey, found := k.GetValidatorConsumerPubKey(ctx, chainID, providerAddr); found {
-			oldConsumerAddrTmp, err := utils.TMCryptoPublicKeyToConsAddr(oldConsumerKey)
+			oldConsumerAddrTmp, err := ccvtypes.TMCryptoPublicKeyToConsAddr(oldConsumerKey)
 			if err != nil {
 				return err
 			}
@@ -513,7 +513,7 @@ func (k Keeper) MustApplyKeyAssignmentToValUpdates(
 	valUpdates []abci.ValidatorUpdate,
 ) (newUpdates []abci.ValidatorUpdate) {
 	for _, valUpdate := range valUpdates {
-		providerAddrTmp, err := utils.TMCryptoPublicKeyToConsAddr(valUpdate.PubKey)
+		providerAddrTmp, err := ccvtypes.TMCryptoPublicKeyToConsAddr(valUpdate.PubKey)
 		if err != nil {
 			panic(fmt.Errorf("cannot get provider address from pub key: %s", err.Error()))
 		}

--- a/x/ccv/provider/keeper/key_assignment_test.go
+++ b/x/ccv/provider/keeper/key_assignment_test.go
@@ -17,7 +17,7 @@ import (
 
 	providerkeeper "github.com/cosmos/interchain-security/x/ccv/provider/keeper"
 	"github.com/cosmos/interchain-security/x/ccv/provider/types"
-	"github.com/cosmos/interchain-security/x/ccv/utils"
+	ccvtypes "github.com/cosmos/interchain-security/x/ccv/types"
 	"github.com/golang/mock/gomock"
 )
 
@@ -337,7 +337,7 @@ func checkCorrectPruningProperty(ctx sdk.Context, k providerkeeper.Keeper, chain
 		// Try to find a validator who has this consumer address currently assigned
 		isCurrentlyAssigned := false
 		for _, valconsPubKey := range k.GetAllValidatorConsumerPubKeys(ctx, &valByConsAddr.ChainId) {
-			consumerAddr, _ := utils.TMCryptoPublicKeyToConsAddr(*valconsPubKey.ConsumerKey)
+			consumerAddr, _ := ccvtypes.TMCryptoPublicKeyToConsAddr(*valconsPubKey.ConsumerKey)
 			if consumerAddr.Equals(valByConsAddr.ConsumerAddr.ToSdkConsAddr()) {
 				isCurrentlyAssigned = true
 				break
@@ -653,7 +653,7 @@ func (vs *ValSet) apply(updates []abci.ValidatorUpdate) {
 	for _, u := range updates {
 		for i, id := range vs.identities { // n2 looping but n is tiny
 			// cons := sdk.ConsAddress(utils.GetChangePubKeyAddress(u))
-			cons, _ := utils.TMCryptoPublicKeyToConsAddr(u.PubKey)
+			cons, _ := ccvtypes.TMCryptoPublicKeyToConsAddr(u.PubKey)
 			if id.SDKValConsAddress().Equals(cons) {
 				vs.power[i] = u.Power
 			}
@@ -852,7 +852,7 @@ func TestSimulatedAssignmentsAndUpdateApplication(t *testing.T) {
 						// Use default if unassigned
 						ck = idP.TMProtoCryptoPublicKey()
 					}
-					consC, err := utils.TMCryptoPublicKeyToConsAddr(ck)
+					consC, err := ccvtypes.TMCryptoPublicKeyToConsAddr(ck)
 					require.NoError(t, err)
 					// Find the corresponding consumer validator (must always be found)
 					for j, idC := range consumerValset.identities {

--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cosmos/ibc-go/v4/modules/core/exported"
 	providertypes "github.com/cosmos/interchain-security/x/ccv/provider/types"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
-	ccvtypes "github.com/cosmos/interchain-security/x/ccv/types"
 )
 
 // OnRecvVSCMaturedPacket handles a VSCMatured packet
@@ -181,7 +180,7 @@ func (k Keeper) SendVSCPacketsToChain(ctx sdk.Context, chainID, channelID string
 	pendingPackets := k.GetPendingVSCPackets(ctx, chainID)
 	for _, data := range pendingPackets {
 		// send packet over IBC
-		err := ccvtypes.SendIBCPacket(
+		err := ccv.SendIBCPacket(
 			ctx,
 			k.scopedKeeper,
 			k.channelKeeper,

--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -12,7 +12,7 @@ import (
 	"github.com/cosmos/ibc-go/v4/modules/core/exported"
 	providertypes "github.com/cosmos/interchain-security/x/ccv/provider/types"
 	ccv "github.com/cosmos/interchain-security/x/ccv/types"
-	utils "github.com/cosmos/interchain-security/x/ccv/utils"
+	ccvtypes "github.com/cosmos/interchain-security/x/ccv/types"
 )
 
 // OnRecvVSCMaturedPacket handles a VSCMatured packet
@@ -181,7 +181,7 @@ func (k Keeper) SendVSCPacketsToChain(ctx sdk.Context, chainID, channelID string
 	pendingPackets := k.GetPendingVSCPackets(ctx, chainID)
 	for _, data := range pendingPackets {
 		// send packet over IBC
-		err := utils.SendIBCPacket(
+		err := ccvtypes.SendIBCPacket(
 			ctx,
 			k.scopedKeeper,
 			k.channelKeeper,

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -8,7 +8,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	ccvutils "github.com/cosmos/interchain-security/x/ccv/utils"
+	ccvtypes "github.com/cosmos/interchain-security/x/ccv/types"
 )
 
 type Status int
@@ -184,7 +184,7 @@ func InitTimeoutTimestampKey(chainID string) []byte {
 // The key has the following format: PendingCAPBytePrefix | timestamp.UnixNano() | chainID
 func PendingCAPKey(timestamp time.Time, chainID string) []byte {
 	ts := uint64(timestamp.UTC().UnixNano())
-	return ccvutils.AppendMany(
+	return ccvtypes.AppendMany(
 		// Append the prefix
 		[]byte{PendingCAPBytePrefix},
 		// Append the time
@@ -198,7 +198,7 @@ func PendingCAPKey(timestamp time.Time, chainID string) []byte {
 // The key has the following format: PendingCRPBytePrefix | timestamp.UnixNano() | chainID
 func PendingCRPKey(timestamp time.Time, chainID string) []byte {
 	ts := uint64(timestamp.UTC().UnixNano())
-	return ccvutils.AppendMany(
+	return ccvtypes.AppendMany(
 		// Append the prefix
 		[]byte{PendingCRPBytePrefix},
 		// Append the time
@@ -297,7 +297,7 @@ func ParseThrottledPacketDataKey(key []byte) (chainId string, ibcSeqNum uint64, 
 // GlobalSlashEntryKey returns the key for storing a global slash queue entry.
 func GlobalSlashEntryKey(entry GlobalSlashEntry) []byte {
 	recvTime := uint64(entry.RecvTime.UTC().UnixNano())
-	return ccvutils.AppendMany(
+	return ccvtypes.AppendMany(
 		// Append byte prefix
 		[]byte{GlobalSlashEntryBytePrefix},
 		// Append time bz
@@ -377,7 +377,7 @@ func SlashLogKey(providerAddr ProviderConsAddress) []byte {
 func ChainIdAndTsKey(prefix byte, chainID string, timestamp time.Time) []byte {
 	partialKey := ChainIdWithLenKey(prefix, chainID)
 	timeBz := sdk.FormatTimeBytes(timestamp)
-	return ccvutils.AppendMany(
+	return ccvtypes.AppendMany(
 		// Append the partialKey
 		partialKey,
 		// Append the time bytes
@@ -389,7 +389,7 @@ func ChainIdAndTsKey(prefix byte, chainID string, timestamp time.Time) []byte {
 // bytePrefix | len(chainID) | chainID
 func ChainIdWithLenKey(prefix byte, chainID string) []byte {
 	chainIdL := len(chainID)
-	return ccvutils.AppendMany(
+	return ccvtypes.AppendMany(
 		// Append the prefix
 		[]byte{prefix},
 		// Append the chainID length
@@ -419,7 +419,7 @@ func ParseChainIdAndTsKey(prefix byte, bz []byte) (string, time.Time, error) {
 // bytePrefix | len(chainID) | chainID | uint64(ID)
 func ChainIdAndUintIdKey(prefix byte, chainID string, uintId uint64) []byte {
 	partialKey := ChainIdWithLenKey(prefix, chainID)
-	return ccvutils.AppendMany(
+	return ccvtypes.AppendMany(
 		// Append the partialKey
 		partialKey,
 		// Append the uint id bytes
@@ -444,7 +444,7 @@ func ParseChainIdAndUintIdKey(prefix byte, bz []byte) (string, uint64, error) {
 // bytePrefix | len(chainID) | chainID | ConsAddress
 func ChainIdAndConsAddrKey(prefix byte, chainID string, addr sdk.ConsAddress) []byte {
 	partialKey := ChainIdWithLenKey(prefix, chainID)
-	return ccvutils.AppendMany(
+	return ccvtypes.AppendMany(
 		// Append the partialKey
 		partialKey,
 		// Append the addr bytes

--- a/x/ccv/types/utils.go
+++ b/x/ccv/types/utils.go
@@ -1,4 +1,4 @@
-package utils
+package types
 
 import (
 	"reflect"
@@ -11,7 +11,6 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v4/modules/core/02-client/types"
 	channeltypes "github.com/cosmos/ibc-go/v4/modules/core/04-channel/types"
 	host "github.com/cosmos/ibc-go/v4/modules/core/24-host"
-	ccv "github.com/cosmos/interchain-security/x/ccv/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmprotocrypto "github.com/tendermint/tendermint/proto/tendermint/crypto"
 )
@@ -59,8 +58,8 @@ func TMCryptoPublicKeyToConsAddr(k tmprotocrypto.PublicKey) (sdk.ConsAddress, er
 // over the source channelID and portID
 func SendIBCPacket(
 	ctx sdk.Context,
-	scopedKeeper ccv.ScopedKeeper,
-	channelKeeper ccv.ChannelKeeper,
+	scopedKeeper ScopedKeeper,
+	channelKeeper ChannelKeeper,
 	channelID string,
 	portID string,
 	packetData []byte,

--- a/x/ccv/types/utils_test.go
+++ b/x/ccv/types/utils_test.go
@@ -1,11 +1,11 @@
-package utils_test
+package types_test
 
 import (
 	"testing"
 
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	ibcsimapp "github.com/cosmos/interchain-security/legacy_ibc_testing/simapp"
-	"github.com/cosmos/interchain-security/x/ccv/utils"
+	"github.com/cosmos/interchain-security/x/ccv/types"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 )
@@ -80,7 +80,7 @@ func TestAccumulateChanges(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			changes := utils.AccumulateChanges(tc.changes1, tc.changes2)
+			changes := types.AccumulateChanges(tc.changes1, tc.changes2)
 			require.Equal(t, tc.expected, changes)
 		})
 	}


### PR DESCRIPTION
# Description

Moves the contents of `x/ccv/utils/` to `x/ccv/types`, which is a different golang package. Existing code now references the ccvtypes package. 

This is step 1 to complete #801  

## Linked issues

#801

## Type of change

If you've checked more than one of the first three boxes, consider splitting this PR into multiple PRs!

- [ ] `Feature`: Changes and/or adds code behavior, irrelevant to bug fixes
- [ ] `Fix`: Changes and/or adds code behavior, specifically to fix a bug
- [x] `Refactor`: Changes existing code style, naming, structure, etc.
- [ ] `Testing`: Adds testing
- [ ] `Docs`: Adds documentation

## Regression tests

Existing UTs

## New behavior tests

n/a

## Versioning Implications

- [x] This PR will affect [semantic versioning as defined for ICS](../CONTRIBUTING.md#semantic-versioning)

If the above box is checked, which version should be bumped?

- [ ] `MAJOR`: Consensus breaking changes to both the provider and consumers(s), including updates/breaking changes to IBC communication between provider and consumer(s)
- [ ] `MINOR`: Consensus breaking changes which affect either only the provider or only the consumer(s)
- [x] `PATCH`: Non consensus breaking changes

## Targeting

Please select one of the following:

- [x] This PR is only relevant to main
- [ ] This PR is relevant to main, and should also be back-ported to ____ (ex: v1.0.0 and v1.1.0)
- [ ] This PR is only relevant to ____ (ex: v1.0.0, v1.1.0, and v1.2.0)
