### PR TITLE
chore: proto check that works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,17 +122,17 @@ proto-gen:
 	@$(protoImage) sh ./scripts/protocgen.sh;
 
 proto-check:
-	@if git diff --quiet --exit-code -- proto; then \
-		echo "No uncommitted changes in proto."; \
+	@if git diff --quiet --exit-code main...HEAD -- proto; then \
+		echo "No changes found in /proto directory between the currently checked out branch and main."; \
 	else \
-		echo "Uncommitted changes found in proto."; \
-		modified_protos=$$(git diff --name-only proto); \
+		echo "Changes found in /proto directory between the currently checked out branch and main."; \
+		modified_protos=$$(git diff --name-only main...HEAD proto); \
 		modified_pb_files= ; \
         for proto_file in $${modified_protos}; do \
             proto_name=$$(basename "$${proto_file}" .proto); \
             pb_files=$$(find x/ccv -name "$${proto_name}.pb.go"); \
             for pb_file in $${pb_files}; do \
-                if git diff --quiet --exit-code -- "$${pb_file}"; then \
+                if git diff --quiet --exit-code main...HEAD -- "$${pb_file}"; then \
                     echo "Missing uncommitted changes in $${pb_file}"; \
 					exit 1; \
                 else \

--- a/Makefile
+++ b/Makefile
@@ -122,19 +122,27 @@ proto-gen:
 	@$(protoImage) sh ./scripts/protocgen.sh;
 
 proto-check:
-	@if git diff --quiet; then \
-		echo "No files were modified before running 'make proto-gen'."; \
+	@if git diff --quiet --exit-code -- proto; then \
+		echo "No uncommitted changes in proto."; \
 	else \
-		echo "Error: Uncommitted changes exist before running 'make proto-gen'. Please commit or stash your changes."; \
-		exit 1; \
-	fi
-	@$(MAKE) proto-gen
-	@if git diff --quiet; then \
-		echo "No files were modified after running 'make proto-gen'. Pass!"; \
-	else \
-		echo "Error: Files were modified after running 'make proto-gen'. Please commit changes to .pb files"; \
-		exit 1; \
-	fi
+		echo "Uncommitted changes found in proto."; \
+		modified_protos=$$(git diff --name-only proto); \
+		modified_pb_files= ; \
+        for proto_file in $${modified_protos}; do \
+            proto_name=$$(basename "$${proto_file}" .proto); \
+            pb_files=$$(find x/ccv -name "$${proto_name}.pb.go"); \
+            for pb_file in $${pb_files}; do \
+                if git diff --quiet --exit-code -- "$${pb_file}"; then \
+                    echo "Missing uncommitted changes in $${pb_file}"; \
+					exit 1; \
+                else \
+                    modified_pb_files+="$${pb_file} "; \
+                fi \
+            done \
+        done; \
+		echo "Pass! Correctly modified pb files: "; \
+		echo $${modified_pb_files}; \
+    fi
 
 proto-format:
 	@echo "Formatting Protobuf files"

--- a/Makefile
+++ b/Makefile
@@ -123,9 +123,9 @@ proto-gen:
 
 proto-check:
 	@if git diff --quiet --exit-code main...HEAD -- proto; then \
-		echo "No changes found in /proto directory between the currently checked out branch and main."; \
+		echo "Pass! No committed changes found in /proto directory between the currently checked out branch and main."; \
 	else \
-		echo "Changes found in /proto directory between the currently checked out branch and main."; \
+		echo "Committed changes found in /proto directory between the currently checked out branch and main."; \
 		modified_protos=$$(git diff --name-only main...HEAD proto); \
 		modified_pb_files= ; \
         for proto_file in $${modified_protos}; do \
@@ -133,7 +133,7 @@ proto-check:
             pb_files=$$(find x/ccv -name "$${proto_name}.pb.go"); \
             for pb_file in $${pb_files}; do \
                 if git diff --quiet --exit-code main...HEAD -- "$${pb_file}"; then \
-                    echo "Missing uncommitted changes in $${pb_file}"; \
+                    echo "Missing committed changes in $${pb_file}"; \
 					exit 1; \
                 else \
                     modified_pb_files+="$${pb_file} "; \


### PR DESCRIPTION
## Description

Builds on #1060 to enable the `make proto-check` test to actually work with the new way of generating protos. This approach is slightly worse, but it works and it's not worth spending anymore time on fixing `make proto-check`

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
