### PR TITLE
fix: remove addr validation for provider fee pool addr param

### DIFF
--- a/x/ccv/consumer/types/params_test.go
+++ b/x/ccv/consumer/types/params_test.go
@@ -30,10 +30,6 @@ func TestValidateParams(t *testing.T) {
 			ccvtypes.NewParams(true, 5, "badchannel/", "", 5, 1005, "0.5", 1000, 24*21*time.Hour, "0.05", []string{"untrn"}, []string{"uatom"}), false,
 		},
 		{
-			"custom invalid params, provider fee pool addr string",
-			ccvtypes.NewParams(true, 5, "", "imabadaddress", 5, 1005, "0.5", 1000, 24*21*time.Hour, "0.05", []string{"untrn"}, []string{"uatom"}), false,
-		},
-		{
 			"custom invalid params, ccv timeout",
 			ccvtypes.NewParams(true, 5, "", "", -5, 1005, "0.5", 1000, 24*21*time.Hour, "0.05", []string{"untrn"}, []string{"uatom"}), false,
 		},

--- a/x/ccv/types/params.go
+++ b/x/ccv/types/params.go
@@ -179,8 +179,8 @@ func ValidateProviderFeePoolAddrStr(i interface{}) error {
 	if i == "" {
 		return nil
 	}
-	// Otherwise validate as usual for a bech32 address
-	return ValidateBech32(i)
+	// Cannot validate provider chain address on the consumer chain
+	return nil
 }
 
 func ValidateSoftOptOutThreshold(i interface{}) error {


### PR DESCRIPTION
Validation was incorrect: we validated provider address with rules of consumer chain.
(Param with key `ProviderFeePoolAddrStr`)

Need to remove this validation for testing purposes since we cannot change this param to any correct address now.
