### PR TITLE
docs: remove an obsolete comment before setting the order of EndBlockers

### DIFF
--- a/app/provider/app.go
+++ b/app/provider/app.go
@@ -530,12 +530,7 @@ func New(
 		vestingtypes.ModuleName,
 		providertypes.ModuleName,
 	)
-	// Interchain Security requirements
-	// 	- provider.EndBlock gets validator updates from the staking module;
-	// 	thus, staking.EndBlock must be executed before provider.EndBlock;
-	//	- creating a new consumer chain requires the following order,
-	//	CreateChildClient(), staking.EndBlock, provider.EndBlock;
-	//	thus, gov.EndBlock must be executed before staking.EndBlock
+
 	app.MM.SetOrderEndBlockers(
 		crisistypes.ModuleName,
 		govtypes.ModuleName,


### PR DESCRIPTION
This is work in progress. Please, do **not** review yet.

## Description

Closes: [#688](https://github.com/cosmos/interchain-security/issues/688)

Remove obsolete comment before setting the `EndBlockers` in [app.go](https://github.com/cosmos/interchain-security/blob/463ec20c87423897009bd78c2dbf96d28bd8f150/app/provider/app.go#L555-L555).

---

### Author Checklist

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
