### PR TITLE
Fix `build` in makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ release/
 docs/tla/states/
 *.out
 vendor/
+build/
 .vscode
 .idea

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,8 @@ mockgen_cmd=go run github.com/golang/mock/mockgen
 mocks:
 	$(mockgen_cmd) -package=keeper -destination=testutil/keeper/mocks.go -source=x/ccv/types/expected_keepers.go
 
+
+BUILDDIR ?= $(CURDIR)/build
 BUILD_TARGETS := build
 
 build: BUILD_ARGS=-o $(BUILDDIR)/


### PR DESCRIPTION
`make build` attempted to write to the `/` root directory as
the current directory path was missing.