### PR TITLE
Add waitBlocks for *both* chains on relayPackets

### DIFF
--- a/tests/e2e/actions.go
+++ b/tests/e2e/actions.go
@@ -1309,6 +1309,7 @@ func (tr TestRun) relayPacketsGorelayer(
 	}
 
 	tr.waitBlocks(action.chainA, 1, 30*time.Second)
+	tr.waitBlocks(action.chainB, 1, 30*time.Second)
 }
 
 func (tr TestRun) relayPacketsHermes(
@@ -1332,6 +1333,7 @@ func (tr TestRun) relayPacketsHermes(
 	}
 
 	tr.waitBlocks(action.chainA, 1, 30*time.Second)
+	tr.waitBlocks(action.chainB, 1, 30*time.Second)
 }
 
 type relayRewardPacketsToProviderAction struct {


### PR DESCRIPTION
## Description

Closes: #1235 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Adds waitBlocks on both chains in relayPackets - either chain might be source or destination, and it seems inconsistent to wait only for one of the chains.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
