### PR TITLE
use ics23 v0.10.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,11 +114,11 @@ proto-lint:
 proto-check-breaking:
 	@$(DOCKER_BUF) breaking --against $(HTTPS_GIT)#branch=main
 
-TM_URL              = https://raw.githubusercontent.com/tendermint/tendermint/v0.34.5/proto/tendermint
+TM_URL              = https://raw.githubusercontent.com/cometbft/cometbft/v0.34.27/proto/tendermint
 GOGO_PROTO_URL      = https://raw.githubusercontent.com/regen-network/protobuf/cosmos
-CONFIO_URL          = https://raw.githubusercontent.com/confio/ics23/v0.7.1
+CONFIO_URL          = https://raw.githubusercontent.com/cosmos/ics23/v0.10.0
 COSMOS_PROTO_URL    = https://raw.githubusercontent.com/regen-network/cosmos-proto/master
-SDK_PROTO_URL 		= https://raw.githubusercontent.com/cosmos/cosmos-sdk/v0.45.13-ics/proto/cosmos
+SDK_PROTO_URL 		= https://raw.githubusercontent.com/cosmos/cosmos-sdk/v0.45.15-ics/proto/cosmos
 
 TM_CRYPTO_TYPES     = third_party/proto/tendermint/crypto
 TM_ABCI_TYPES       = third_party/proto/tendermint/abci

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/cosmos/interchain-security
 go 1.20
 
 require (
-	github.com/confio/ics23/go v0.9.0
+	github.com/confio/ics23/go v0.9.0 // indirect
 	github.com/cosmos/cosmos-sdk v0.45.15
 	github.com/cosmos/ibc-go/v4 v4.3.0
 	github.com/gogo/protobuf v1.3.3
@@ -30,6 +30,8 @@ require (
 	google.golang.org/protobuf v1.30.0
 	gopkg.in/yaml.v2 v2.4.0
 )
+
+require github.com/cosmos/ics23/go v0.10.0
 
 require (
 	cosmossdk.io/api v0.2.6 // indirect
@@ -59,6 +61,7 @@ require (
 	github.com/cosmos/cosmos-db v0.0.0-20221226095112-f3c38ecb5e32 // indirect
 	github.com/cosmos/cosmos-proto v1.0.0-beta.1 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
+	github.com/cosmos/gogoproto v1.4.3 // indirect
 	github.com/cosmos/gorocksdb v1.2.0 // indirect
 	github.com/cosmos/iavl v0.19.5 // indirect
 	github.com/cosmos/ledger-cosmos-go v0.12.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -234,12 +234,16 @@ github.com/cosmos/cosmos-sdk v0.45.15-ics/go.mod h1:bScuNwWAP0TZJpUf+SHXRU3xGoUP
 github.com/cosmos/go-bip39 v0.0.0-20180819234021-555e2067c45d/go.mod h1:tSxLoYXyBmiFeKpvmq4dzayMdCjCnu8uqmCysIGBT2Y=
 github.com/cosmos/go-bip39 v1.0.0 h1:pcomnQdrdH22njcAatO0yWojsUnCO3y2tNoV1cb6hHY=
 github.com/cosmos/go-bip39 v1.0.0/go.mod h1:RNJv0H/pOIVgxw6KS7QeX2a0Uo0aKUlfhZ4xuwvCdJw=
+github.com/cosmos/gogoproto v1.4.3 h1:RP3yyVREh9snv/lsOvmsAPQt8f44LgL281X0IOIhhcI=
+github.com/cosmos/gogoproto v1.4.3/go.mod h1:0hLIG5TR7IvV1fme1HCFKjfzW9X2x0Mo+RooWXCnOWU=
 github.com/cosmos/gorocksdb v1.2.0 h1:d0l3jJG8M4hBouIZq0mDUHZ+zjOx044J3nGRskwTb4Y=
 github.com/cosmos/gorocksdb v1.2.0/go.mod h1:aaKvKItm514hKfNJpUJXnnOWeBnk2GL4+Qw9NHizILw=
 github.com/cosmos/iavl v0.19.5 h1:rGA3hOrgNxgRM5wYcSCxgQBap7fW82WZgY78V9po/iY=
 github.com/cosmos/iavl v0.19.5/go.mod h1:X9PKD3J0iFxdmgNLa7b2LYWdsGd90ToV5cAONApkEPw=
 github.com/cosmos/ibc-go/v4 v4.3.0 h1:yOzVsyZzsv4XPBux8gq+D0LhZn45yGWKjvT+6Vyo5no=
 github.com/cosmos/ibc-go/v4 v4.3.0/go.mod h1:CcLvIoi9NNtIbNsxs4KjBGjYhlwqtsmXy1AKARKiMzQ=
+github.com/cosmos/ics23/go v0.10.0 h1:iXqLLgp2Lp+EdpIuwXTYIQU+AiHj9mOC2X9ab++bZDM=
+github.com/cosmos/ics23/go v0.10.0/go.mod h1:ZfJSmng/TBNTBkFemHHHj5YY7VAU/MBU980F4VU1NG0=
 github.com/cosmos/ledger-cosmos-go v0.12.2 h1:/XYaBlE2BJxtvpkHiBm97gFGSGmYGKunKyF3nNqAXZA=
 github.com/cosmos/ledger-cosmos-go v0.12.2/go.mod h1:ZcqYgnfNJ6lAXe4HPtWgarNEY+B74i+2/8MhZw4ziiI=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=

--- a/third_party/proto/confio/proofs.proto
+++ b/third_party/proto/confio/proofs.proto
@@ -1,17 +1,18 @@
 syntax = "proto3";
 
-package ics23;
-option go_package = "github.com/confio/ics23/go";
+package cosmos.ics23.v1;
+
+option go_package = "github.com/cosmos/ics23/go;ics23";
 
 enum HashOp {
-    // NO_HASH is the default if no data passed. Note this is an illegal argument some places.
-    NO_HASH = 0;
-    SHA256 = 1;
-    SHA512 = 2;
-    KECCAK = 3;
-    RIPEMD160 = 4;
-    BITCOIN = 5;  // ripemd160(sha256(x))
-    SHA512_256 = 6;
+  // NO_HASH is the default if no data passed. Note this is an illegal argument some places.
+  NO_HASH    = 0;
+  SHA256     = 1;
+  SHA512     = 2;
+  KECCAK     = 3;
+  RIPEMD160  = 4;
+  BITCOIN    = 5; // ripemd160(sha256(x))
+  SHA512_256 = 6;
 }
 
 /**
@@ -21,24 +22,24 @@ algorithm, the length will be prepended to the key and value bytes.
 (Each one with it's own encoded length)
 */
 enum LengthOp {
-    // NO_PREFIX don't include any length info
-    NO_PREFIX = 0; 
-    // VAR_PROTO uses protobuf (and go-amino) varint encoding of the length
-    VAR_PROTO = 1; 
-    // VAR_RLP uses rlp int encoding of the length
-    VAR_RLP = 2; 
-    // FIXED32_BIG uses big-endian encoding of the length as a 32 bit integer
-    FIXED32_BIG = 3; 
-    // FIXED32_LITTLE uses little-endian encoding of the length as a 32 bit integer
-    FIXED32_LITTLE = 4; 
-    // FIXED64_BIG uses big-endian encoding of the length as a 64 bit integer
-    FIXED64_BIG = 5;
-    // FIXED64_LITTLE uses little-endian encoding of the length as a 64 bit integer
-    FIXED64_LITTLE = 6;
-    // REQUIRE_32_BYTES is like NONE, but will fail if the input is not exactly 32 bytes (sha256 output)
-    REQUIRE_32_BYTES = 7;
-    // REQUIRE_64_BYTES is like NONE, but will fail if the input is not exactly 64 bytes (sha512 output)
-    REQUIRE_64_BYTES = 8;
+  // NO_PREFIX don't include any length info
+  NO_PREFIX = 0;
+  // VAR_PROTO uses protobuf (and go-amino) varint encoding of the length
+  VAR_PROTO = 1;
+  // VAR_RLP uses rlp int encoding of the length
+  VAR_RLP = 2;
+  // FIXED32_BIG uses big-endian encoding of the length as a 32 bit integer
+  FIXED32_BIG = 3;
+  // FIXED32_LITTLE uses little-endian encoding of the length as a 32 bit integer
+  FIXED32_LITTLE = 4;
+  // FIXED64_BIG uses big-endian encoding of the length as a 64 bit integer
+  FIXED64_BIG = 5;
+  // FIXED64_LITTLE uses little-endian encoding of the length as a 64 bit integer
+  FIXED64_LITTLE = 6;
+  // REQUIRE_32_BYTES is like NONE, but will fail if the input is not exactly 32 bytes (sha256 output)
+  REQUIRE_32_BYTES = 7;
+  // REQUIRE_64_BYTES is like NONE, but will fail if the input is not exactly 64 bytes (sha512 output)
+  REQUIRE_64_BYTES = 8;
 }
 
 /**
@@ -63,10 +64,10 @@ in the ProofSpec is valuable to prevent this mutability. And why all trees shoul
 length-prefix the data before hashing it.
 */
 message ExistenceProof {
-    bytes key = 1;
-    bytes value = 2;
-    LeafOp leaf = 3;
-    repeated InnerOp path = 4;    
+  bytes            key   = 1;
+  bytes            value = 2;
+  LeafOp           leaf  = 3;
+  repeated InnerOp path  = 4;
 }
 
 /*
@@ -75,21 +76,21 @@ one right of the desired key. If both proofs are valid AND they are neighbors,
 then there is no valid proof for the given key.
 */
 message NonExistenceProof {
-    bytes key = 1; // TODO: remove this as unnecessary??? we prove a range
-    ExistenceProof left = 2;
-    ExistenceProof right = 3;
+  bytes          key   = 1; // TODO: remove this as unnecessary??? we prove a range
+  ExistenceProof left  = 2;
+  ExistenceProof right = 3;
 }
 
 /*
 CommitmentProof is either an ExistenceProof or a NonExistenceProof, or a Batch of such messages
 */
 message CommitmentProof {
-    oneof proof {
-        ExistenceProof exist = 1;
-        NonExistenceProof nonexist = 2;
-        BatchProof batch = 3;
-        CompressedBatchProof compressed = 4;
-    }
+  oneof proof {
+    ExistenceProof       exist      = 1;
+    NonExistenceProof    nonexist   = 2;
+    BatchProof           batch      = 3;
+    CompressedBatchProof compressed = 4;
+  }
 }
 
 /**
@@ -109,13 +110,13 @@ Then combine the bytes, and hash it
   output = hash(prefix || length(hkey) || hkey || length(hvalue) || hvalue)
 */
 message LeafOp {
-    HashOp hash = 1;
-    HashOp prehash_key = 2;
-    HashOp prehash_value = 3;
-    LengthOp length = 4;
-    // prefix is a fixed bytes that may optionally be included at the beginning to differentiate
-    // a leaf node from an inner node.
-    bytes prefix = 5;
+  HashOp   hash          = 1;
+  HashOp   prehash_key   = 2;
+  HashOp   prehash_value = 3;
+  LengthOp length        = 4;
+  // prefix is a fixed bytes that may optionally be included at the beginning to differentiate
+  // a leaf node from an inner node.
+  bytes prefix = 5;
 }
 
 /**
@@ -136,11 +137,10 @@ some value to differentiate from leaf nodes, should be included in prefix and su
 If either of prefix or suffix is empty, we just treat it as an empty string
 */
 message InnerOp {
-    HashOp hash = 1;
-    bytes prefix = 2;
-    bytes suffix = 3;
+  HashOp hash   = 1;
+  bytes  prefix = 2;
+  bytes  suffix = 3;
 }
-
 
 /**
 ProofSpec defines what the expected parameters are for a given proof type.
@@ -156,13 +156,17 @@ tree format server uses. But not in code, rather a configuration object.
 */
 message ProofSpec {
   // any field in the ExistenceProof must be the same as in this spec.
-  // except Prefix, which is just the first bytes of prefix (spec can be longer) 
-  LeafOp leaf_spec = 1;
+  // except Prefix, which is just the first bytes of prefix (spec can be longer)
+  LeafOp    leaf_spec  = 1;
   InnerSpec inner_spec = 2;
   // max_depth (if > 0) is the maximum number of InnerOps allowed (mainly for fixed-depth tries)
   int32 max_depth = 3;
   // min_depth (if > 0) is the minimum number of InnerOps allowed (mainly for fixed-depth tries)
   int32 min_depth = 4;
+  // prehash_key_before_comparison is a flag that indicates whether to use the
+  // prehash_key specified by LeafOp to compare lexical ordering of keys for
+  // non-existence proofs.
+  bool prehash_key_before_comparison = 5;
 }
 
 /*
@@ -176,17 +180,17 @@ This enables:
   isLeftNeighbor(spec: InnerSpec, left: InnerOp, right: InnerOp)
 */
 message InnerSpec {
-    // Child order is the ordering of the children node, must count from 0
-    // iavl tree is [0, 1] (left then right)
-    // merk is [0, 2, 1] (left, right, here)
-    repeated int32 child_order = 1;
-    int32 child_size = 2;
-    int32 min_prefix_length = 3;
-    int32 max_prefix_length = 4;
-    // empty child is the prehash image that is used when one child is nil (eg. 20 bytes of 0)
-    bytes empty_child = 5;
-    // hash is the algorithm that must be used for each InnerOp
-    HashOp hash = 6;
+  // Child order is the ordering of the children node, must count from 0
+  // iavl tree is [0, 1] (left then right)
+  // merk is [0, 2, 1] (left, right, here)
+  repeated int32 child_order       = 1;
+  int32          child_size        = 2;
+  int32          min_prefix_length = 3;
+  int32          max_prefix_length = 4;
+  // empty child is the prehash image that is used when one child is nil (eg. 20 bytes of 0)
+  bytes empty_child = 5;
+  // hash is the algorithm that must be used for each InnerOp
+  HashOp hash = 6;
 }
 
 /*
@@ -199,37 +203,36 @@ message BatchProof {
 // Use BatchEntry not CommitmentProof, to avoid recursion
 message BatchEntry {
   oneof proof {
-    ExistenceProof exist = 1;
+    ExistenceProof    exist    = 1;
     NonExistenceProof nonexist = 2;
   }
 }
 
-
 /****** all items here are compressed forms *******/
 
 message CompressedBatchProof {
-  repeated CompressedBatchEntry entries = 1;
-  repeated InnerOp lookup_inners = 2;
+  repeated CompressedBatchEntry entries       = 1;
+  repeated InnerOp              lookup_inners = 2;
 }
 
 // Use BatchEntry not CommitmentProof, to avoid recursion
 message CompressedBatchEntry {
   oneof proof {
-    CompressedExistenceProof exist = 1;
+    CompressedExistenceProof    exist    = 1;
     CompressedNonExistenceProof nonexist = 2;
   }
 }
 
 message CompressedExistenceProof {
-  bytes key = 1;
-  bytes value = 2;
-  LeafOp leaf = 3;
+  bytes  key   = 1;
+  bytes  value = 2;
+  LeafOp leaf  = 3;
   // these are indexes into the lookup_inners table in CompressedBatchProof
-  repeated int32 path = 4;    
+  repeated int32 path = 4;
 }
 
 message CompressedNonExistenceProof {
-  bytes key = 1; // TODO: remove this as unnecessary??? we prove a range
-  CompressedExistenceProof left = 2;
+  bytes                    key   = 1; // TODO: remove this as unnecessary??? we prove a range
+  CompressedExistenceProof left  = 2;
   CompressedExistenceProof right = 3;
 }

--- a/x/ccv/provider/keeper/proposal_test.go
+++ b/x/ccv/provider/keeper/proposal_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 	"time"
 
-	_go "github.com/confio/ics23/go"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	evidencetypes "github.com/cosmos/cosmos-sdk/x/evidence/types"
 	clienttypes "github.com/cosmos/ibc-go/v4/modules/core/02-client/types"
 	ibctmtypes "github.com/cosmos/ibc-go/v4/modules/light-clients/07-tendermint/types"
+	_go "github.com/cosmos/ics23/go"
 	"github.com/golang/mock/gomock"
 	abci "github.com/tendermint/tendermint/abci/types"
 


### PR DESCRIPTION
# Description

This is an in-progress pr that brings ics23 v0.10.0 to interchain 
security.  I suspect that it is not relevant until:

* https://github.com/cosmos/ibc-go/pull/3471

Is merged.  For those working on #817, I think that we should be able to 
smoothly replace this without difficulty. 

## Linked issues

Works toward the 47 upgrade but targets the 45 version of ics

## Type of change

If you've checked more than one of the first three boxes, consider splitting this PR into multiple PRs!

- [ ] `Feature`: Changes and/or adds code behavior, irrelevant to bug fixes
- [ ] `Fix`: Changes and/or adds code behavior, specifically to fix a bug
- [ ] `Refactor`: Changes existing code style, naming, structure, etc.
- [ ] `Testing`: Adds testing
- [ ] `Docs`: Adds documentation

## Regression tests

If `Refactor`, describe the new or existing tests that verify no behavior was changed or added where refactors were introduced.

## New behavior tests

If `Feature` or `Fix`, describe the new or existing tests that verify the new behavior is correct and expected.

## Versioning Implications

- [ ] This PR will affect [semantic versioning as defined for ICS](../CONTRIBUTING.md#semantic-versioning)

If the above box is checked, which version should be bumped?

- [ ] `MAJOR`: Consensus breaking changes to both the provider and consumers(s), including updates/breaking changes to IBC communication between provider and consumer(s)
- [ ] `MINOR`: Consensus breaking changes which affect either only the provider or only the consumer(s)
- [ ] `PATCH`: Non consensus breaking changes

## Targeting

Please select one of the following:

- [ ] This PR is only relevant to main
- [ ] This PR is relevant to main, and should also be back-ported to ____ (ex: v1.0.0 and v1.1.0)
- [ ] This PR is only relevant to ____ (ex: v1.0.0, v1.1.0, and v1.2.0)
