### PR TITLE
test: Fix failing e2e test

### DIFF
--- a/tests/e2e/actions.go
+++ b/tests/e2e/actions.go
@@ -1813,7 +1813,8 @@ type assignConsumerPubKeyAction struct {
 	// reconfigureNode will change keys the node uses and restart
 	reconfigureNode bool
 	// executing the action should raise an error
-	expectError bool
+	expectError   bool
+	expectedError string
 }
 
 func (tr TestRun) assignConsumerPubKey(action assignConsumerPubKeyAction, verbose bool) {
@@ -1848,8 +1849,8 @@ func (tr TestRun) assignConsumerPubKey(action assignConsumerPubKeyAction, verbos
 	}
 
 	if action.expectError {
-		if err == nil {
-			log.Fatalf("expected error not raised: %s", string(bz))
+		if err == nil || !strings.Contains(string(bz), action.expectedError) {
+			log.Fatalf("expected error not raised: expected: '%s', got '%s'", action.expectedError, (bz))
 		}
 
 		if verbose {

--- a/tests/e2e/actions.go
+++ b/tests/e2e/actions.go
@@ -1819,8 +1819,9 @@ type assignConsumerPubKeyAction struct {
 func (tr TestRun) assignConsumerPubKey(action assignConsumerPubKeyAction, verbose bool) {
 	valCfg := tr.validatorConfigs[action.validator]
 
+	// Note: to get error response reported back from this command '--gas auto' needs to be set.
 	assignKey := fmt.Sprintf(
-		`%s tx provider assign-consensus-key %s '%s' --from validator%s --chain-id %s --home %s --node %s --gas 90000 --keyring-backend test -y -o json`,
+		`%s tx provider assign-consensus-key %s '%s' --from validator%s --chain-id %s --home %s --node %s --gas auto --keyring-backend test -y -o json`,
 		tr.chainConfigs[chainID("provi")].binaryName,
 		string(tr.chainConfigs[action.chain].chainId),
 		action.consumerPubkey,
@@ -1847,6 +1848,10 @@ func (tr TestRun) assignConsumerPubKey(action assignConsumerPubKeyAction, verbos
 	}
 
 	if action.expectError {
+		if err == nil {
+			log.Fatalf("expected error not raised: %s", string(bz))
+		}
+
 		if verbose {
 			fmt.Printf("got expected error during key assignment | err: %s \n", err.Error())
 		}

--- a/tests/e2e/actions.go
+++ b/tests/e2e/actions.go
@@ -1853,7 +1853,7 @@ func (tr TestRun) assignConsumerPubKey(action assignConsumerPubKeyAction, verbos
 		}
 
 		if verbose {
-			fmt.Printf("got expected error during key assignment | err: %s | output: %s \n", err, string(bz)) 
+			fmt.Printf("got expected error during key assignment | err: %s | output: %s \n", err, string(bz))
 		}
 	}
 

--- a/tests/e2e/actions.go
+++ b/tests/e2e/actions.go
@@ -1853,7 +1853,7 @@ func (tr TestRun) assignConsumerPubKey(action assignConsumerPubKeyAction, verbos
 		}
 
 		if verbose {
-			fmt.Printf("got expected error during key assignment | err: %s \n", err.Error())
+			fmt.Printf("got expected error during key assignment | err: %s | output: %s \n", err, string(bz)) 
 		}
 	}
 

--- a/tests/e2e/steps_start_chains.go
+++ b/tests/e2e/steps_start_chains.go
@@ -88,6 +88,7 @@ func stepsStartConsumerChain(consumerName string, proposalIndex, chainIndex uint
 				consumerPubkey:  `{"@type":"/cosmos.crypto.ed25519.PubKey","key":"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is="}`,
 				reconfigureNode: false,
 				expectError:     true,
+				expectedError:   "a validator has assigned the consumer key already: consumer key is already in use by a validator",
 			},
 			state: State{},
 		},
@@ -100,6 +101,7 @@ func stepsStartConsumerChain(consumerName string, proposalIndex, chainIndex uint
 				consumerPubkey:  `{"@type":"/cosmos.crypto.ed25519.PubKey","key":"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is="}`,
 				reconfigureNode: false,
 				expectError:     true,
+				expectedError:   "a validator has assigned the consumer key already: consumer key is already in use by a validator",
 			},
 			state: State{
 				chainID(consumerName): ChainState{


### PR DESCRIPTION
## Description

Closes: #1167 

This PR fixes an error in the e2e test.
When running e2e tests
- tests did not check expected error condition in assignConsumerPubKey
- transaction command to assign consensus key did not return error until '--gas auto' option was provided

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
