### PR TITLE
tests: fix relayer/consensus discrepancy for throttle v2 e2e test 

### DIFF
--- a/tests/e2e/config.go
+++ b/tests/e2e/config.go
@@ -174,7 +174,7 @@ func SlashThrottleTestRun() TestRun {
 					".app_state.slashing.params.min_signed_per_window = \"0.500000000000000000\" | " +
 					".app_state.slashing.params.downtime_jail_duration = \"60s\" | " +
 					".app_state.slashing.params.slash_fraction_downtime = \"0.010000000000000000\" | " +
-					".app_state.provider.params.slash_meter_replenish_fraction = \"0.10\" | " +
+					".app_state.provider.params.slash_meter_replenish_fraction = \"0.05\" | " +
 					".app_state.provider.params.slash_meter_replenish_period = \"20s\"",
 			},
 			chainID("consu"): {

--- a/tests/e2e/steps_downtime.go
+++ b/tests/e2e/steps_downtime.go
@@ -309,15 +309,33 @@ func stepsThrottledDowntime(consumerName string) []Step {
 				chainID("provi"): ChainState{
 					ValPowers: &map[validatorID]uint{
 						validatorID("alice"): 511,
-						validatorID("bob"):   0, // bob is jailed
+						validatorID("bob"):   0, // bob is jailed on provider
 						validatorID("carol"): 500,
 					},
 				},
 				chainID(consumerName): ChainState{
-					// VSC packet applying jailing is not yet relayed to consumer
 					ValPowers: &map[validatorID]uint{
 						validatorID("alice"): 511,
-						validatorID("bob"):   500,
+						// VSC packet applying jailing may or may not be relayed to consumer
+						// depending on hermes vs gorelayer behavior. Therefore skip asserting bob's consumer power
+						validatorID("carol"): 500,
+					},
+				},
+			},
+		},
+		{
+			// After relaying one more time, vsc packet applying jailing should be seen on consumer
+			action: relayPacketsAction{
+				chainA:  chainID("provi"),
+				chainB:  chainID(consumerName),
+				port:    "provider",
+				channel: 0,
+			},
+			state: State{
+				chainID(consumerName): ChainState{
+					ValPowers: &map[validatorID]uint{
+						validatorID("alice"): 511,
+						validatorID("bob"):   0,
 						validatorID("carol"): 500,
 					},
 				},
@@ -340,7 +358,7 @@ func stepsThrottledDowntime(consumerName string) []Step {
 				chainID(consumerName): ChainState{
 					ValPowers: &map[validatorID]uint{
 						validatorID("alice"): 511,
-						validatorID("bob"):   500, // VSC packet applying bob jailing is not yet relayed to consumer
+						validatorID("bob"):   0,
 						validatorID("carol"): 500,
 					},
 				},
@@ -364,7 +382,7 @@ func stepsThrottledDowntime(consumerName string) []Step {
 				chainID(consumerName): ChainState{
 					ValPowers: &map[validatorID]uint{
 						validatorID("alice"): 511,
-						validatorID("bob"):   0, // VSC packet applying bob jailing is also relayed and recv by consumer
+						validatorID("bob"):   0,
 						validatorID("carol"): 500,
 					},
 				},

--- a/tests/e2e/steps_downtime.go
+++ b/tests/e2e/steps_downtime.go
@@ -444,10 +444,10 @@ func stepsThrottledDowntime(consumerName string) []Step {
 				//
 				// We've already waited 60 seconds for unjailValidatorAction
 				//
-				// So timeout should be 100 - 60 + buffer = 80 seconds
-
-				// timeout: 200 * time.Second,
-				timeout: 80 * time.Second,
+				// So timeout should be 100 - 60
+				// + large buffer to consider that cometmock did not pass blocks during unjail step
+				// = 100 seconds
+				timeout: 100 * time.Second,
 			},
 			state: State{
 				chainID("provi"): ChainState{


### PR DESCRIPTION
## Description

Handles a discrepancy with how packets are relayed between gorelayer and hermes in e2e tests for throttling v2. 

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
