### PR TITLE
supress gosec false positives

### DIFF
--- a/x/ccv/consumer/types/keys.go
+++ b/x/ccv/consumer/types/keys.go
@@ -26,6 +26,7 @@ const (
 	ConsumerRedistributeName = "cons_redistribute"
 
 	// ConsumerToSendToProviderName is a "buffer" address for outgoing fees to be transferred to the provider chain
+	//#nosec G101 -- (false positive) this is not a hardcoded credential
 	ConsumerToSendToProviderName = "cons_to_send_to_provider"
 )
 

--- a/x/ccv/types/events.go
+++ b/x/ccv/types/events.go
@@ -35,10 +35,11 @@ const (
 	AttributeConsumerConsensusPubKey  = "consumer_consensus_pub_key"
 
 	AttributeDistributionCurrentHeight = "current_distribution_height"
-	AttributeDistributionNextHeight    = "next_distribution_height"
-	AttributeDistributionFraction      = "distribution_fraction"
-	AttributeDistributionTotal         = "total"
-	AttributeDistributionToProvider    = "provider_amount"
+	//#nosec G101 -- (false positive) this is not a hardcoded credential
+	AttributeDistributionNextHeight = "next_distribution_height"
+	AttributeDistributionFraction   = "distribution_fraction"
+	AttributeDistributionTotal      = "total"
+	AttributeDistributionToProvider = "provider_amount"
 
 	AttributeConsumerRewardDenom     = "consumer_reward_denom"
 	AttributeConsumerRewardDepositor = "consumer_reward_depositor"


### PR DESCRIPTION
## Description

_gosec security scanner_ started [failing](https://github.com/cosmos/interchain-security/actions/runs/5924842585/job/16063142935?pr=1169) recently with:
```
[x/ccv/types/events.go:38] - G101 (CWE-798): Potential hardcoded credentials (Confidence: LOW, Severity: HIGH)
    37: 	AttributeDistributionCurrentHeight = "current_distribution_height"
  > 38: 	AttributeDistributionNextHeight    = "next_distribution_height"

[x/ccv/consumer/types/keys.go:29] - G101 (CWE-798): Potential hardcoded credentials (Confidence: LOW, Severity: HIGH)
    28: 	// ConsumerToSendToProviderName is a "buffer" address for outgoing fees to be transferred to the provider chain
  > 29: 	ConsumerToSendToProviderName = "cons_to_send_to_provider"
```

Both are false positives because neither `next_distribution_height` or `cons_to_send_to_provider` are hardcoded credentials. This PR just adds [annotations](https://github.com/securego/gosec#annotating-code) to suppress those 2 specific false positives.

Note, that we did not create an issue for this PR because this PR is rather minor. 