### PR TITLE
tests: add tests to show that packets are equivalent in proto but not in JSON

### DIFF
--- a/x/ccv/types/ccv_marshalling_test.go
+++ b/x/ccv/types/ccv_marshalling_test.go
@@ -1,0 +1,61 @@
+package types
+
+import (
+	"testing"
+
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/libs/bytes"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsumerPacketDataMarshalling(t *testing.T) {
+	// create and marshal a consumer packet as proto bytes -> uses "new" Infraction enum
+	newSlashFormat := NewSlashPacketData(
+		abci.Validator{Address: bytes.HexBytes{}, Power: int64(1)},
+		uint64(1),
+		stakingtypes.Infraction_INFRACTION_DOWNTIME,
+	)
+	newPacketFormat := ConsumerPacketData{
+		Type: SlashPacket,
+		Data: &ConsumerPacketData_SlashPacketData{
+			SlashPacketData: newSlashFormat, // -> uses "new" Infraction enum
+		},
+	}
+	newPacketFormatBytes, err := newPacketFormat.Marshal()
+	if err != nil {
+		require.NoError(t, err, "could not marshal v47bytes")
+		t.FailNow()
+	}
+	require.NotZero(t, newPacketFormatBytes, "newPacketFormatBytes should not be zero")
+
+	var oldPacketFormat ConsumerPacketDataV1
+	err = oldPacketFormat.Unmarshal(newPacketFormatBytes)
+	if err != nil {
+		require.NoError(t, err, "could not unmarshal newPacketFormatBytes")
+		t.FailNow()
+	}
+	require.NotZero(t, oldPacketFormat, "oldPacketFormat should not be zero")
+
+	oldPacketFormatBytes, err := oldPacketFormat.Marshal()
+	if err != nil {
+		require.NoError(t, err, "could not marshal oldPacketFormat")
+		t.FailNow()
+	}
+	require.NotZero(t, oldPacketFormatBytes, "oldPacketFormatBytes should not be zero")
+
+	// allow visually confirming that these are the same bytes
+	t.Log("oldPacketFormatBytes", oldPacketFormatBytes)
+	t.Log("newPacketFormatBytes", newPacketFormatBytes)
+
+	// check that the old packet format is the same as the new packet format
+	require.Equal(t, newPacketFormatBytes, oldPacketFormatBytes, "oldPacketFormatBytes should be the same as newPacketFormatBytes")
+
+	// compare JSON strings
+	newPacketFormatJSON := ModuleCdc.MustMarshalJSON(&newPacketFormat)
+	oldPacketFormatJSON := ModuleCdc.MustMarshalJSON(&oldPacketFormat)
+	t.Log("oldPacketFormatJSON", string(newPacketFormatJSON))
+	t.Log("newPacketFormatJSON", string(oldPacketFormatJSON))
+
+	require.NotEqual(t, newPacketFormatJSON, oldPacketFormatJSON, "oldPacketFormatJSON and newPacketFormatJSON are the same")
+}

--- a/x/ccv/types/ccv_marshalling_test.go
+++ b/x/ccv/types/ccv_marshalling_test.go
@@ -45,17 +45,17 @@ func TestConsumerPacketDataMarshalling(t *testing.T) {
 	require.NotZero(t, oldPacketFormatBytes, "oldPacketFormatBytes should not be zero")
 
 	// allow visually confirming that these are the same bytes
-	t.Log("oldPacketFormatBytes", oldPacketFormatBytes)
-	t.Log("newPacketFormatBytes", newPacketFormatBytes)
-
+	t.Log("oldPacketFormatBytes", oldPacketFormatBytes) // [8 1 18 8 10 2 24 1 16 1 24 2] -> same byte array
+	t.Log("newPacketFormatBytes", newPacketFormatBytes) // [8 1 18 8 10 2 24 1 16 1 24 2] -> same byte array
 	// check that the old packet format is the same as the new packet format
 	require.Equal(t, newPacketFormatBytes, oldPacketFormatBytes, "oldPacketFormatBytes should be the same as newPacketFormatBytes")
 
 	// compare JSON strings
 	newPacketFormatJSON := ModuleCdc.MustMarshalJSON(&newPacketFormat)
 	oldPacketFormatJSON := ModuleCdc.MustMarshalJSON(&oldPacketFormat)
-	t.Log("oldPacketFormatJSON", string(newPacketFormatJSON))
-	t.Log("newPacketFormatJSON", string(oldPacketFormatJSON))
+
+	t.Log("oldPacketFormatJSON", string(newPacketFormatJSON)) // {"type":"CONSUMER_PACKET_TYPE_SLASH","slashPacketData":{"validator":{"address":"","power":"1"},"valset_update_id":"1","infraction":"INFRACTION_DOWNTIME"}} -> different byte array
+	t.Log("newPacketFormatJSON", string(oldPacketFormatJSON)) // {"type":"CONSUMER_PACKET_TYPE_SLASH","slashPacketData":{"validator":{"address":null,"power":"1"},"valset_update_id":"1","infraction":"INFRACTION_TYPE_DOWNTIME"}} -> different byte array
 
 	require.NotEqual(t, newPacketFormatJSON, oldPacketFormatJSON, "oldPacketFormatJSON and newPacketFormatJSON are the same")
 }


### PR DESCRIPTION
This Draft PR creates a test that confirms that `Infraction` and `InfractionType` are equivalent when stored as proto bytes, but not when marshalled to JSON.

Marshalling to JSON happens only when sending data over the wire as an IBC packet.

`InfractionType` enum definition (aka "old"):
```golang
enum InfractionType {
  INFRACTION_TYPE_UNSPECIFIED = 0;
  INFRACTION_TYPE_DOUBLE_SIGN = 1;
  INFRACTION_TYPE_DOWNTIME = 2;
}
```

`Infraction` enum from cosmos/x/staking (aka "new"):
```golang
// Infraction indicates the infraction a validator commited.
enum Infraction {
  // UNSPECIFIED defines an empty infraction.
  INFRACTION_UNSPECIFIED = 0;
  // DOUBLE_SIGN defines a validator that double-signs a block.
  INFRACTION_DOUBLE_SIGN = 1;
  // DOWNTIME defines a validator that missed signing too many blocks.
  INFRACTION_DOWNTIME = 2;
}
```

Please go the the `Preview` tab and select the appropriate sub-template:

* [Production code](?expand=1&template=production.md) - for types `fix`, `feat`, and `refactor`.
* [Docs](?expand=1&template=docs.md) - for documentation changes.
* [Others](?expand=1&template=others.md) - for changes that do not affect production code.