### PR TITLE
testing: e2e tests for soft opt out 

### DIFF
--- a/tests/e2e/actions.go
+++ b/tests/e2e/actions.go
@@ -514,9 +514,10 @@ func (tr TestRun) voteGovProposal(
 }
 
 type startConsumerChainAction struct {
-	consumerChain chainID
-	providerChain chainID
-	validators    []StartChainValidator
+	consumerChain  chainID
+	providerChain  chainID
+	validators     []StartChainValidator
+	genesisChanges string
 }
 
 func (tr TestRun) startConsumerChain(
@@ -545,7 +546,7 @@ func (tr TestRun) startConsumerChain(
 	consumerGenesis := ".app_state.ccvconsumer = " + string(bz)
 	consumerGenesisChanges := tr.chainConfigs[action.consumerChain].genesisChanges
 	if consumerGenesisChanges != "" {
-		consumerGenesis = consumerGenesis + " | " + consumerGenesisChanges
+		consumerGenesis = consumerGenesis + " | " + consumerGenesisChanges + " | " + action.genesisChanges
 	}
 
 	tr.startChain(StartChainAction{

--- a/tests/e2e/step_delegation.go
+++ b/tests/e2e/step_delegation.go
@@ -127,6 +127,9 @@ func stepsUnbond(consumerName string) []Step {
 	}
 }
 
+// stepsRedelegateForOptOut tests redelegation, and sets up voting powers s.t
+// alice will have less than 5% of the total voting power. This is needed to
+// test opt-out functionality.
 func stepsRedelegateForOptOut(consumerName string) []Step {
 	return []Step{
 		{

--- a/tests/e2e/step_delegation.go
+++ b/tests/e2e/step_delegation.go
@@ -127,8 +127,7 @@ func stepsUnbond(consumerName string) []Step {
 	}
 }
 
-// stepsRedelegate tests redelegation and resulting validator power changes.
-func stepsRedelegate(consumerName string) []Step {
+func stepsRedelegateForOptOut(consumerName string) []Step {
 	return []Step{
 		{
 			action: redelegateTokensAction{
@@ -136,9 +135,58 @@ func stepsRedelegate(consumerName string) []Step {
 				src:      validatorID("alice"),
 				dst:      validatorID("carol"),
 				txSender: validatorID("alice"),
-				// Leave alice with majority stake so non-faulty validators maintain more than
+				amount:   450000000,
+			},
+			state: State{
+				chainID("provi"): ChainState{
+					ValPowers: &map[validatorID]uint{
+						validatorID("alice"): 60,
+						validatorID("bob"):   500,
+						validatorID("carol"): 950,
+					},
+				},
+				chainID(consumerName): ChainState{
+					ValPowers: &map[validatorID]uint{
+						// Voting power changes not seen by consumer yet
+						validatorID("alice"): 510,
+						validatorID("bob"):   500,
+						validatorID("carol"): 500,
+					},
+				},
+			},
+		},
+		{
+			action: relayPacketsAction{
+				chain:   chainID("provi"),
+				port:    "provider",
+				channel: 0,
+			},
+			state: State{
+				chainID(consumerName): ChainState{
+					ValPowers: &map[validatorID]uint{
+						// Now power changes are seen by consumer
+						validatorID("alice"): 60,
+						validatorID("bob"):   500,
+						validatorID("carol"): 950,
+					},
+				},
+			},
+		},
+	}
+}
+
+// stepsRedelegate tests redelegation and resulting validator power changes.
+func stepsRedelegate(consumerName string) []Step {
+	return []Step{
+		{
+			action: redelegateTokensAction{
+				chain:    chainID("provi"),
+				src:      validatorID("carol"),
+				dst:      validatorID("alice"),
+				txSender: validatorID("carol"),
+				// redelegate s.t. alice has majority stake so non-faulty validators maintain more than
 				// 2/3 voting power during downtime tests below, avoiding chain halt
-				amount: 1000000,
+				amount: 449000000,
 			},
 			state: State{
 				chainID("provi"): ChainState{
@@ -152,9 +200,9 @@ func stepsRedelegate(consumerName string) []Step {
 				chainID(consumerName): ChainState{
 					ValPowers: &map[validatorID]uint{
 						// Voting power changes not seen by consumer yet
-						validatorID("alice"): 510,
+						validatorID("alice"): 60,
 						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+						validatorID("carol"): 950,
 					},
 				},
 			},

--- a/tests/e2e/steps.go
+++ b/tests/e2e/steps.go
@@ -18,6 +18,8 @@ var happyPathSteps = concatSteps(
 	stepsDelegate("consu"),
 	stepsAssignConsumerKeyOnStartedChain("consu", "bob"),
 	stepsUnbond("consu"),
+	stepsRedelegateForOptOut("consu"),
+	stepsDowntimeWithOptOut("consu"),
 	stepsRedelegate("consu"),
 	stepsDowntime("consu"),
 	stepsRejectEquivocationProposal("consu", 2),   // prop to tombstone bob is rejected

--- a/tests/e2e/steps_downtime.go
+++ b/tests/e2e/steps_downtime.go
@@ -202,9 +202,58 @@ func stepsDowntime(consumerName string) []Step {
 				},
 			},
 		},
+	}
+}
 
-		// TODO: Test full unbonding functionality, tracked as: https://github.com/cosmos/interchain-security/issues/311
-
+func stepsDowntimeWithOptOut(consumerName string) []Step {
+	return []Step{
+		{
+			action: downtimeSlashAction{
+				chain:     chainID(consumerName),
+				validator: validatorID("alice"),
+			},
+			state: State{
+				// powers not affected on either chain
+				chainID("provi"): ChainState{
+					ValPowers: &map[validatorID]uint{
+						validatorID("alice"): 60,
+						validatorID("bob"):   500,
+						validatorID("carol"): 950,
+					},
+				},
+				chainID(consumerName): ChainState{
+					ValPowers: &map[validatorID]uint{
+						validatorID("alice"): 60,
+						validatorID("bob"):   500,
+						validatorID("carol"): 950,
+					},
+				},
+			},
+		},
+		{
+			action: relayPacketsAction{
+				chain:   chainID("provi"),
+				port:    "provider",
+				channel: 0,
+			},
+			state: State{
+				chainID("provi"): ChainState{
+					ValPowers: &map[validatorID]uint{
+						// alice is not slashed or jailed due to soft opt out
+						validatorID("alice"): 60,
+						validatorID("bob"):   500,
+						validatorID("carol"): 950,
+					},
+				},
+				chainID(consumerName): ChainState{
+					ValPowers: &map[validatorID]uint{
+						validatorID("alice"): 60,
+						validatorID("bob"):   500,
+						validatorID("carol"): 950,
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/tests/e2e/steps_downtime.go
+++ b/tests/e2e/steps_downtime.go
@@ -205,6 +205,10 @@ func stepsDowntime(consumerName string) []Step {
 	}
 }
 
+// stepsDowntimeWithOptOut returns steps validating that alice can incur downtime
+// and not be slashed/jailed, since her voting power is less than 5% of the total.
+//
+// Note: 60 / (60 + 500 + 950) ~= 0.04
 func stepsDowntimeWithOptOut(consumerName string) []Step {
 	return []Step{
 		{

--- a/tests/e2e/steps_start_chains.go
+++ b/tests/e2e/steps_start_chains.go
@@ -147,6 +147,12 @@ func stepsStartConsumerChain(consumerName string, proposalIndex, chainIndex uint
 					{id: validatorID("alice"), stake: 500000000, allocation: 10000000000},
 					{id: validatorID("carol"), stake: 500000000, allocation: 10000000000},
 				},
+				// For consumers that're launching with the provider being on an earlier version
+				// of ICS before the soft opt-out threshold was introduced, we need to set the
+				// soft opt-out threshold to 0.05 in the consumer genesis to ensure that the
+				// consumer binary doesn't panic. Sdk requires that all params are set to valid
+				// values from the genesis file.
+				genesisChanges: ".app_state.ccvconsumer.params.soft_opt_out_threshold = \"0.05\"",
 			},
 			state: State{
 				chainID("provi"): ChainState{


### PR DESCRIPTION
# Description

Adds e2e tests validating #765 

## Linked issues

Closes https://github.com/cosmos/interchain-security/issues/849

## Type of change

If you've checked more than one of the first three boxes, consider splitting this PR into multiple PRs!

- [ ] `Feature`: Changes and/or adds code behavior, irrelevant to bug fixes
- [ ] `Fix`: Changes and/or adds code behavior, specifically to fix a bug
- [ ] `Refactor`: Changes existing code style, naming, structure, etc.
- [x] `Testing`: Adds testing
- [ ] `Docs`: Adds documentation

## Regression tests

Existing happy path steps are still there

## New behavior tests
Two new steps functions were added, stepsRedelegateForOptOut and stepsDowntimeWithOptOut. 

## Versioning Implications

- [ ] This PR will affect [semantic versioning as defined for ICS](../CONTRIBUTING.md#semantic-versioning)

If the above box is checked, which version should be bumped?

- [ ] `MAJOR`: Consensus breaking changes to both the provider and consumers(s), including updates/breaking changes to IBC communication between provider and consumer(s)
- [ ] `MINOR`: Consensus breaking changes which affect either only the provider or only the consumer(s)
- [ ] `PATCH`: Non consensus breaking changes

## Targeting

Please select one of the following:

- [x] This PR is only relevant to main
- [ ] This PR is relevant to main, and should also be back-ported to ____ (ex: v1.0.0 and v1.1.0)
- [ ] This PR is only relevant to ____ (ex: v1.0.0, v1.1.0, and v1.2.0)
