### PR TITLE
other: reenable proper make proto-check

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,3 @@ Dockerfile
 scripts/
 .vscode/
 .github/
-proto/

--- a/Makefile
+++ b/Makefile
@@ -122,27 +122,19 @@ proto-gen:
 	@$(protoImage) sh ./scripts/protocgen.sh;
 
 proto-check:
-	@if git diff --quiet --exit-code main...HEAD -- proto; then \
-		echo "Pass! No committed changes found in /proto directory between the currently checked out branch and main."; \
+	@if git diff --quiet; then \
+		echo "No files were modified before running 'make proto-gen'."; \
 	else \
-		echo "Committed changes found in /proto directory between the currently checked out branch and main."; \
-		modified_protos=$$(git diff --name-only main...HEAD proto); \
-		modified_pb_files= ; \
-        for proto_file in $${modified_protos}; do \
-            proto_name=$$(basename "$${proto_file}" .proto); \
-            pb_files=$$(find x/ccv -name "$${proto_name}.pb.go"); \
-            for pb_file in $${pb_files}; do \
-                if git diff --quiet --exit-code main...HEAD -- "$${pb_file}"; then \
-                    echo "Missing committed changes in $${pb_file}"; \
-					exit 1; \
-                else \
-                    modified_pb_files+="$${pb_file} "; \
-                fi \
-            done \
-        done; \
-		echo "Pass! Correctly modified pb files: "; \
-		echo $${modified_pb_files}; \
-    fi
+		echo "Error: Uncommitted changes exist before running 'make proto-gen'. Please commit or stash your changes."; \
+		exit 1; \
+	fi
+	@$(MAKE) proto-gen
+	@if git diff --quiet; then \
+		echo "No files were modified after running 'make proto-gen'. Pass!"; \
+	else \
+		echo "Error: Files were modified after running 'make proto-gen'. Please commit changes to .pb files"; \
+		exit 1; \
+	fi
 
 proto-format:
 	@echo "Formatting Protobuf files"


### PR DESCRIPTION
## Description

@MSalopek pointed out that a recent addition to the `.dockerignore` file was the reason that the old "proper" way of running `make proto-gen` was not working. This PR simply:
- reverts the changes to `Makefile` in https://github.com/cosmos/interchain-security/pull/1060
- Removes the culprit line from `.dockerignore`

Nice find Matija!

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
