### PR TITLE
fix: update broken .dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,7 @@ updates:
     labels:
       - dependencies
   
-    - package-ecosystem: gomod
+  - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: daily


### PR DESCRIPTION
## Description

Closes: NA

`.dependabot.yml` is invalid and cannot be parsed after merging https://github.com/cosmos/interchain-security/pull/1140

This fixes it and makes the CI pipeline pass.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
