### PR TITLE
Implement a cli command showing the consumer rewards pool address

### DIFF
--- a/x/ccv/provider/keeper/distribution.go
+++ b/x/ccv/provider/keeper/distribution.go
@@ -30,6 +30,7 @@ func (k Keeper) RegisterConsumerRewardDenom(ctx sdk.Context, denom string, sende
 	return nil
 }
 
+// GetConsumerRewardDenomRegistrationFee returns the consumer reward pool account address
 func (k Keeper) GetConsumerRewardsPoolAddressStr(ctx sdk.Context) string {
 	return k.accountKeeper.GetModuleAccount(
 		ctx, types.ConsumerRewardsPool).GetAddress().String()


### PR DESCRIPTION
This PR will implement a cli command that James Parillo from Figment was asking about.  It is surely not done. It should be backportable to 
v1.
