### PR TITLE
chore: Add integration for equivocation with CometMock

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ test-e2e-short:
 # run only happy path E2E tests with cometmock
 # this set of traces does not test equivocation but it does check downtime
 test-e2e-short-cometmock:
-	go run ./tests/e2e/... --short-happy-path --use-cometmock --use-gorelayer
+	go run ./tests/e2e/... --cometmock-happy-path --use-cometmock --use-gorelayer
 
 # run full E2E tests in sequence (including multiconsumer)
 test-e2e-multi-consumer:

--- a/tests/e2e/main.go
+++ b/tests/e2e/main.go
@@ -16,12 +16,11 @@ import (
 )
 
 var (
-	verbose            = flag.Bool("verbose", false, "turn verbose logging on/off")
-	happyPathOnly      = flag.Bool("happy-path-only", false, "run happy path tests only")
-	shortHappyPathOnly = flag.Bool("short-happy-path", false, `run abridged happy path tests only.
+	verbose                      = flag.Bool("verbose", false, "turn verbose logging on/off")
+	happyPathOnly                = flag.Bool("happy-path-only", false, "run happy path tests only")
+	cometmockCompatibleHappyPath = flag.Bool("cometmock-happy-path", false, `run cometmock compatible happy path tests only.
 This is like the happy path, but skips steps
 that involve starting or stopping nodes for the same chain outside of the chain setup or teardown.
-In particular, this skips steps related to downtime and double signing.
 This is suited for CometMock+Gorelayer testing`)
 	includeMultiConsumer = flag.Bool("include-multi-consumer", false, "include multiconsumer tests in run")
 	parallel             = flag.Bool("parallel", false, "run all tests in parallel")
@@ -42,10 +41,10 @@ var (
 func main() {
 	flag.Parse()
 
-	if shortHappyPathOnly != nil && *shortHappyPathOnly {
+	if cometmockCompatibleHappyPath != nil && *cometmockCompatibleHappyPath {
 		fmt.Println("=============== running short happy path only ===============")
 		tr := DefaultTestRun()
-		tr.Run(shortHappyPathSteps, *localSdkPath, *useGaia, *gaiaTag)
+		tr.Run(cometmockCompatibleHappyPathSteps, *localSdkPath, *useGaia, *gaiaTag)
 		return
 	}
 

--- a/tests/e2e/steps.go
+++ b/tests/e2e/steps.go
@@ -31,12 +31,14 @@ var happyPathSteps = concatSteps(
 	stepsStopChain("consu", 4),                     // stop chain
 )
 
-var shortHappyPathSteps = concatSteps(
+var cometmockCompatibleHappyPathSteps = concatSteps(
 	stepsStartChains([]string{"consu"}, false),
 	stepsDelegate("consu"),
 	stepsUnbond("consu"),
 	stepsRedelegateShort("consu"),
 	stepsDowntime("consu"),
+	stepsRejectEquivocationProposal("consu", 2),   // prop to tombstone bob is rejected
+	stepsDoubleSignOnProviderAndConsumer("consu"), // carol double signs on provider, bob double signs on consumer
 	stepsStartRelayer(),
 	stepsConsumerRemovalPropNotPassing("consu", 2), // submit removal prop but vote no on it - chain should stay
 	stepsStopChain("consu", 3),                     // stop chain


### PR DESCRIPTION
## Description

Closes: #[1190](https://github.com/cosmos/interchain-security/issues/1190)

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

* Renames the short-happy-path to cometmock-happy-path and adds equivocation steps to it:
  * It is starting to not be significantly shorter as cometmock supports more operations
  * The previous name was confusing as became clear in some discussions
* Add a separate case for CometMock in equivocation
  * Refactor commonly used functionality that is needed for downtime and equivocation

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
