### PR TITLE
tests: increase timeout in nightly e2e for multiconsumer

### DIFF
--- a/.github/workflows/manual-e2e.yml
+++ b/.github/workflows/manual-e2e.yml
@@ -87,7 +87,7 @@ jobs:
           run: go run ./tests/e2e/... --tc slash-throttle
   multiconsumer-test:
       runs-on: ubuntu-latest
-      timeout-minutes: 20
+      timeout-minutes: 40
       steps:
         - uses: actions/setup-go@v4
           with:

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -100,7 +100,7 @@ jobs:
         run: go run ./tests/e2e/... --tc slash-throttle
   multiconsumer-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 40
     steps:
       - uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
## Description

Closes: N/A

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Increases timeout from 20 to 40 minutes for `multiconsumer` nightly test run to reduce false negatives.

**Context**
After checking nightly test run failures it was determined that the test was simply killed prematurely. Additional fixes may be required if the problem persists after these changes.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
