### PR TITLE
tests: Export struct fields in the e2e tests

### DIFF
--- a/tests/e2e/actions.go
+++ b/tests/e2e/actions.go
@@ -35,9 +35,9 @@ func (tr TestRun) sendTokens(
 	action SendTokensAction,
 	verbose bool,
 ) {
-	BinaryName := tr.chainConfigs[action.Chain].BinaryName
+	binaryName := tr.chainConfigs[action.Chain].BinaryName
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, BinaryName,
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, binaryName,
 
 		"tx", "bank", "send",
 		tr.validatorConfigs[action.From].DelAddress,

--- a/tests/e2e/actions.go
+++ b/tests/e2e/actions.go
@@ -23,10 +23,10 @@ import (
 )
 
 type SendTokensAction struct {
-	chain  chainID
-	from   validatorID
-	to     validatorID
-	amount uint
+	Chain  ChainID
+	From   ValidatorID
+	To     ValidatorID
+	Amount uint
 }
 
 const done = "done!!!!!!!!"
@@ -35,18 +35,18 @@ func (tr TestRun) sendTokens(
 	action SendTokensAction,
 	verbose bool,
 ) {
-	binaryName := tr.chainConfigs[action.chain].binaryName
+	BinaryName := tr.chainConfigs[action.Chain].BinaryName
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, binaryName,
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, BinaryName,
 
 		"tx", "bank", "send",
-		tr.validatorConfigs[action.from].delAddress,
-		tr.validatorConfigs[action.to].delAddress,
-		fmt.Sprint(action.amount)+`stake`,
+		tr.validatorConfigs[action.From].DelAddress,
+		tr.validatorConfigs[action.To].DelAddress,
+		fmt.Sprint(action.Amount)+`stake`,
 
-		`--chain-id`, string(tr.chainConfigs[action.chain].chainId),
-		`--home`, tr.getValidatorHome(action.chain, action.from),
-		`--node`, tr.getValidatorNode(action.chain, action.from),
+		`--chain-id`, string(tr.chainConfigs[action.Chain].ChainId),
+		`--home`, tr.getValidatorHome(action.Chain, action.From),
+		`--node`, tr.getValidatorNode(action.Chain, action.From),
 		`--keyring-backend`, `test`,
 		`-y`,
 	)
@@ -59,28 +59,28 @@ func (tr TestRun) sendTokens(
 	}
 
 	// wait for inclusion in a block -> '--broadcast-mode block' is deprecated
-	tr.waitBlocks(action.chain, 2, 30*time.Second)
+	tr.waitBlocks(action.Chain, 2, 30*time.Second)
 }
 
 type StartChainAction struct {
-	chain      chainID
-	validators []StartChainValidator
+	Chain      ChainID
+	Validators []StartChainValidator
 	// Genesis changes specific to this action, appended to genesis changes defined in chain config
-	genesisChanges string
-	skipGentx      bool
+	GenesisChanges string
+	SkipGentx      bool
 }
 
 type StartChainValidator struct {
-	id         validatorID
-	allocation uint
-	stake      uint
+	Id         ValidatorID
+	Allocation uint
+	Stake      uint
 }
 
 func (tr *TestRun) startChain(
 	action StartChainAction,
 	verbose bool,
 ) {
-	chainConfig := tr.chainConfigs[action.chain]
+	chainConfig := tr.chainConfigs[action.Chain]
 	type jsonValAttrs struct {
 		Mnemonic         string `json:"mnemonic"`
 		Allocation       string `json:"allocation"`
@@ -96,20 +96,20 @@ func (tr *TestRun) startChain(
 	}
 
 	var validators []jsonValAttrs
-	for _, val := range action.validators {
+	for _, val := range action.Validators {
 		validators = append(validators, jsonValAttrs{
-			Mnemonic:         tr.validatorConfigs[val.id].mnemonic,
-			NodeKey:          tr.validatorConfigs[val.id].nodeKey,
-			ValId:            fmt.Sprint(val.id),
-			PrivValidatorKey: tr.validatorConfigs[val.id].privValidatorKey,
-			Allocation:       fmt.Sprint(val.allocation) + "stake",
-			Stake:            fmt.Sprint(val.stake) + "stake",
-			IpSuffix:         tr.validatorConfigs[val.id].ipSuffix,
+			Mnemonic:         tr.validatorConfigs[val.Id].Mnemonic,
+			NodeKey:          tr.validatorConfigs[val.Id].NodeKey,
+			ValId:            fmt.Sprint(val.Id),
+			PrivValidatorKey: tr.validatorConfigs[val.Id].PrivValidatorKey,
+			Allocation:       fmt.Sprint(val.Allocation) + "stake",
+			Stake:            fmt.Sprint(val.Stake) + "stake",
+			IpSuffix:         tr.validatorConfigs[val.Id].IpSuffix,
 
-			ConsumerMnemonic:         tr.validatorConfigs[val.id].consumerMnemonic,
-			ConsumerPrivValidatorKey: tr.validatorConfigs[val.id].consumerPrivValidatorKey,
+			ConsumerMnemonic:         tr.validatorConfigs[val.Id].ConsumerMnemonic,
+			ConsumerPrivValidatorKey: tr.validatorConfigs[val.Id].ConsumerPrivValidatorKey,
 			// if true node will be started with consumer key for each consumer chain
-			StartWithConsumerKey: tr.validatorConfigs[val.id].useConsumerKey,
+			StartWithConsumerKey: tr.validatorConfigs[val.Id].UseConsumerKey,
 		})
 	}
 
@@ -120,10 +120,10 @@ func (tr *TestRun) startChain(
 
 	// Concat genesis changes defined in chain config, with any custom genesis changes for this chain instantiation
 	var genesisChanges string
-	if action.genesisChanges != "" {
-		genesisChanges = chainConfig.genesisChanges + " | " + action.genesisChanges
+	if action.GenesisChanges != "" {
+		genesisChanges = chainConfig.GenesisChanges + " | " + action.GenesisChanges
 	} else {
-		genesisChanges = chainConfig.genesisChanges
+		genesisChanges = chainConfig.GenesisChanges
 	}
 
 	var cometmockArg string
@@ -134,10 +134,10 @@ func (tr *TestRun) startChain(
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, "/bin/bash",
-		"/testnet-scripts/start-chain.sh", chainConfig.binaryName, string(vals),
-		string(chainConfig.chainId), chainConfig.ipPrefix, genesisChanges,
-		fmt.Sprint(action.skipGentx),
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "/bin/bash",
+		"/testnet-scripts/start-chain.sh", chainConfig.BinaryName, string(vals),
+		string(chainConfig.ChainId), chainConfig.IpPrefix, genesisChanges,
+		fmt.Sprint(action.SkipGentx),
 		// override config/config.toml for each node on chain
 		// usually timeout_commit and peer_gossip_sleep_duration are changed to vary the test run duration
 		// lower timeout_commit means the blocks are produced faster making the test run shorter
@@ -172,25 +172,26 @@ func (tr *TestRun) startChain(
 	}
 
 	tr.addChainToRelayer(addChainToRelayerAction{
-		chain:     action.chain,
-		validator: action.validators[0].id,
+		Chain:     action.Chain,
+		Validator: action.Validators[0].Id,
 	}, verbose)
 
 	// store the fact that we started the chain
-	tr.runningChains[action.chain] = true
-	fmt.Println("Started chain", action.chain)
+	tr.runningChains[action.Chain] = true
+	fmt.Println("Started chain", action.Chain)
 	if tr.timeOffset != 0 {
 		// advance time for this chain so that it is in sync with the rest of the network
-		tr.AdvanceTimeForChain(action.chain, tr.timeOffset)
+		tr.AdvanceTimeForChain(action.Chain, tr.timeOffset)
 	}
 }
 
 type submitTextProposalAction struct {
-	chain       chainID
-	from        validatorID
-	deposit     uint
-	title       string
-	description string
+	Chain       ChainID
+	From        ValidatorID
+	Deposit     uint
+	PropType    string
+	Title       string
+	Description string
 }
 
 func (tr TestRun) submitTextProposal(
@@ -199,15 +200,16 @@ func (tr TestRun) submitTextProposal(
 ) {
 	// TEXT PROPOSAL
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[action.chain].binaryName,
+	bz, err := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[action.Chain].BinaryName,
 		"tx", "gov", "submit-legacy-proposal",
-		`--title`, action.title,
-		`--description`, action.description,
-		`--deposit`, fmt.Sprint(action.deposit)+`stake`,
-		`--from`, `validator`+fmt.Sprint(action.from),
-		`--chain-id`, string(tr.chainConfigs[action.chain].chainId),
-		`--home`, tr.getValidatorHome(action.chain, action.from),
-		`--node`, tr.getValidatorNode(action.chain, action.from),
+		`--title`, action.Title,
+		`--description`, action.Description,
+		`--type`, action.PropType,
+		`--deposit`, fmt.Sprint(action.Deposit)+`stake`,
+		`--from`, `validator`+fmt.Sprint(action.From),
+		`--chain-id`, string(tr.chainConfigs[action.Chain].ChainId),
+		`--home`, tr.getValidatorHome(action.Chain, action.From),
+		`--node`, tr.getValidatorNode(action.Chain, action.From),
 		`--keyring-backend`, `test`,
 		`-y`,
 	).CombinedOutput()
@@ -216,31 +218,31 @@ func (tr TestRun) submitTextProposal(
 	}
 
 	// wait for inclusion in a block -> '--broadcast-mode block' is deprecated
-	tr.waitBlocks(action.chain, 1, 10*time.Second)
+	tr.waitBlocks(action.Chain, 1, 10*time.Second)
 }
 
 type submitConsumerAdditionProposalAction struct {
-	preCCV              bool
-	chain               chainID
-	from                validatorID
-	deposit             uint
-	consumerChain       chainID
-	spawnTime           uint
-	initialHeight       clienttypes.Height
-	distributionChannel string
+	PreCCV              bool
+	Chain               ChainID
+	From                ValidatorID
+	Deposit             uint
+	ConsumerChain       ChainID
+	SpawnTime           uint
+	InitialHeight       clienttypes.Height
+	DistributionChannel string
 }
 
 func (tr TestRun) submitConsumerAdditionProposal(
 	action submitConsumerAdditionProposalAction,
 	verbose bool,
 ) {
-	spawnTime := tr.containerConfig.now.Add(time.Duration(action.spawnTime) * time.Millisecond)
+	spawnTime := tr.containerConfig.Now.Add(time.Duration(action.SpawnTime) * time.Millisecond)
 	params := ccvtypes.DefaultParams()
 	prop := client.ConsumerAdditionProposalJSON{
 		Title:                             "Propose the addition of a new chain",
 		Summary:                           "Gonna be a great chain",
-		ChainId:                           string(tr.chainConfigs[action.consumerChain].chainId),
-		InitialHeight:                     action.initialHeight,
+		ChainId:                           string(tr.chainConfigs[action.ConsumerChain].ChainId),
+		InitialHeight:                     action.InitialHeight,
 		GenesisHash:                       []byte("gen_hash"),
 		BinaryHash:                        []byte("bin_hash"),
 		SpawnTime:                         spawnTime,
@@ -250,8 +252,8 @@ func (tr TestRun) submitConsumerAdditionProposal(
 		CcvTimeoutPeriod:                  params.CcvTimeoutPeriod,
 		TransferTimeoutPeriod:             params.TransferTimeoutPeriod,
 		UnbondingPeriod:                   params.UnbondingPeriod,
-		Deposit:                           fmt.Sprint(action.deposit) + `stake`,
-		DistributionTransmissionChannel:   action.distributionChannel,
+		Deposit:                           fmt.Sprint(action.Deposit) + `stake`,
+		DistributionTransmissionChannel:   action.DistributionChannel,
 	}
 
 	bz, err := json.Marshal(prop)
@@ -265,7 +267,7 @@ func (tr TestRun) submitConsumerAdditionProposal(
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err = exec.Command("docker", "exec", tr.containerConfig.instanceName,
+	bz, err = exec.Command("docker", "exec", tr.containerConfig.InstanceName,
 		"/bin/bash", "-c", fmt.Sprintf(`echo '%s' > %s`, jsonStr, "/temp-proposal.json")).CombinedOutput()
 
 	if err != nil {
@@ -274,13 +276,13 @@ func (tr TestRun) submitConsumerAdditionProposal(
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	// CONSUMER ADDITION PROPOSAL
-	bz, err = exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[action.chain].binaryName,
+	bz, err = exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[action.Chain].BinaryName,
 		"tx", "gov", "submit-legacy-proposal", "consumer-addition", "/temp-proposal.json",
-		`--from`, `validator`+fmt.Sprint(action.from),
-		`--chain-id`, string(tr.chainConfigs[action.chain].chainId),
-		`--home`, tr.getValidatorHome(action.chain, action.from),
+		`--from`, `validator`+fmt.Sprint(action.From),
+		`--chain-id`, string(tr.chainConfigs[action.Chain].ChainId),
+		`--home`, tr.getValidatorHome(action.Chain, action.From),
 		`--gas`, `900000`,
-		`--node`, tr.getValidatorNode(action.chain, action.from),
+		`--node`, tr.getValidatorNode(action.Chain, action.From),
 		`--keyring-backend`, `test`,
 		`-y`,
 	).CombinedOutput()
@@ -290,28 +292,28 @@ func (tr TestRun) submitConsumerAdditionProposal(
 	}
 
 	// wait for inclusion in a block -> '--broadcast-mode block' is deprecated
-	tr.waitBlocks(chainID("provi"), 2, 10*time.Second)
+	tr.waitBlocks(ChainID("provi"), 2, 10*time.Second)
 }
 
 type submitConsumerRemovalProposalAction struct {
-	chain          chainID
-	from           validatorID
-	deposit        uint
-	consumerChain  chainID
-	stopTimeOffset time.Duration // offset from time.Now()
+	Chain          ChainID
+	From           ValidatorID
+	Deposit        uint
+	ConsumerChain  ChainID
+	StopTimeOffset time.Duration // offset from time.Now()
 }
 
 func (tr TestRun) submitConsumerRemovalProposal(
 	action submitConsumerRemovalProposalAction,
 	verbose bool,
 ) {
-	stopTime := tr.containerConfig.now.Add(action.stopTimeOffset)
+	stopTime := tr.containerConfig.Now.Add(action.StopTimeOffset)
 	prop := client.ConsumerRemovalProposalJSON{
-		Title:    fmt.Sprintf("Stop the %v chain", action.consumerChain),
+		Title:    fmt.Sprintf("Stop the %v chain", action.ConsumerChain),
 		Summary:  "It was a great chain",
-		ChainId:  string(tr.chainConfigs[action.consumerChain].chainId),
+		ChainId:  string(tr.chainConfigs[action.ConsumerChain].ChainId),
 		StopTime: stopTime,
-		Deposit:  fmt.Sprint(action.deposit) + `stake`,
+		Deposit:  fmt.Sprint(action.Deposit) + `stake`,
 	}
 
 	bz, err := json.Marshal(prop)
@@ -325,7 +327,7 @@ func (tr TestRun) submitConsumerRemovalProposal(
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err = exec.Command("docker", "exec", tr.containerConfig.instanceName,
+	bz, err = exec.Command("docker", "exec", tr.containerConfig.InstanceName,
 		"/bin/bash", "-c", fmt.Sprintf(`echo '%s' > %s`, jsonStr, "/temp-proposal.json")).CombinedOutput()
 
 	if err != nil {
@@ -333,13 +335,14 @@ func (tr TestRun) submitConsumerRemovalProposal(
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	// CONSUMER REMOVAL PROPOSAL
-	bz, err = exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[action.chain].binaryName,
-		"tx", "gov", "submit-legacy-proposal", "consumer-removal", "/temp-proposal.json",
-		`--from`, `validator`+fmt.Sprint(action.from),
-		`--chain-id`, string(tr.chainConfigs[action.chain].chainId),
-		`--home`, tr.getValidatorHome(action.chain, action.from),
-		`--node`, tr.getValidatorNode(action.chain, action.from),
+	bz, err = exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[action.Chain].BinaryName,
+
+		"tx", "gov", "submit-legacy-proposal", "consumer-removal",
+		"/temp-proposal.json",
+		`--from`, `validator`+fmt.Sprint(action.From),
+		`--chain-id`, string(tr.chainConfigs[action.Chain].ChainId),
+		`--home`, tr.getValidatorHome(action.Chain, action.From),
+		`--node`, tr.getValidatorNode(action.Chain, action.From),
 		`--gas`, "900000",
 		`--keyring-backend`, `test`,
 		`-y`,
@@ -350,16 +353,16 @@ func (tr TestRun) submitConsumerRemovalProposal(
 	}
 
 	// wait for inclusion in a block -> '--broadcast-mode block' is deprecated
-	tr.waitBlocks(chainID("provi"), 2, 20*time.Second)
+	tr.waitBlocks(ChainID("provi"), 2, 20*time.Second)
 }
 
 type submitParamChangeLegacyProposalAction struct {
-	chain    chainID
-	from     validatorID
-	deposit  uint
-	subspace string
-	key      string
-	value    interface{}
+	Chain    ChainID
+	From     ValidatorID
+	Deposit  uint
+	Subspace string
+	Key      string
+	Value    interface{}
 }
 
 type paramChangeProposalJSON struct {
@@ -384,8 +387,8 @@ func (tr TestRun) submitParamChangeProposal(
 		Title:       "Legacy Param change",
 		Summary:     "Changing legacy module params",
 		Description: "Changing legacy module params",
-		Changes:     []paramChangeJSON{{Subspace: action.subspace, Key: action.key, Value: action.value}},
-		Deposit:     fmt.Sprint(action.deposit) + `stake`,
+		Changes:     []paramChangeJSON{{Subspace: action.Subspace, Key: action.Key, Value: action.Value}},
+		Deposit:     fmt.Sprint(action.Deposit) + `stake`,
 	}
 
 	bz, err := json.Marshal(prop)
@@ -399,7 +402,7 @@ func (tr TestRun) submitParamChangeProposal(
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err = exec.Command("docker", "exec", tr.containerConfig.instanceName,
+	bz, err = exec.Command("docker", "exec", tr.containerConfig.InstanceName,
 		"/bin/bash", "-c", fmt.Sprintf(`echo '%s' > %s`, jsonStr, "/params-proposal.json")).CombinedOutput()
 
 	if err != nil {
@@ -407,13 +410,15 @@ func (tr TestRun) submitParamChangeProposal(
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	// PARAM CHANGE PROPOSAL // we should be able to make these all one command which will be cool
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[action.chain].binaryName,
+	// PARAM CHANGE PROPOSAL
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[action.Chain].BinaryName,
+
 		"tx", "gov", "submit-legacy-proposal", "param-change", "/params-proposal.json",
-		`--from`, `validator`+fmt.Sprint(action.from),
-		`--chain-id`, string(tr.chainConfigs[action.chain].chainId),
-		`--home`, tr.getValidatorHome(action.chain, action.from),
-		`--node`, tr.getValidatorNode(action.chain, action.from),
+
+		`--from`, `validator`+fmt.Sprint(action.From),
+		`--chain-id`, string(tr.chainConfigs[action.Chain].ChainId),
+		`--home`, tr.getValidatorHome(action.Chain, action.From),
+		`--node`, tr.getValidatorNode(action.Chain, action.From),
 		`--gas`, "900000",
 		`--keyring-backend`, `test`,
 		`-y`,
@@ -425,38 +430,38 @@ func (tr TestRun) submitParamChangeProposal(
 	}
 
 	// wait for inclusion in a block -> '--broadcast-mode block' is deprecated
-	tr.waitBlocks(action.chain, 2, 60*time.Second)
+	tr.waitBlocks(action.Chain, 2, 60*time.Second)
 }
 
 type submitEquivocationProposalAction struct {
-	chain     chainID
-	height    int64
-	time      time.Time
-	power     int64
-	validator validatorID
-	deposit   uint
-	from      validatorID
+	Chain     ChainID
+	Height    int64
+	Time      time.Time
+	Power     int64
+	Validator ValidatorID
+	Deposit   uint
+	From      ValidatorID
 }
 
 func (tr TestRun) submitEquivocationProposal(action submitEquivocationProposalAction, verbose bool) {
-	val := tr.validatorConfigs[action.validator]
-	providerChain := tr.chainConfigs[chainID("provi")]
+	val := tr.validatorConfigs[action.Validator]
+	providerChain := tr.chainConfigs[ChainID("provi")]
 
 	prop := client.EquivocationProposalJSON{
 		Summary: "Validator equivocation!",
 		EquivocationProposal: types.EquivocationProposal{
 			Title:       "Validator equivocation!",
-			Description: fmt.Sprintf("Validator: %s has committed an equivocation infraction on chainID: %s", action.validator, action.chain),
+			Description: fmt.Sprintf("Validator: %s has committed an equivocation infraction on ChainID: %s", action.Validator, action.Chain),
 			Equivocations: []*evidencetypes.Equivocation{
 				{
-					Height:           action.height,
-					Time:             action.time,
-					Power:            action.power,
-					ConsensusAddress: val.valconsAddress,
+					Height:           action.Height,
+					Time:             action.Time,
+					Power:            action.Power,
+					ConsensusAddress: val.ValconsAddress,
 				},
 			},
 		},
-		Deposit: fmt.Sprint(action.deposit) + `stake`,
+		Deposit: fmt.Sprint(action.Deposit) + `stake`,
 	}
 
 	bz, err := json.Marshal(prop)
@@ -470,7 +475,7 @@ func (tr TestRun) submitEquivocationProposal(action submitEquivocationProposalAc
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err = exec.Command("docker", "exec", tr.containerConfig.instanceName,
+	bz, err = exec.Command("docker", "exec", tr.containerConfig.InstanceName,
 		"/bin/bash", "-c", fmt.Sprintf(`echo '%s' > %s`, jsonStr, "/equivocation-proposal.json")).CombinedOutput()
 
 	if err != nil {
@@ -479,12 +484,14 @@ func (tr TestRun) submitEquivocationProposal(action submitEquivocationProposalAc
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	// EQUIVOCATION PROPOSAL
-	bz, err = exec.Command("docker", "exec", tr.containerConfig.instanceName, providerChain.binaryName,
+	bz, err = exec.Command("docker", "exec", tr.containerConfig.InstanceName, providerChain.BinaryName,
+
 		"tx", "gov", "submit-legacy-proposal", "equivocation", "/equivocation-proposal.json",
-		`--from`, `validator`+fmt.Sprint(action.from),
-		`--chain-id`, string(providerChain.chainId),
-		`--home`, tr.getValidatorHome(providerChain.chainId, action.from),
-		`--node`, tr.getValidatorNode(providerChain.chainId, action.from),
+
+		`--from`, `validator`+fmt.Sprint(action.From),
+		`--chain-id`, string(providerChain.ChainId),
+		`--home`, tr.getValidatorHome(providerChain.ChainId, action.From),
+		`--node`, tr.getValidatorNode(providerChain.ChainId, action.From),
 		`--gas`, "9000000",
 		`--keyring-backend`, `test`,
 		`-y`,
@@ -495,14 +502,14 @@ func (tr TestRun) submitEquivocationProposal(action submitEquivocationProposalAc
 	}
 
 	// wait for inclusion in a block -> '--broadcast-mode block' is deprecated
-	tr.waitBlocks(chainID("provi"), 2, 30*time.Second)
+	tr.waitBlocks(ChainID("provi"), 2, 30*time.Second)
 }
 
 type voteGovProposalAction struct {
-	chain      chainID
-	from       []validatorID
-	vote       []string
-	propNumber uint
+	Chain      ChainID
+	From       []ValidatorID
+	Vote       []string
+	PropNumber uint
 }
 
 func (tr *TestRun) voteGovProposal(
@@ -510,21 +517,21 @@ func (tr *TestRun) voteGovProposal(
 	verbose bool,
 ) {
 	var wg sync.WaitGroup
-	for i, val := range action.from {
+	for i, val := range action.From {
 		wg.Add(1)
-		vote := action.vote[i]
-		go func(val validatorID, vote string) {
+		vote := action.Vote[i]
+		go func(val ValidatorID, vote string) {
 			defer wg.Done()
 			//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-			bz, err := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[action.chain].binaryName,
+			bz, err := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[action.Chain].BinaryName,
 
 				"tx", "gov", "vote",
-				fmt.Sprint(action.propNumber), vote,
+				fmt.Sprint(action.PropNumber), vote,
 
 				`--from`, `validator`+fmt.Sprint(val),
-				`--chain-id`, string(tr.chainConfigs[action.chain].chainId),
-				`--home`, tr.getValidatorHome(action.chain, val),
-				`--node`, tr.getValidatorNode(action.chain, val),
+				`--chain-id`, string(tr.chainConfigs[action.Chain].ChainId),
+				`--home`, tr.getValidatorHome(action.Chain, val),
+				`--node`, tr.getValidatorNode(action.Chain, val),
 				`--keyring-backend`, `test`,
 				`--gas`, "900000",
 				`-y`,
@@ -537,15 +544,15 @@ func (tr *TestRun) voteGovProposal(
 
 	wg.Wait()
 	// wait for inclusion in a block -> '--broadcast-mode block' is deprecated
-	tr.waitBlocks(action.chain, 1, 10*time.Second)
-	tr.WaitTime(time.Duration(tr.chainConfigs[action.chain].votingWaitTime) * time.Second)
+	tr.waitBlocks(action.Chain, 1, 10*time.Second)
+	tr.WaitTime(time.Duration(tr.chainConfigs[action.Chain].VotingWaitTime) * time.Second)
 }
 
 type startConsumerChainAction struct {
-	consumerChain  chainID
-	providerChain  chainID
-	validators     []StartChainValidator
-	genesisChanges string
+	ConsumerChain  ChainID
+	ProviderChain  ChainID
+	Validators     []StartChainValidator
+	GenesisChanges string
 }
 
 func (tr *TestRun) startConsumerChain(
@@ -553,12 +560,12 @@ func (tr *TestRun) startConsumerChain(
 	verbose bool,
 ) {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[action.providerChain].binaryName,
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[action.ProviderChain].BinaryName,
 
 		"query", "provider", "consumer-genesis",
-		string(tr.chainConfigs[action.consumerChain].chainId),
+		string(tr.chainConfigs[action.ConsumerChain].ChainId),
 
-		`--node`, tr.getQueryNode(action.providerChain),
+		`--node`, tr.getQueryNode(action.ProviderChain),
 		`-o`, `json`,
 	)
 
@@ -572,24 +579,24 @@ func (tr *TestRun) startConsumerChain(
 	}
 
 	consumerGenesis := ".app_state.ccvconsumer = " + string(bz)
-	consumerGenesisChanges := tr.chainConfigs[action.consumerChain].genesisChanges
+	consumerGenesisChanges := tr.chainConfigs[action.ConsumerChain].GenesisChanges
 	if consumerGenesisChanges != "" {
-		consumerGenesis = consumerGenesis + " | " + consumerGenesisChanges + " | " + action.genesisChanges
+		consumerGenesis = consumerGenesis + " | " + consumerGenesisChanges + " | " + action.GenesisChanges
 	}
 
 	tr.startChain(StartChainAction{
-		chain:          action.consumerChain,
-		validators:     action.validators,
-		genesisChanges: consumerGenesis,
-		skipGentx:      true,
+		Chain:          action.ConsumerChain,
+		Validators:     action.Validators,
+		GenesisChanges: consumerGenesis,
+		SkipGentx:      true,
 	}, verbose)
 }
 
 type ChangeoverChainAction struct {
-	sovereignChain chainID
-	providerChain  chainID
-	validators     []StartChainValidator
-	genesisChanges string
+	SovereignChain ChainID
+	ProviderChain  ChainID
+	Validators     []StartChainValidator
+	GenesisChanges string
 }
 
 func (tr TestRun) changeoverChain(
@@ -599,12 +606,12 @@ func (tr TestRun) changeoverChain(
 	// sleep until the consumer chain genesis is ready on consumer
 	time.Sleep(5 * time.Second)
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[action.providerChain].binaryName,
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[action.ProviderChain].BinaryName,
 
 		"query", "provider", "consumer-genesis",
-		string(tr.chainConfigs[action.sovereignChain].chainId),
+		string(tr.chainConfigs[action.SovereignChain].ChainId),
 
-		`--node`, tr.getQueryNode(action.providerChain),
+		`--node`, tr.getQueryNode(action.ProviderChain),
 		`-o`, `json`,
 	)
 
@@ -618,14 +625,14 @@ func (tr TestRun) changeoverChain(
 	}
 
 	consumerGenesis := ".app_state.ccvconsumer = " + string(bz)
-	consumerGenesisChanges := tr.chainConfigs[action.sovereignChain].genesisChanges
+	consumerGenesisChanges := tr.chainConfigs[action.SovereignChain].GenesisChanges
 	if consumerGenesisChanges != "" {
-		consumerGenesis = consumerGenesis + " | " + consumerGenesisChanges + " | " + action.genesisChanges
+		consumerGenesis = consumerGenesis + " | " + consumerGenesisChanges + " | " + action.GenesisChanges
 	}
 
 	tr.startChangeover(ChangeoverChainAction{
-		validators:     action.validators,
-		genesisChanges: consumerGenesis,
+		Validators:     action.Validators,
+		GenesisChanges: consumerGenesis,
 	}, verbose)
 }
 
@@ -633,7 +640,7 @@ func (tr TestRun) startChangeover(
 	action ChangeoverChainAction,
 	verbose bool,
 ) {
-	chainConfig := tr.chainConfigs[chainID("sover")]
+	chainConfig := tr.chainConfigs[ChainID("sover")]
 	type jsonValAttrs struct {
 		Mnemonic         string `json:"mnemonic"`
 		Allocation       string `json:"allocation"`
@@ -649,20 +656,20 @@ func (tr TestRun) startChangeover(
 	}
 
 	var validators []jsonValAttrs
-	for _, val := range action.validators {
+	for _, val := range action.Validators {
 		validators = append(validators, jsonValAttrs{
-			Mnemonic:         tr.validatorConfigs[val.id].mnemonic,
-			NodeKey:          tr.validatorConfigs[val.id].nodeKey,
-			ValId:            fmt.Sprint(val.id),
-			PrivValidatorKey: tr.validatorConfigs[val.id].privValidatorKey,
-			Allocation:       fmt.Sprint(val.allocation) + "stake",
-			Stake:            fmt.Sprint(val.stake) + "stake",
-			IpSuffix:         tr.validatorConfigs[val.id].ipSuffix,
+			Mnemonic:         tr.validatorConfigs[val.Id].Mnemonic,
+			NodeKey:          tr.validatorConfigs[val.Id].NodeKey,
+			ValId:            fmt.Sprint(val.Id),
+			PrivValidatorKey: tr.validatorConfigs[val.Id].PrivValidatorKey,
+			Allocation:       fmt.Sprint(val.Allocation) + "stake",
+			Stake:            fmt.Sprint(val.Stake) + "stake",
+			IpSuffix:         tr.validatorConfigs[val.Id].IpSuffix,
 
-			ConsumerMnemonic:         tr.validatorConfigs[val.id].consumerMnemonic,
-			ConsumerPrivValidatorKey: tr.validatorConfigs[val.id].consumerPrivValidatorKey,
+			ConsumerMnemonic:         tr.validatorConfigs[val.Id].ConsumerMnemonic,
+			ConsumerPrivValidatorKey: tr.validatorConfigs[val.Id].ConsumerPrivValidatorKey,
 			// if true node will be started with consumer key for each consumer chain
-			StartWithConsumerKey: tr.validatorConfigs[val.id].useConsumerKey,
+			StartWithConsumerKey: tr.validatorConfigs[val.Id].UseConsumerKey,
 		})
 	}
 
@@ -673,16 +680,16 @@ func (tr TestRun) startChangeover(
 
 	// Concat genesis changes defined in chain config, with any custom genesis changes for this chain instantiation
 	var genesisChanges string
-	if action.genesisChanges != "" {
-		genesisChanges = chainConfig.genesisChanges + " | " + action.genesisChanges
+	if action.GenesisChanges != "" {
+		genesisChanges = chainConfig.GenesisChanges + " | " + action.GenesisChanges
 	} else {
-		genesisChanges = chainConfig.genesisChanges
+		genesisChanges = chainConfig.GenesisChanges
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, "/bin/bash",
-		"/testnet-scripts/start-changeover.sh", chainConfig.upgradeBinary, string(vals),
-		"sover", chainConfig.ipPrefix, genesisChanges,
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "/bin/bash",
+		"/testnet-scripts/start-changeover.sh", chainConfig.UpgradeBinary, string(vals),
+		"sover", chainConfig.IpPrefix, genesisChanges,
 		tr.tendermintConfigOverride,
 	)
 
@@ -713,8 +720,8 @@ func (tr TestRun) startChangeover(
 }
 
 type addChainToRelayerAction struct {
-	chain     chainID
-	validator validatorID
+	Chain     ChainID
+	Validator ValidatorID
 }
 
 const hermesChainConfigTemplate = `
@@ -779,37 +786,37 @@ func (tr TestRun) addChainToGorelayer(
 	action addChainToRelayerAction,
 	verbose bool,
 ) {
-	queryNodeIP := tr.getQueryNodeIP(action.chain)
-	chainId := tr.chainConfigs[action.chain].chainId
+	queryNodeIP := tr.getQueryNodeIP(action.Chain)
+	ChainId := tr.chainConfigs[action.Chain].ChainId
 	rpcAddr := "http://" + queryNodeIP + ":26658"
 
 	chainConfig := fmt.Sprintf(gorelayerChainConfigTemplate,
-		chainId,
+		ChainId,
 		rpcAddr,
 	)
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err := exec.Command("docker", "exec", tr.containerConfig.instanceName, "rly", "config", "init").CombinedOutput()
+	bz, err := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "rly", "config", "init").CombinedOutput()
 	if err != nil && !strings.Contains(string(bz), "config already exists") {
 		log.Fatal(err, "\n", string(bz))
 	}
 
-	chainConfigFileName := fmt.Sprintf("/root/%s_config.json", chainId)
+	chainConfigFileName := fmt.Sprintf("/root/%s_config.json", ChainId)
 
 	bashCommand := fmt.Sprintf(`echo '%s' >> %s`, chainConfig, chainConfigFileName)
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err = exec.Command("docker", "exec", tr.containerConfig.instanceName, "bash", "-c",
+	bz, err = exec.Command("docker", "exec", tr.containerConfig.InstanceName, "bash", "-c",
 		bashCommand).CombinedOutput()
 	if err != nil {
 		log.Fatal(err, "\n", string(bz))
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	addChainCommand := exec.Command("docker", "exec", tr.containerConfig.instanceName, "rly", "chains", "add", "--file", chainConfigFileName, string(chainId))
+	addChainCommand := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "rly", "chains", "add", "--file", chainConfigFileName, string(ChainId))
 	executeCommand(addChainCommand, "add chain")
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	keyRestoreCommand := exec.Command("docker", "exec", tr.containerConfig.instanceName, "rly", "keys", "restore", string(chainId), "default", tr.validatorConfigs[action.validator].mnemonic)
+	keyRestoreCommand := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "rly", "keys", "restore", string(ChainId), "default", tr.validatorConfigs[action.Validator].Mnemonic)
 	executeCommand(keyRestoreCommand, "restore keys")
 }
 
@@ -817,8 +824,8 @@ func (tr TestRun) addChainToHermes(
 	action addChainToRelayerAction,
 	verbose bool,
 ) {
-	queryNodeIP := tr.getQueryNodeIP(action.chain)
-	chainId := tr.chainConfigs[action.chain].chainId
+	queryNodeIP := tr.getQueryNodeIP(action.Chain)
+	ChainId := tr.chainConfigs[action.Chain].ChainId
 	keyName := "query"
 	rpcAddr := "http://" + queryNodeIP + ":26658"
 	grpcAddr := "tcp://" + queryNodeIP + ":9091"
@@ -826,7 +833,7 @@ func (tr TestRun) addChainToHermes(
 
 	chainConfig := fmt.Sprintf(hermesChainConfigTemplate,
 		grpcAddr,
-		chainId,
+		ChainId,
 		keyName,
 		rpcAddr,
 		wsAddr,
@@ -836,7 +843,7 @@ func (tr TestRun) addChainToHermes(
 	bashCommand := fmt.Sprintf(`echo '%s' >> %s`, chainConfig, "/root/.hermes/config.toml")
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err := exec.Command("docker", "exec", tr.containerConfig.instanceName, "bash", "-c",
+	bz, err := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "bash", "-c",
 		bashCommand,
 	).CombinedOutput()
 	if err != nil {
@@ -844,9 +851,9 @@ func (tr TestRun) addChainToHermes(
 	}
 
 	// Save mnemonic to file within container
-	saveMnemonicCommand := fmt.Sprintf(`echo '%s' > %s`, tr.validatorConfigs[action.validator].mnemonic, "/root/.hermes/mnemonic.txt")
+	saveMnemonicCommand := fmt.Sprintf(`echo '%s' > %s`, tr.validatorConfigs[action.Validator].Mnemonic, "/root/.hermes/mnemonic.txt")
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err = exec.Command("docker", "exec", tr.containerConfig.instanceName, "bash", "-c",
+	bz, err = exec.Command("docker", "exec", tr.containerConfig.InstanceName, "bash", "-c",
 		saveMnemonicCommand,
 	).CombinedOutput()
 	if err != nil {
@@ -854,9 +861,9 @@ func (tr TestRun) addChainToHermes(
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err = exec.Command("docker", "exec", tr.containerConfig.instanceName, "hermes",
+	bz, err = exec.Command("docker", "exec", tr.containerConfig.InstanceName, "hermes",
 		"keys", "add",
-		"--chain", string(tr.chainConfigs[action.chain].chainId),
+		"--chain", string(tr.chainConfigs[action.Chain].ChainId),
 		"--mnemonic-file", "/root/.hermes/mnemonic.txt",
 	).CombinedOutput()
 
@@ -886,10 +893,10 @@ const gorelayerPathConfigTemplate = `{
 `
 
 type addIbcConnectionAction struct {
-	chainA  chainID
-	chainB  chainID
-	clientA uint
-	clientB uint
+	ChainA  ChainID
+	ChainB  ChainID
+	ClientA uint
+	ClientB uint
 }
 
 func (tr TestRun) addIbcConnection(
@@ -907,23 +914,23 @@ func (tr TestRun) addIbcConnectionGorelayer(
 	action addIbcConnectionAction,
 	verbose bool,
 ) {
-	pathName := tr.GetPathNameForGorelayer(action.chainA, action.chainB)
+	pathName := tr.GetPathNameForGorelayer(action.ChainA, action.ChainB)
 
-	pathConfig := fmt.Sprintf(gorelayerPathConfigTemplate, action.chainA, action.clientA, action.chainB, action.clientB)
+	pathConfig := fmt.Sprintf(gorelayerPathConfigTemplate, action.ChainA, action.ClientA, action.ChainB, action.ClientB)
 
 	pathConfigFileName := fmt.Sprintf("/root/%s_config.json", pathName)
 
 	bashCommand := fmt.Sprintf(`echo '%s' >> %s`, pathConfig, pathConfigFileName)
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	pathConfigCommand := exec.Command("docker", "exec", tr.containerConfig.instanceName, "bash", "-c",
+	pathConfigCommand := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "bash", "-c",
 		bashCommand)
 	executeCommand(pathConfigCommand, "add path config")
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	newPathCommand := exec.Command("docker", "exec", tr.containerConfig.instanceName, "rly",
+	newPathCommand := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "rly",
 		"paths", "add",
-		string(tr.chainConfigs[action.chainA].chainId),
-		string(tr.chainConfigs[action.chainB].chainId),
+		string(tr.chainConfigs[action.ChainA].ChainId),
+		string(tr.chainConfigs[action.ChainB].ChainId),
 		pathName,
 		"--file", pathConfigFileName,
 	)
@@ -931,31 +938,31 @@ func (tr TestRun) addIbcConnectionGorelayer(
 	executeCommand(newPathCommand, "new path")
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	newClientsCommand := exec.Command("docker", "exec", tr.containerConfig.instanceName, "rly",
+	newClientsCommand := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "rly",
 		"transact", "clients",
 		pathName,
 	)
 
 	executeCommand(newClientsCommand, "new clients")
 
-	tr.waitBlocks(action.chainA, 1, 10*time.Second)
-	tr.waitBlocks(action.chainB, 1, 10*time.Second)
+	tr.waitBlocks(action.ChainA, 1, 10*time.Second)
+	tr.waitBlocks(action.ChainB, 1, 10*time.Second)
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	newConnectionCommand := exec.Command("docker", "exec", tr.containerConfig.instanceName, "rly",
+	newConnectionCommand := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "rly",
 		"transact", "connection",
 		pathName,
 	)
 
 	executeCommand(newConnectionCommand, "new connection")
 
-	tr.waitBlocks(action.chainA, 1, 10*time.Second)
-	tr.waitBlocks(action.chainB, 1, 10*time.Second)
+	tr.waitBlocks(action.ChainA, 1, 10*time.Second)
+	tr.waitBlocks(action.ChainB, 1, 10*time.Second)
 }
 
 type createIbcClientsAction struct {
-	chainA chainID
-	chainB chainID
+	ChainA ChainID
+	ChainB ChainID
 }
 
 // if clients are not provided hermes will first
@@ -966,10 +973,10 @@ func (tr TestRun) createIbcClientsHermes(
 	verbose bool,
 ) {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, "hermes",
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "hermes",
 		"create", "connection",
-		"--a-chain", string(tr.chainConfigs[action.chainA].chainId),
-		"--b-chain", string(tr.chainConfigs[action.chainB].chainId),
+		"--a-chain", string(tr.chainConfigs[action.ChainA].ChainId),
+		"--b-chain", string(tr.chainConfigs[action.ChainB].ChainId),
 	)
 
 	cmdReader, err := cmd.StdoutPipe()
@@ -1003,11 +1010,11 @@ func (tr TestRun) addIbcConnectionHermes(
 	verbose bool,
 ) {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, "hermes",
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "hermes",
 		"create", "connection",
-		"--a-chain", string(tr.chainConfigs[action.chainA].chainId),
-		"--a-client", "07-tendermint-"+fmt.Sprint(action.clientA),
-		"--b-client", "07-tendermint-"+fmt.Sprint(action.clientB),
+		"--a-chain", string(tr.chainConfigs[action.ChainA].ChainId),
+		"--a-client", "07-tendermint-"+fmt.Sprint(action.ClientA),
+		"--b-client", "07-tendermint-"+fmt.Sprint(action.ClientB),
 	)
 
 	cmdReader, err := cmd.StdoutPipe()
@@ -1037,13 +1044,13 @@ func (tr TestRun) addIbcConnectionHermes(
 }
 
 type addIbcChannelAction struct {
-	chainA      chainID
-	chainB      chainID
-	connectionA uint
-	portA       string
-	portB       string
-	order       string
-	version     string
+	ChainA      ChainID
+	ChainB      ChainID
+	ConnectionA uint
+	PortA       string
+	PortB       string
+	Order       string
+	Version     string
 }
 
 type startRelayerAction struct{}
@@ -1065,7 +1072,7 @@ func (tr TestRun) startGorelayer(
 ) {
 	// gorelayer start is running in detached mode
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", "-d", tr.containerConfig.instanceName, "rly",
+	cmd := exec.Command("docker", "exec", "-d", tr.containerConfig.InstanceName, "rly",
 		"start",
 	)
 
@@ -1084,7 +1091,7 @@ func (tr TestRun) startHermes(
 ) {
 	// hermes start is running in detached mode
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", "-d", tr.containerConfig.instanceName, "hermes",
+	cmd := exec.Command("docker", "exec", "-d", tr.containerConfig.InstanceName, "hermes",
 		"start",
 	)
 
@@ -1112,15 +1119,15 @@ func (tr TestRun) addIbcChannelGorelayer(
 	action addIbcChannelAction,
 	verbose bool,
 ) {
-	pathName := tr.GetPathNameForGorelayer(action.chainA, action.chainB)
+	pathName := tr.GetPathNameForGorelayer(action.ChainA, action.ChainB)
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, "rly",
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "rly",
 		"transact", "channel",
 		pathName,
-		"--src-port", action.portA,
-		"--dst-port", action.portB,
-		"--version", tr.containerConfig.ccvVersion,
-		"--order", action.order,
+		"--src-port", action.PortA,
+		"--dst-port", action.PortB,
+		"--version", tr.containerConfig.CcvVersion,
+		"--order", action.Order,
 		"--debug",
 	)
 	executeCommand(cmd, "addChannel")
@@ -1132,20 +1139,20 @@ func (tr TestRun) addIbcChannelHermes(
 ) {
 	// if version is not specified, use the default version when creating ccv connections
 	// otherwise, use the provided version schema (usually it is ICS20-1 for IBC transfer)
-	chanVersion := action.version
+	chanVersion := action.Version
 	if chanVersion == "" {
-		chanVersion = tr.containerConfig.ccvVersion
+		chanVersion = tr.containerConfig.CcvVersion
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, "hermes",
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "hermes",
 		"create", "channel",
-		"--a-chain", string(tr.chainConfigs[action.chainA].chainId),
-		"--a-connection", "connection-"+fmt.Sprint(action.connectionA),
-		"--a-port", action.portA,
-		"--b-port", action.portB,
+		"--a-chain", string(tr.chainConfigs[action.ChainA].ChainId),
+		"--a-connection", "connection-"+fmt.Sprint(action.ConnectionA),
+		"--a-port", action.PortA,
+		"--b-port", action.PortB,
 		"--channel-version", chanVersion,
-		"--order", action.order,
+		"--order", action.Order,
 	)
 
 	if verbose {
@@ -1179,14 +1186,14 @@ func (tr TestRun) addIbcChannelHermes(
 }
 
 type transferChannelCompleteAction struct {
-	chainA      chainID
-	chainB      chainID
-	connectionA uint
-	portA       string
-	portB       string
-	order       string
-	channelA    uint
-	channelB    uint
+	ChainA      ChainID
+	ChainB      ChainID
+	ConnectionA uint
+	PortA       string
+	PortB       string
+	Order       string
+	ChannelA    uint
+	ChannelB    uint
 }
 
 func (tr TestRun) transferChannelComplete(
@@ -1198,41 +1205,41 @@ func (tr TestRun) transferChannelComplete(
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with chanOpenTryCmd arguments.
-	chanOpenTryCmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, "hermes",
+	chanOpenTryCmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "hermes",
 		"tx", "chan-open-try",
-		"--dst-chain", string(tr.chainConfigs[action.chainB].chainId),
-		"--src-chain", string(tr.chainConfigs[action.chainA].chainId),
-		"--dst-connection", "connection-"+fmt.Sprint(action.connectionA),
-		"--dst-port", action.portB,
-		"--src-port", action.portA,
-		"--src-channel", "channel-"+fmt.Sprint(action.channelA),
+		"--dst-chain", string(tr.chainConfigs[action.ChainB].ChainId),
+		"--src-chain", string(tr.chainConfigs[action.ChainA].ChainId),
+		"--dst-connection", "connection-"+fmt.Sprint(action.ConnectionA),
+		"--dst-port", action.PortB,
+		"--src-port", action.PortA,
+		"--src-channel", "channel-"+fmt.Sprint(action.ChannelA),
 	)
 	executeCommand(chanOpenTryCmd, "transferChanOpenTry")
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with chanOpenAckCmd arguments.
-	chanOpenAckCmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, "hermes",
+	chanOpenAckCmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "hermes",
 		"tx", "chan-open-ack",
-		"--dst-chain", string(tr.chainConfigs[action.chainA].chainId),
-		"--src-chain", string(tr.chainConfigs[action.chainB].chainId),
-		"--dst-connection", "connection-"+fmt.Sprint(action.connectionA),
-		"--dst-port", action.portA,
-		"--src-port", action.portB,
-		"--dst-channel", "channel-"+fmt.Sprint(action.channelA),
-		"--src-channel", "channel-"+fmt.Sprint(action.channelB),
+		"--dst-chain", string(tr.chainConfigs[action.ChainA].ChainId),
+		"--src-chain", string(tr.chainConfigs[action.ChainB].ChainId),
+		"--dst-connection", "connection-"+fmt.Sprint(action.ConnectionA),
+		"--dst-port", action.PortA,
+		"--src-port", action.PortB,
+		"--dst-channel", "channel-"+fmt.Sprint(action.ChannelA),
+		"--src-channel", "channel-"+fmt.Sprint(action.ChannelB),
 	)
 
 	executeCommand(chanOpenAckCmd, "transferChanOpenAck")
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with chanOpenConfirmCmd arguments.
-	chanOpenConfirmCmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, "hermes",
+	chanOpenConfirmCmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "hermes",
 		"tx", "chan-open-confirm",
-		"--dst-chain", string(tr.chainConfigs[action.chainB].chainId),
-		"--src-chain", string(tr.chainConfigs[action.chainA].chainId),
-		"--dst-connection", "connection-"+fmt.Sprint(action.connectionA),
-		"--dst-port", action.portB,
-		"--src-port", action.portA,
-		"--dst-channel", "channel-"+fmt.Sprint(action.channelB),
-		"--src-channel", "channel-"+fmt.Sprint(action.channelA),
+		"--dst-chain", string(tr.chainConfigs[action.ChainB].ChainId),
+		"--src-chain", string(tr.chainConfigs[action.ChainA].ChainId),
+		"--dst-connection", "connection-"+fmt.Sprint(action.ConnectionA),
+		"--dst-port", action.PortB,
+		"--src-port", action.PortA,
+		"--dst-channel", "channel-"+fmt.Sprint(action.ChannelB),
+		"--src-channel", "channel-"+fmt.Sprint(action.ChannelA),
 	)
 	executeCommand(chanOpenConfirmCmd, "transferChanOpenConfirm")
 }
@@ -1271,10 +1278,10 @@ func executeCommand(cmd *exec.Cmd, cmdName string) {
 }
 
 type relayPacketsAction struct {
-	chainA  chainID
-	chainB  chainID
-	port    string
-	channel uint
+	ChainA  ChainID
+	ChainB  ChainID
+	Port    string
+	Channel uint
 }
 
 func (tr TestRun) relayPackets(
@@ -1292,13 +1299,13 @@ func (tr TestRun) relayPacketsGorelayer(
 	action relayPacketsAction,
 	verbose bool,
 ) {
-	pathName := tr.GetPathNameForGorelayer(action.chainA, action.chainB)
+	pathName := tr.GetPathNameForGorelayer(action.ChainA, action.ChainB)
 
 	// rly transact relay-packets [path-name] --channel [channel-id]
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, "rly", "transact", "flush",
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "rly", "transact", "flush",
 		pathName,
-		"channel-"+fmt.Sprint(action.channel),
+		"channel-"+fmt.Sprint(action.Channel),
 	)
 	if verbose {
 		log.Println("relayPackets cmd:", cmd.String())
@@ -1308,8 +1315,8 @@ func (tr TestRun) relayPacketsGorelayer(
 		log.Fatal(err, "\n", string(bz))
 	}
 
-	tr.waitBlocks(action.chainA, 1, 30*time.Second)
-	tr.waitBlocks(action.chainB, 1, 30*time.Second)
+	tr.waitBlocks(action.ChainA, 1, 30*time.Second)
+	tr.waitBlocks(action.ChainB, 1, 30*time.Second)
 }
 
 func (tr TestRun) relayPacketsHermes(
@@ -1318,10 +1325,10 @@ func (tr TestRun) relayPacketsHermes(
 ) {
 	// hermes clear packets ibc0 transfer channel-13
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, "hermes", "clear", "packets",
-		"--chain", string(tr.chainConfigs[action.chainA].chainId),
-		"--port", action.port,
-		"--channel", "channel-"+fmt.Sprint(action.channel),
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "hermes", "clear", "packets",
+		"--chain", string(tr.chainConfigs[action.ChainA].ChainId),
+		"--port", action.Port,
+		"--channel", "channel-"+fmt.Sprint(action.Channel),
 	)
 	if verbose {
 		log.Println("relayPackets cmd:", cmd.String())
@@ -1332,58 +1339,58 @@ func (tr TestRun) relayPacketsHermes(
 		log.Fatal(err, "\n", string(bz))
 	}
 
-	tr.waitBlocks(action.chainA, 1, 30*time.Second)
-	tr.waitBlocks(action.chainB, 1, 30*time.Second)
+	tr.waitBlocks(action.ChainA, 1, 30*time.Second)
+	tr.waitBlocks(action.ChainB, 1, 30*time.Second)
 }
 
 type relayRewardPacketsToProviderAction struct {
-	consumerChain chainID
-	providerChain chainID
-	port          string
-	channel       uint
+	ConsumerChain ChainID
+	ProviderChain ChainID
+	Port          string
+	Channel       uint
 }
 
 func (tr TestRun) relayRewardPacketsToProvider(
 	action relayRewardPacketsToProviderAction,
 	verbose bool,
 ) {
-	blockPerDistribution, _ := strconv.ParseUint(strings.Trim(tr.getParam(action.consumerChain, Param{Subspace: "ccvconsumer", Key: "BlocksPerDistributionTransmission"}), "\""), 10, 64)
-	currentBlock := uint64(tr.getBlockHeight(action.consumerChain))
+	blockPerDistribution, _ := strconv.ParseUint(strings.Trim(tr.getParam(action.ConsumerChain, Param{Subspace: "ccvconsumer", Key: "BlocksPerDistributionTransmission"}), "\""), 10, 64)
+	currentBlock := uint64(tr.getBlockHeight(action.ConsumerChain))
 	if currentBlock <= blockPerDistribution {
-		tr.waitBlocks(action.consumerChain, uint(blockPerDistribution-currentBlock+1), 60*time.Second)
+		tr.waitBlocks(action.ConsumerChain, uint(blockPerDistribution-currentBlock+1), 60*time.Second)
 	}
 
-	tr.relayPackets(relayPacketsAction{chainA: action.consumerChain, chainB: action.providerChain, port: action.port, channel: action.channel}, verbose)
-	tr.waitBlocks(action.providerChain, 1, 10*time.Second)
+	tr.relayPackets(relayPacketsAction{ChainA: action.ConsumerChain, ChainB: action.ProviderChain, Port: action.Port, Channel: action.Channel}, verbose)
+	tr.waitBlocks(action.ProviderChain, 1, 10*time.Second)
 }
 
 type delegateTokensAction struct {
-	chain  chainID
-	from   validatorID
-	to     validatorID
-	amount uint
+	Chain  ChainID
+	From   ValidatorID
+	To     ValidatorID
+	Amount uint
 }
 
 func (tr TestRun) delegateTokens(
 	action delegateTokensAction,
 	verbose bool,
 ) {
-	toValCfg := tr.validatorConfigs[action.to]
-	delegateAddr := toValCfg.valoperAddress
-	if action.chain != chainID("provi") && toValCfg.useConsumerKey {
-		delegateAddr = toValCfg.consumerValoperAddress
+	toValCfg := tr.validatorConfigs[action.To]
+	delegateAddr := toValCfg.ValoperAddress
+	if action.Chain != ChainID("provi") && toValCfg.UseConsumerKey {
+		delegateAddr = toValCfg.ConsumerValoperAddress
 	}
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[action.chain].binaryName,
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[action.Chain].BinaryName,
 
 		"tx", "staking", "delegate",
 		delegateAddr,
-		fmt.Sprint(action.amount)+`stake`,
+		fmt.Sprint(action.Amount)+`stake`,
 
-		`--from`, `validator`+fmt.Sprint(action.from),
-		`--chain-id`, string(tr.chainConfigs[action.chain].chainId),
-		`--home`, tr.getValidatorHome(action.chain, action.from),
-		`--node`, tr.getValidatorNode(action.chain, action.from),
+		`--from`, `validator`+fmt.Sprint(action.From),
+		`--chain-id`, string(tr.chainConfigs[action.Chain].ChainId),
+		`--home`, tr.getValidatorHome(action.Chain, action.From),
+		`--node`, tr.getValidatorNode(action.Chain, action.From),
 		`--keyring-backend`, `test`,
 		`-y`,
 	)
@@ -1398,36 +1405,36 @@ func (tr TestRun) delegateTokens(
 	}
 
 	// wait for inclusion in a block -> '--broadcast-mode block' is deprecated
-	tr.waitBlocks(action.chain, 2, 10*time.Second)
+	tr.waitBlocks(action.Chain, 2, 10*time.Second)
 }
 
 type unbondTokensAction struct {
-	chain      chainID
-	sender     validatorID
-	unbondFrom validatorID
-	amount     uint
+	Chain      ChainID
+	Sender     ValidatorID
+	UnbondFrom ValidatorID
+	Amount     uint
 }
 
 func (tr TestRun) unbondTokens(
 	action unbondTokensAction,
 	verbose bool,
 ) {
-	unbondFrom := tr.validatorConfigs[action.unbondFrom].valoperAddress
-	if tr.validatorConfigs[action.unbondFrom].useConsumerKey {
-		unbondFrom = tr.validatorConfigs[action.unbondFrom].consumerValoperAddress
+	unbondFrom := tr.validatorConfigs[action.UnbondFrom].ValoperAddress
+	if tr.validatorConfigs[action.UnbondFrom].UseConsumerKey {
+		unbondFrom = tr.validatorConfigs[action.UnbondFrom].ConsumerValoperAddress
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[action.chain].binaryName,
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[action.Chain].BinaryName,
 
 		"tx", "staking", "unbond",
 		unbondFrom,
-		fmt.Sprint(action.amount)+`stake`,
+		fmt.Sprint(action.Amount)+`stake`,
 
-		`--from`, `validator`+fmt.Sprint(action.sender),
-		`--chain-id`, string(tr.chainConfigs[action.chain].chainId),
-		`--home`, tr.getValidatorHome(action.chain, action.sender),
-		`--node`, tr.getValidatorNode(action.chain, action.sender),
+		`--from`, `validator`+fmt.Sprint(action.Sender),
+		`--chain-id`, string(tr.chainConfigs[action.Chain].ChainId),
+		`--home`, tr.getValidatorHome(action.Chain, action.Sender),
+		`--node`, tr.getValidatorNode(action.Chain, action.Sender),
 		`--gas`, "900000",
 		`--keyring-backend`, `test`,
 		`-y`,
@@ -1443,33 +1450,33 @@ func (tr TestRun) unbondTokens(
 	}
 
 	// wait for inclusion in a block -> '--broadcast-mode block' is deprecated
-	tr.waitBlocks(action.chain, 2, 20*time.Second)
+	tr.waitBlocks(action.Chain, 2, 20*time.Second)
 }
 
 type cancelUnbondTokensAction struct {
-	chain     chainID
-	delegator validatorID
-	validator validatorID
-	amount    uint
+	Chain     ChainID
+	Delegator ValidatorID
+	Validator ValidatorID
+	Amount    uint
 }
 
 func (tr TestRun) cancelUnbondTokens(
 	action cancelUnbondTokensAction,
 	verbose bool,
 ) {
-	validator := tr.validatorConfigs[action.validator].valoperAddress
-	if tr.validatorConfigs[action.validator].useConsumerKey {
-		validator = tr.validatorConfigs[action.validator].consumerValoperAddress
+	validator := tr.validatorConfigs[action.Validator].ValoperAddress
+	if tr.validatorConfigs[action.Validator].UseConsumerKey {
+		validator = tr.validatorConfigs[action.Validator].ConsumerValoperAddress
 	}
 
 	// get creation-height from state
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[action.chain].binaryName,
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[action.Chain].BinaryName,
 		"q", "staking", "unbonding-delegation",
-		tr.validatorConfigs[action.delegator].delAddress,
+		tr.validatorConfigs[action.Delegator].DelAddress,
 		validator,
-		`--home`, tr.getValidatorHome(action.chain, action.delegator),
-		`--node`, tr.getValidatorNode(action.chain, action.delegator),
+		`--home`, tr.getValidatorHome(action.Chain, action.Delegator),
+		`--node`, tr.getValidatorNode(action.Chain, action.Delegator),
 		`-o`, `json`,
 	)
 	if verbose {
@@ -1486,15 +1493,15 @@ func (tr TestRun) cancelUnbondTokens(
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd = exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[action.chain].binaryName,
+	cmd = exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[action.Chain].BinaryName,
 		"tx", "staking", "cancel-unbond",
 		validator,
-		fmt.Sprint(action.amount)+`stake`,
+		fmt.Sprint(action.Amount)+`stake`,
 		fmt.Sprint(creationHeight),
-		`--from`, `validator`+fmt.Sprint(action.delegator),
-		`--chain-id`, string(tr.chainConfigs[action.chain].chainId),
-		`--home`, tr.getValidatorHome(action.chain, action.delegator),
-		`--node`, tr.getValidatorNode(action.chain, action.delegator),
+		`--from`, `validator`+fmt.Sprint(action.Delegator),
+		`--chain-id`, string(tr.chainConfigs[action.Chain].ChainId),
+		`--home`, tr.getValidatorHome(action.Chain, action.Delegator),
+		`--node`, tr.getValidatorNode(action.Chain, action.Delegator),
 		`--gas`, "900000",
 		`--keyring-backend`, `test`,
 		`-o`, `json`,
@@ -1511,43 +1518,43 @@ func (tr TestRun) cancelUnbondTokens(
 	}
 
 	// wait for inclusion in a block -> '--broadcast-mode block' is deprecated
-	tr.waitBlocks(action.chain, 2, 20*time.Second)
+	tr.waitBlocks(action.Chain, 2, 20*time.Second)
 }
 
 type redelegateTokensAction struct {
-	chain    chainID
-	src      validatorID
-	dst      validatorID
-	txSender validatorID
-	amount   uint
+	Chain    ChainID
+	Src      ValidatorID
+	Dst      ValidatorID
+	TxSender ValidatorID
+	Amount   uint
 }
 
 func (tr TestRun) redelegateTokens(action redelegateTokensAction, verbose bool) {
-	srcCfg := tr.validatorConfigs[action.src]
-	dstCfg := tr.validatorConfigs[action.dst]
+	srcCfg := tr.validatorConfigs[action.Src]
+	dstCfg := tr.validatorConfigs[action.Dst]
 
-	redelegateSrc := srcCfg.valoperAddress
-	if action.chain != chainID("provi") && srcCfg.useConsumerKey {
-		redelegateSrc = srcCfg.consumerValoperAddress
+	redelegateSrc := srcCfg.ValoperAddress
+	if action.Chain != ChainID("provi") && srcCfg.UseConsumerKey {
+		redelegateSrc = srcCfg.ConsumerValoperAddress
 	}
 
-	redelegateDst := dstCfg.valoperAddress
-	if action.chain != chainID("provi") && dstCfg.useConsumerKey {
-		redelegateDst = dstCfg.consumerValoperAddress
+	redelegateDst := dstCfg.ValoperAddress
+	if action.Chain != ChainID("provi") && dstCfg.UseConsumerKey {
+		redelegateDst = dstCfg.ConsumerValoperAddress
 	}
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	cmd := exec.Command("docker", "exec",
-		tr.containerConfig.instanceName,
-		tr.chainConfigs[action.chain].binaryName,
+		tr.containerConfig.InstanceName,
+		tr.chainConfigs[action.Chain].BinaryName,
 
 		"tx", "staking", "redelegate",
 		redelegateSrc,
 		redelegateDst,
-		fmt.Sprint(action.amount)+`stake`,
-		`--from`, `validator`+fmt.Sprint(action.txSender),
-		`--chain-id`, string(tr.chainConfigs[action.chain].chainId),
-		`--home`, tr.getValidatorHome(action.chain, action.txSender),
-		`--node`, tr.getValidatorNode(action.chain, action.txSender),
+		fmt.Sprint(action.Amount)+`stake`,
+		`--from`, `validator`+fmt.Sprint(action.TxSender),
+		`--chain-id`, string(tr.chainConfigs[action.Chain].ChainId),
+		`--home`, tr.getValidatorHome(action.Chain, action.TxSender),
+		`--node`, tr.getValidatorNode(action.Chain, action.TxSender),
 		// Need to manually set gas limit past default (200000), since redelegate has a lot of operations
 		`--gas`, "900000",
 		`--keyring-backend`, `test`,
@@ -1564,12 +1571,12 @@ func (tr TestRun) redelegateTokens(action redelegateTokensAction, verbose bool) 
 	}
 
 	// wait for inclusion in a block -> '--broadcast-mode block' is deprecated
-	tr.waitBlocks(action.chain, 2, 10*time.Second)
+	tr.waitBlocks(action.Chain, 2, 10*time.Second)
 }
 
 type downtimeSlashAction struct {
-	chain     chainID
-	validator validatorID
+	Chain     ChainID
+	Validator ValidatorID
 }
 
 // takes a string representation of the private key like
@@ -1588,15 +1595,15 @@ func (tr TestRun) getValidatorKeyAddressFromString(keystring string) string {
 
 func (tr TestRun) invokeDowntimeSlash(action downtimeSlashAction, verbose bool) {
 	// Bring validator down
-	tr.setValidatorDowntime(action.chain, action.validator, true, verbose)
+	tr.setValidatorDowntime(action.Chain, action.Validator, true, verbose)
 	// Wait appropriate amount of blocks for validator to be slashed
-	tr.waitBlocks(action.chain, 10, 3*time.Minute)
+	tr.waitBlocks(action.Chain, 10, 3*time.Minute)
 	// Bring validator back up
-	tr.setValidatorDowntime(action.chain, action.validator, false, verbose)
+	tr.setValidatorDowntime(action.Chain, action.Validator, false, verbose)
 }
 
 // Sets validator downtime by setting the virtual ethernet interface of a node to "up" or "down"
-func (tr TestRun) setValidatorDowntime(chain chainID, validator validatorID, down, verbose bool) {
+func (tr TestRun) setValidatorDowntime(chain ChainID, validator ValidatorID, down, verbose bool) {
 	var lastArg string
 	if down {
 		lastArg = "down"
@@ -1621,7 +1628,7 @@ func (tr TestRun) setValidatorDowntime(chain chainID, validator validatorID, dow
 	cmd := exec.Command(
 		"docker",
 		"exec",
-		tr.containerConfig.instanceName,
+		tr.containerConfig.InstanceName,
 		"ip",
 		"link",
 		"set",
@@ -1639,16 +1646,16 @@ func (tr TestRun) setValidatorDowntime(chain chainID, validator validatorID, dow
 	}
 }
 
-func (tr TestRun) GetValidatorPrivateKeyAddress(chain chainID, validator validatorID) string {
+func (tr TestRun) GetValidatorPrivateKeyAddress(chain ChainID, validator ValidatorID) string {
 	var validatorPrivateKeyAddress string
-	if chain == chainID("provi") {
-		validatorPrivateKeyAddress = tr.getValidatorKeyAddressFromString(tr.validatorConfigs[validator].privValidatorKey)
+	if chain == ChainID("provi") {
+		validatorPrivateKeyAddress = tr.getValidatorKeyAddressFromString(tr.validatorConfigs[validator].PrivValidatorKey)
 	} else {
 		var valAddressString string
-		if tr.validatorConfigs[validator].useConsumerKey {
-			valAddressString = tr.validatorConfigs[validator].consumerPrivValidatorKey
+		if tr.validatorConfigs[validator].UseConsumerKey {
+			valAddressString = tr.validatorConfigs[validator].ConsumerPrivValidatorKey
 		} else {
-			valAddressString = tr.validatorConfigs[validator].privValidatorKey
+			valAddressString = tr.validatorConfigs[validator].PrivValidatorKey
 		}
 		validatorPrivateKeyAddress = tr.getValidatorKeyAddressFromString(valAddressString)
 	}
@@ -1656,8 +1663,8 @@ func (tr TestRun) GetValidatorPrivateKeyAddress(chain chainID, validator validat
 }
 
 type unjailValidatorAction struct {
-	provider  chainID
-	validator validatorID
+	Provider  ChainID
+	Validator ValidatorID
 }
 
 // Sends an unjail transaction to the provider chain
@@ -1667,14 +1674,14 @@ func (tr TestRun) unjailValidator(action unjailValidatorAction, verbose bool) {
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	cmd := exec.Command("docker", "exec",
-		tr.containerConfig.instanceName,
-		tr.chainConfigs[action.provider].binaryName,
+		tr.containerConfig.InstanceName,
+		tr.chainConfigs[action.Provider].BinaryName,
 		"tx", "slashing", "unjail",
 		// Validator is sender here
-		`--from`, `validator`+fmt.Sprint(action.validator),
-		`--chain-id`, string(tr.chainConfigs[action.provider].chainId),
-		`--home`, tr.getValidatorHome(action.provider, action.validator),
-		`--node`, tr.getValidatorNode(action.provider, action.validator),
+		`--from`, `validator`+fmt.Sprint(action.Validator),
+		`--chain-id`, string(tr.chainConfigs[action.Provider].ChainId),
+		`--home`, tr.getValidatorHome(action.Provider, action.Validator),
+		`--node`, tr.getValidatorNode(action.Provider, action.Validator),
 		`--gas`, "900000",
 		`--keyring-backend`, `test`,
 		`-y`,
@@ -1691,13 +1698,13 @@ func (tr TestRun) unjailValidator(action unjailValidatorAction, verbose bool) {
 
 	// wait for 1 blocks to make sure that tx got included
 	// in a block and packets committed before proceeding
-	tr.waitBlocks(action.provider, 2, time.Minute)
+	tr.waitBlocks(action.Provider, 2, time.Minute)
 }
 
 type registerRepresentativeAction struct {
-	chain           chainID
-	representatives []validatorID
-	stakes          []uint
+	Chain           ChainID
+	Representatives []ValidatorID
+	Stakes          []uint
 }
 
 func (tr TestRun) registerRepresentative(
@@ -1705,16 +1712,16 @@ func (tr TestRun) registerRepresentative(
 	verbose bool,
 ) {
 	var wg sync.WaitGroup
-	for i, val := range action.representatives {
+	for i, val := range action.Representatives {
 		wg.Add(1)
-		stake := action.stakes[i]
-		go func(val validatorID, stake uint) {
+		stake := action.Stakes[i]
+		go func(val ValidatorID, stake uint) {
 			defer wg.Done()
 
 			//#nosec G204 -- Bypass linter warning for spawning subprocess with pubKeycmd arguments.
-			pubKeycmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[action.chain].binaryName,
+			pubKeycmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[action.Chain].BinaryName,
 				"tendermint", "show-validator",
-				`--home`, tr.getValidatorHome(action.chain, val),
+				`--home`, tr.getValidatorHome(action.Chain, val),
 			)
 
 			bzPubKey, err := pubKeycmd.CombinedOutput()
@@ -1723,7 +1730,7 @@ func (tr TestRun) registerRepresentative(
 			}
 
 			//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-			bz, err := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[action.chain].binaryName,
+			bz, err := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[action.Chain].BinaryName,
 				"tx", "staking", "create-validator",
 				`--amount`, fmt.Sprint(stake)+"stake",
 				`--pubkey`, string(bzPubKey),
@@ -1733,9 +1740,9 @@ func (tr TestRun) registerRepresentative(
 				`--commission-max-change-rate`, "0.01",
 				`--min-self-delegation`, "1",
 				`--from`, `validator`+fmt.Sprint(val),
-				`--chain-id`, string(tr.chainConfigs[action.chain].chainId),
-				`--home`, tr.getValidatorHome(action.chain, val),
-				`--node`, tr.getValidatorNode(action.chain, val),
+				`--chain-id`, string(tr.chainConfigs[action.Chain].ChainId),
+				`--home`, tr.getValidatorHome(action.Chain, val),
+				`--node`, tr.getValidatorNode(action.Chain, val),
 				`--keyring-backend`, `test`,
 				`-y`,
 			).CombinedOutput()
@@ -1744,7 +1751,7 @@ func (tr TestRun) registerRepresentative(
 			}
 
 			// wait for inclusion in a block -> '--broadcast-mode block' is deprecated
-			tr.waitBlocks(action.chain, 1, 10*time.Second)
+			tr.waitBlocks(action.Chain, 1, 10*time.Second)
 		}(val, stake)
 	}
 
@@ -1752,23 +1759,23 @@ func (tr TestRun) registerRepresentative(
 }
 
 type submitChangeRewardDenomsProposalAction struct {
-	denom   string
-	deposit uint
-	from    validatorID
+	Denom   string
+	Deposit uint
+	From    ValidatorID
 }
 
 func (tr TestRun) submitChangeRewardDenomsProposal(action submitChangeRewardDenomsProposalAction, verbose bool) {
-	providerChain := tr.chainConfigs[chainID("provi")]
+	providerChain := tr.chainConfigs[ChainID("provi")]
 
 	prop := client.ChangeRewardDenomsProposalJSON{
 		Summary: "Change reward denoms",
 		ChangeRewardDenomsProposal: types.ChangeRewardDenomsProposal{
 			Title:          "Change reward denoms",
 			Description:    "Change reward denoms",
-			DenomsToAdd:    []string{action.denom},
+			DenomsToAdd:    []string{action.Denom},
 			DenomsToRemove: []string{"stake"},
 		},
-		Deposit: fmt.Sprint(action.deposit) + `stake`,
+		Deposit: fmt.Sprint(action.Deposit) + `stake`,
 	}
 
 	bz, err := json.Marshal(prop)
@@ -1782,7 +1789,7 @@ func (tr TestRun) submitChangeRewardDenomsProposal(action submitChangeRewardDeno
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err = exec.Command("docker", "exec", tr.containerConfig.instanceName,
+	bz, err = exec.Command("docker", "exec", tr.containerConfig.InstanceName,
 		"/bin/bash", "-c", fmt.Sprintf(`echo '%s' > %s`, jsonStr, "/change-reward-denoms-proposal.json")).CombinedOutput()
 
 	if err != nil {
@@ -1791,12 +1798,12 @@ func (tr TestRun) submitChangeRewardDenomsProposal(action submitChangeRewardDeno
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	// CHANGE REWARDS DENOM PROPOSAL
-	bz, err = exec.Command("docker", "exec", tr.containerConfig.instanceName, providerChain.binaryName,
+	bz, err = exec.Command("docker", "exec", tr.containerConfig.InstanceName, providerChain.BinaryName,
 		"tx", "gov", "submit-legacy-proposal", "change-reward-denoms", "/change-reward-denoms-proposal.json",
-		`--from`, `validator`+fmt.Sprint(action.from),
-		`--chain-id`, string(providerChain.chainId),
-		`--home`, tr.getValidatorHome(providerChain.chainId, action.from),
-		`--node`, tr.getValidatorNode(providerChain.chainId, action.from),
+		`--from`, `validator`+fmt.Sprint(action.From),
+		`--chain-id`, string(providerChain.ChainId),
+		`--home`, tr.getValidatorHome(providerChain.ChainId, action.From),
+		`--node`, tr.getValidatorNode(providerChain.ChainId, action.From),
 		`--gas`, "9000000",
 		`--keyring-backend`, `test`,
 		`-y`,
@@ -1807,7 +1814,7 @@ func (tr TestRun) submitChangeRewardDenomsProposal(action submitChangeRewardDeno
 	}
 
 	// wait for inclusion in a block -> '--broadcast-mode block' is deprecated
-	tr.waitBlocks(chainID("provi"), 2, 30*time.Second)
+	tr.waitBlocks(ChainID("provi"), 2, 30*time.Second)
 }
 
 // Creates an additional node on selected chain
@@ -1821,9 +1828,9 @@ func (tr TestRun) submitChangeRewardDenomsProposal(action submitChangeRewardDeno
 // - start the new node
 // Double sign should be registered within couple blocks.
 type doublesignSlashAction struct {
-	// start another node for this validator
-	validator validatorID
-	chain     chainID
+	// start another node for this Validator
+	Validator ValidatorID
+	Chain     ChainID
 }
 
 func (tr TestRun) invokeDoublesignSlash(
@@ -1831,25 +1838,25 @@ func (tr TestRun) invokeDoublesignSlash(
 	verbose bool,
 ) {
 	if !tr.useCometmock {
-		chainConfig := tr.chainConfigs[action.chain]
+		chainConfig := tr.chainConfigs[action.Chain]
 		//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-		bz, err := exec.Command("docker", "exec", tr.containerConfig.instanceName, "/bin/bash",
-			"/testnet-scripts/cause-doublesign.sh", chainConfig.binaryName, string(action.validator),
-			string(chainConfig.chainId), chainConfig.ipPrefix).CombinedOutput()
+		bz, err := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "/bin/bash",
+			"/testnet-scripts/cause-doublesign.sh", chainConfig.BinaryName, string(action.Validator),
+			string(chainConfig.ChainId), chainConfig.IpPrefix).CombinedOutput()
 		if err != nil {
 			log.Fatal(err, "\n", string(bz))
 		}
 		tr.waitBlocks("provi", 10, 2*time.Minute)
 	} else { // tr.useCometMock
-		validatorPrivateKeyAddress := tr.GetValidatorPrivateKeyAddress(action.chain, action.validator)
+		validatorPrivateKeyAddress := tr.GetValidatorPrivateKeyAddress(action.Chain, action.Validator)
 
 		method := "cause_double_sign"
 		params := fmt.Sprintf(`{"private_key_address":"%s"}`, validatorPrivateKeyAddress)
 
-		address := tr.getQueryNodeRPCAddress(action.chain)
+		address := tr.getQueryNodeRPCAddress(action.Chain)
 
 		tr.curlJsonRPCRequest(method, params, address)
-		tr.waitBlocks(action.chain, 1, 10*time.Second)
+		tr.waitBlocks(action.Chain, 1, 10*time.Second)
 		return
 	}
 }
@@ -1859,15 +1866,15 @@ func (tr TestRun) invokeDoublesignSlash(
 // See https://github.com/cometbft/cometbft/tree/main/spec/light-client/accountability
 // for more information about light client attacks.
 type lightClientEquivocationAttackAction struct {
-	validator validatorID
-	chain     chainID
+	Validator ValidatorID
+	Chain     ChainID
 }
 
 func (tr TestRun) lightClientEquivocationAttack(
 	action lightClientEquivocationAttackAction,
 	verbose bool,
 ) {
-	tr.lightClientAttack(action.validator, action.chain, LightClientEquivocationAttack)
+	tr.lightClientAttack(action.Validator, action.Chain, LightClientEquivocationAttack)
 }
 
 // Cause light client attack evidence for a certain validator to appear on the given chain.
@@ -1875,15 +1882,15 @@ func (tr TestRun) lightClientEquivocationAttack(
 // See https://github.com/cometbft/cometbft/tree/main/spec/light-client/accountability
 // for more information about light client attacks.
 type lightClientAmnesiaAttackAction struct {
-	validator validatorID
-	chain     chainID
+	Validator ValidatorID
+	Chain     ChainID
 }
 
 func (tr TestRun) lightClientAmnesiaAttack(
 	action lightClientAmnesiaAttackAction,
 	verbose bool,
 ) {
-	tr.lightClientAttack(action.validator, action.chain, LightClientAmnesiaAttack)
+	tr.lightClientAttack(action.Validator, action.Chain, LightClientAmnesiaAttack)
 }
 
 // Cause light client attack evidence for a certain validator to appear on the given chain.
@@ -1891,15 +1898,15 @@ func (tr TestRun) lightClientAmnesiaAttack(
 // See https://github.com/cometbft/cometbft/tree/main/spec/light-client/accountability
 // for more information about light client attacks.
 type lightClientLunaticAttackAction struct {
-	validator validatorID
-	chain     chainID
+	Validator ValidatorID
+	Chain     ChainID
 }
 
 func (tr TestRun) lightClientLunaticAttack(
 	action lightClientLunaticAttackAction,
 	verbose bool,
 ) {
-	tr.lightClientAttack(action.validator, action.chain, LightClientLunaticAttack)
+	tr.lightClientAttack(action.Validator, action.Chain, LightClientLunaticAttack)
 }
 
 type LightClientAttackType string
@@ -1911,8 +1918,8 @@ const (
 )
 
 func (tr TestRun) lightClientAttack(
-	validator validatorID,
-	chain chainID,
+	validator ValidatorID,
+	chain ChainID,
 	attackType LightClientAttackType,
 ) {
 	if !tr.useCometmock {
@@ -1930,18 +1937,18 @@ func (tr TestRun) lightClientAttack(
 }
 
 type assignConsumerPubKeyAction struct {
-	chain          chainID
-	validator      validatorID
-	consumerPubkey string
-	// reconfigureNode will change keys the node uses and restart
-	reconfigureNode bool
+	Chain          ChainID
+	Validator      ValidatorID
+	ConsumerPubkey string
+	// ReconfigureNode will change keys the node uses and restart
+	ReconfigureNode bool
 	// executing the action should raise an error
-	expectError   bool
-	expectedError string
+	ExpectError   bool
+	ExpectedError string
 }
 
 func (tr TestRun) assignConsumerPubKey(action assignConsumerPubKeyAction, verbose bool) {
-	valCfg := tr.validatorConfigs[action.validator]
+	valCfg := tr.validatorConfigs[action.Validator]
 
 	// Note: to get error response reported back from this command '--gas auto' needs to be set.
 	gas := "auto"
@@ -1951,19 +1958,19 @@ func (tr TestRun) assignConsumerPubKey(action assignConsumerPubKeyAction, verbos
 	}
 	assignKey := fmt.Sprintf(
 		`%s tx provider assign-consensus-key %s '%s' --from validator%s --chain-id %s --home %s --node %s --gas %s --keyring-backend test -y -o json`,
-		tr.chainConfigs[chainID("provi")].binaryName,
-		string(tr.chainConfigs[action.chain].chainId),
-		action.consumerPubkey,
-		action.validator,
-		tr.chainConfigs[chainID("provi")].chainId,
-		tr.getValidatorHome(chainID("provi"), action.validator),
-		tr.getValidatorNode(chainID("provi"), action.validator),
+		tr.chainConfigs[ChainID("provi")].BinaryName,
+		string(tr.chainConfigs[action.Chain].ChainId),
+		action.ConsumerPubkey,
+		action.Validator,
+		tr.chainConfigs[ChainID("provi")].ChainId,
+		tr.getValidatorHome(ChainID("provi"), action.Validator),
+		tr.getValidatorNode(ChainID("provi"), action.Validator),
 		gas,
 	)
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	cmd := exec.Command("docker", "exec",
-		tr.containerConfig.instanceName,
+		tr.containerConfig.InstanceName,
 		"/bin/bash", "-c",
 		assignKey,
 	)
@@ -1973,13 +1980,13 @@ func (tr TestRun) assignConsumerPubKey(action assignConsumerPubKeyAction, verbos
 	}
 
 	bz, err := cmd.CombinedOutput()
-	if err != nil && !action.expectError {
+	if err != nil && !action.ExpectError {
 		log.Fatalf("unexpected error during key assignment - output: %s, err: %s", string(bz), err)
 	}
 
-	if action.expectError && !tr.useCometmock { // error report ony works with --gas auto, which does not work with CometMock, so ignore
-		if err == nil || !strings.Contains(string(bz), action.expectedError) {
-			log.Fatalf("expected error not raised: expected: '%s', got '%s'", action.expectedError, (bz))
+	if action.ExpectError && !tr.useCometmock { // error report ony works with --gas auto, which does not work with CometMock, so ignore
+		if err == nil || !strings.Contains(string(bz), action.ExpectedError) {
+			log.Fatalf("expected error not raised: expected: '%s', got '%s'", action.ExpectedError, (bz))
 		}
 
 		if verbose {
@@ -1989,14 +1996,14 @@ func (tr TestRun) assignConsumerPubKey(action assignConsumerPubKeyAction, verbos
 
 	// node was started with provider key
 	// we swap the nodes's keys for consumer keys and restart it
-	if action.reconfigureNode {
+	if action.ReconfigureNode {
 		//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-		configureNodeCmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, "/bin/bash",
-			"/testnet-scripts/reconfigure-node.sh", tr.chainConfigs[action.chain].binaryName,
-			string(action.validator), string(action.chain),
-			tr.chainConfigs[action.chain].ipPrefix, valCfg.ipSuffix,
-			valCfg.consumerMnemonic, valCfg.consumerPrivValidatorKey,
-			valCfg.consumerNodeKey,
+		configureNodeCmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "/bin/bash",
+			"/testnet-scripts/reconfigure-node.sh", tr.chainConfigs[action.Chain].BinaryName,
+			string(action.Validator), string(action.Chain),
+			tr.chainConfigs[action.Chain].IpPrefix, valCfg.IpSuffix,
+			valCfg.ConsumerMnemonic, valCfg.ConsumerPrivValidatorKey,
+			valCfg.ConsumerNodeKey,
 		)
 
 		if verbose {
@@ -2032,54 +2039,54 @@ func (tr TestRun) assignConsumerPubKey(action assignConsumerPubKeyAction, verbos
 		// make the validator use consumer key
 		// @POfftermatt I am currently using this for downtime slashing with cometmock
 		// (I need to find the currently used validator key address)Í
-		valCfg.useConsumerKey = true
-		tr.validatorConfigs[action.validator] = valCfg
+		valCfg.UseConsumerKey = true
+		tr.validatorConfigs[action.Validator] = valCfg
 	}
 
 	// wait for inclusion in a block -> '--broadcast-mode block' is deprecated
-	tr.waitBlocks(chainID("provi"), 2, 30*time.Second)
+	tr.waitBlocks(ChainID("provi"), 2, 30*time.Second)
 }
 
 // slashThrottleDequeue polls slash queue sizes until nextQueueSize is achieved
 type slashThrottleDequeue struct {
-	chain            chainID
-	currentQueueSize int
-	nextQueueSize    int
-	// panic if timeout is exceeded
-	timeout time.Duration
+	Chain            ChainID
+	CurrentQueueSize int
+	NextQueueSize    int
+	// panic if Timeout is exceeded
+	Timeout time.Duration
 }
 
 func (tr TestRun) waitForSlashThrottleDequeue(
 	action slashThrottleDequeue,
 	verbose bool,
 ) {
-	timeout := time.Now().Add(action.timeout)
+	timeout := time.Now().Add(action.Timeout)
 	initialGlobalQueueSize := int(tr.getGlobalSlashQueueSize())
 
-	if initialGlobalQueueSize != action.currentQueueSize {
-		panic(fmt.Sprintf("wrong initial queue size: %d - expected global queue: %d\n", initialGlobalQueueSize, action.currentQueueSize))
+	if initialGlobalQueueSize != action.CurrentQueueSize {
+		panic(fmt.Sprintf("wrong initial queue size: %d - expected global queue: %d\n", initialGlobalQueueSize, action.CurrentQueueSize))
 	}
 	for {
 		globalQueueSize := int(tr.getGlobalSlashQueueSize())
-		chainQueueSize := int(tr.getConsumerChainPacketQueueSize(action.chain))
+		chainQueueSize := int(tr.getConsumerChainPacketQueueSize(action.Chain))
 		if verbose {
-			fmt.Printf("waiting for packed queue size to reach: %d - current: %d\n", action.nextQueueSize, globalQueueSize)
+			fmt.Printf("waiting for packed queue size to reach: %d - current: %d\n", action.NextQueueSize, globalQueueSize)
 		}
 
 		// check if global queue size is equal to chain queue size
-		if globalQueueSize == chainQueueSize && globalQueueSize == action.nextQueueSize { //nolint:gocritic // this is the comparison that we want here.
+		if globalQueueSize == chainQueueSize && globalQueueSize == action.NextQueueSize { //nolint:gocritic // this is the comparison that we want here.
 			break
 		}
 
 		if time.Now().After(timeout) {
-			panic(fmt.Sprintf("\n\n\nwaitForSlashThrottleDequeuemethod has timed out after: %s\n\n", action.timeout))
+			panic(fmt.Sprintf("\n\n\nwaitForSlashThrottleDequeuemethod has timed out after: %s\n\n", action.Timeout))
 		}
 
 		time.Sleep(500 * time.Millisecond)
 	}
 	// wair for 2 blocks to be created
 	// allowing the jailing to be incorporated into voting power
-	tr.waitBlocks(action.chain, 2, time.Minute)
+	tr.waitBlocks(action.Chain, 2, time.Minute)
 }
 
 func uintPointer(i uint) *uint {
@@ -2089,7 +2096,7 @@ func uintPointer(i uint) *uint {
 // GetPathNameForGorelayer returns the name of the path between two given chains used by Gorelayer.
 // Since paths are bidirectional, we need either chain to be able to be provided as first or second argument
 // and still return the same name, so we sort the chain names alphabetically.
-func (tr TestRun) GetPathNameForGorelayer(chainA, chainB chainID) string {
+func (tr TestRun) GetPathNameForGorelayer(chainA, chainB ChainID) string {
 	var pathName string
 	if string(chainA) < string(chainB) {
 		pathName = string(chainA) + "-" + string(chainB)
@@ -2121,7 +2128,7 @@ func (tr *TestRun) WaitTime(duration time.Duration) {
 	}
 }
 
-func (tr TestRun) AdvanceTimeForChain(chain chainID, duration time.Duration) {
+func (tr TestRun) AdvanceTimeForChain(chain ChainID, duration time.Duration) {
 	// cometmock avoids sleeping, and instead advances time for all chains
 	method := "advance_time"
 	params := fmt.Sprintf(`{"duration_in_seconds": "%d"}`, int(math.Ceil(duration.Seconds())))

--- a/tests/e2e/actions.go
+++ b/tests/e2e/actions.go
@@ -189,7 +189,6 @@ type submitTextProposalAction struct {
 	Chain       ChainID
 	From        ValidatorID
 	Deposit     uint
-	PropType    string
 	Title       string
 	Description string
 }
@@ -204,7 +203,6 @@ func (tr TestRun) submitTextProposal(
 		"tx", "gov", "submit-legacy-proposal",
 		`--title`, action.Title,
 		`--description`, action.Description,
-		`--type`, action.PropType,
 		`--deposit`, fmt.Sprint(action.Deposit)+`stake`,
 		`--from`, `validator`+fmt.Sprint(action.From),
 		`--chain-id`, string(tr.chainConfigs[action.Chain].ChainId),

--- a/tests/e2e/actions_sovereign_chain.go
+++ b/tests/e2e/actions_sovereign_chain.go
@@ -10,10 +10,10 @@ import (
 )
 
 type StartSovereignChainAction struct {
-	chain      chainID
-	validators []StartChainValidator
+	Chain      ChainID
+	Validators []StartChainValidator
 	// Genesis changes specific to this action, appended to genesis changes defined in chain config
-	genesisChanges string
+	GenesisChanges string
 }
 
 // calls a simplified startup script (start-sovereign.sh) and runs a validator node
@@ -38,20 +38,20 @@ func (tr TestRun) startSovereignChain(
 	}
 
 	var validators []jsonValAttrs
-	for _, val := range action.validators {
+	for _, val := range action.Validators {
 		validators = append(validators, jsonValAttrs{
-			Mnemonic:         tr.validatorConfigs[val.id].mnemonic,
-			NodeKey:          tr.validatorConfigs[val.id].nodeKey,
-			ValId:            fmt.Sprint(val.id),
-			PrivValidatorKey: tr.validatorConfigs[val.id].privValidatorKey,
-			Allocation:       fmt.Sprint(val.allocation) + "stake",
-			Stake:            fmt.Sprint(val.stake) + "stake",
-			IpSuffix:         tr.validatorConfigs[val.id].ipSuffix,
+			Mnemonic:         tr.validatorConfigs[val.Id].Mnemonic,
+			NodeKey:          tr.validatorConfigs[val.Id].NodeKey,
+			ValId:            fmt.Sprint(val.Id),
+			PrivValidatorKey: tr.validatorConfigs[val.Id].PrivValidatorKey,
+			Allocation:       fmt.Sprint(val.Allocation) + "stake",
+			Stake:            fmt.Sprint(val.Stake) + "stake",
+			IpSuffix:         tr.validatorConfigs[val.Id].IpSuffix,
 
-			ConsumerMnemonic:         tr.validatorConfigs[val.id].consumerMnemonic,
-			ConsumerPrivValidatorKey: tr.validatorConfigs[val.id].consumerPrivValidatorKey,
+			ConsumerMnemonic:         tr.validatorConfigs[val.Id].ConsumerMnemonic,
+			ConsumerPrivValidatorKey: tr.validatorConfigs[val.Id].ConsumerPrivValidatorKey,
 			// if true node will be started with consumer key for each consumer chain
-			StartWithConsumerKey: tr.validatorConfigs[val.id].useConsumerKey,
+			StartWithConsumerKey: tr.validatorConfigs[val.Id].UseConsumerKey,
 		})
 	}
 
@@ -62,16 +62,16 @@ func (tr TestRun) startSovereignChain(
 
 	// Concat genesis changes defined in chain config, with any custom genesis changes for this chain instantiation
 	var genesisChanges string
-	if action.genesisChanges != "" {
-		genesisChanges = chainConfig.genesisChanges + " | " + action.genesisChanges
+	if action.GenesisChanges != "" {
+		genesisChanges = chainConfig.GenesisChanges + " | " + action.GenesisChanges
 	} else {
-		genesisChanges = chainConfig.genesisChanges
+		genesisChanges = chainConfig.GenesisChanges
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, "/bin/bash",
-		"/testnet-scripts/start-sovereign.sh", chainConfig.binaryName, string(vals),
-		string(chainConfig.chainId), chainConfig.ipPrefix, genesisChanges,
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "/bin/bash",
+		"/testnet-scripts/start-sovereign.sh", chainConfig.BinaryName, string(vals),
+		string(chainConfig.ChainId), chainConfig.IpPrefix, genesisChanges,
 		tr.tendermintConfigOverride,
 	)
 
@@ -100,16 +100,16 @@ func (tr TestRun) startSovereignChain(
 		log.Fatal(err)
 	}
 	tr.addChainToRelayer(addChainToRelayerAction{
-		chain:     action.chain,
-		validator: action.validators[0].id,
+		Chain:     action.Chain,
+		Validator: action.Validators[0].Id,
 	}, verbose)
 }
 
 type LegacyUpgradeProposalAction struct {
-	chainID       chainID
-	upgradeTitle  string
-	proposer      validatorID
-	upgradeHeight uint64
+	ChainID       ChainID
+	UpgradeTitle  string
+	Proposer      ValidatorID
+	UpgradeHeight uint64
 }
 
 func (tr *TestRun) submitLegacyUpgradeProposal(action LegacyUpgradeProposalAction, verbose bool) {
@@ -128,18 +128,18 @@ func (tr *TestRun) submitLegacyUpgradeProposal(action LegacyUpgradeProposalActio
 		--node %s \
 		--no-validate \
 		-y`,
-		tr.chainConfigs[chainID("sover")].binaryName,
-		action.upgradeTitle,
-		action.upgradeTitle,
-		fmt.Sprint(action.upgradeHeight),
-		action.proposer,
-		tr.chainConfigs[chainID("sover")].chainId,
-		tr.getValidatorHome(chainID("sover"), action.proposer),
-		tr.getValidatorNode(chainID("sover"), action.proposer),
+		tr.chainConfigs[ChainID("sover")].BinaryName,
+		action.UpgradeTitle,
+		action.UpgradeTitle,
+		fmt.Sprint(action.UpgradeHeight),
+		action.Proposer,
+		tr.chainConfigs[ChainID("sover")].ChainId,
+		tr.getValidatorHome(ChainID("sover"), action.Proposer),
+		tr.getValidatorNode(ChainID("sover"), action.Proposer),
 	)
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	cmd := exec.Command("docker", "exec",
-		tr.containerConfig.instanceName,
+		tr.containerConfig.InstanceName,
 		"/bin/bash", "-c",
 		submit,
 	)
@@ -153,16 +153,16 @@ func (tr *TestRun) submitLegacyUpgradeProposal(action LegacyUpgradeProposalActio
 		log.Fatal(err, "\n", string(bz))
 	}
 
-	tr.waitBlocks(action.chainID, 1, 15*time.Second)
+	tr.waitBlocks(action.ChainID, 1, 15*time.Second)
 }
 
 type waitUntilBlockAction struct {
-	block uint
-	chain chainID
+	Block uint
+	Chain ChainID
 }
 
 func (tr *TestRun) waitUntilBlockOnChain(action waitUntilBlockAction) {
-	fmt.Println("waitUntilBlockOnChain is waiting for block:", action.block)
-	tr.waitUntilBlock(action.chain, action.block, 120*time.Second)
-	fmt.Println("waitUntilBlockOnChain done waiting for block:", action.block)
+	fmt.Println("waitUntilBlockOnChain is waiting for block:", action.Block)
+	tr.waitUntilBlock(action.Chain, action.Block, 120*time.Second)
+	fmt.Println("waitUntilBlockOnChain done waiting for block:", action.Block)
 }

--- a/tests/e2e/config.go
+++ b/tests/e2e/config.go
@@ -8,55 +8,55 @@ import (
 
 // TODO: Determine if user defined type (wrapping a primitive string) is desired in long run
 type (
-	chainID     string
-	validatorID string
+	ChainID     string
+	ValidatorID string
 )
 
 // Attributes that are unique to a validator. Allows us to map (part of)
 // the set of strings defined above to a set of viable validators
 type ValidatorConfig struct {
-	mnemonic         string
-	delAddress       string
-	valoperAddress   string
-	valconsAddress   string
-	privValidatorKey string
-	nodeKey          string
+	Mnemonic         string
+	DelAddress       string
+	ValoperAddress   string
+	ValconsAddress   string
+	PrivValidatorKey string
+	NodeKey          string
 	// Must be an integer greater than 0 and less than 253
-	ipSuffix string
+	IpSuffix string
 
 	// consumer chain key assignment data
 	// keys are used on a new node
-	consumerMnemonic         string
-	consumerDelAddress       string
-	consumerValoperAddress   string
-	consumerValconsAddress   string
-	consumerValPubKey        string
-	consumerPrivValidatorKey string
-	consumerNodeKey          string
-	useConsumerKey           bool // if true the validator node will start with consumer key
+	ConsumerMnemonic         string
+	ConsumerDelAddress       string
+	ConsumerValoperAddress   string
+	ConsumerValconsAddress   string
+	ConsumerValPubKey        string
+	ConsumerPrivValidatorKey string
+	ConsumerNodeKey          string
+	UseConsumerKey           bool // if true the validator node will start with consumer key
 }
 
 // Attributes that are unique to a chain. Allows us to map (part of)
 // the set of strings defined above to a set of viable chains
 type ChainConfig struct {
-	chainId chainID
+	ChainId ChainID
 	// Must be unique per chain
-	ipPrefix       string
-	votingWaitTime uint
+	IpPrefix       string
+	VotingWaitTime uint
 	// Any transformations to apply to the genesis file of all chains instantiated with this chain config, as a jq string.
 	// Example: ".app_state.gov.params.voting_period = \"5s\" | .app_state.slashing.params.signed_blocks_window = \"2\" | .app_state.slashing.params.min_signed_per_window = \"0.500000000000000000\""
-	genesisChanges string
-	binaryName     string
+	GenesisChanges string
+	BinaryName     string
 
 	// binary to use after upgrade height
-	upgradeBinary string
+	UpgradeBinary string
 }
 
 type ContainerConfig struct {
-	containerName string
-	instanceName  string
-	ccvVersion    string
-	now           time.Time
+	ContainerName string
+	InstanceName  string
+	CcvVersion    string
+	Now           time.Time
 }
 
 // TODO: Split out TestRun and system wide config like localsdkpath
@@ -64,8 +64,8 @@ type TestRun struct {
 	// These are the non altered values during a typical test run, where multiple test runs can exist
 	// to validate different action sequences and corresponding state checks.
 	containerConfig  ContainerConfig
-	validatorConfigs map[validatorID]ValidatorConfig
-	chainConfigs     map[chainID]ChainConfig
+	validatorConfigs map[ValidatorID]ValidatorConfig
+	chainConfigs     map[ChainID]ChainConfig
 	// override config.toml parameters
 	// usually used to override timeout_commit
 	// having shorter timeout_commit reduces the test runtime because blocks are produced faster
@@ -77,7 +77,7 @@ type TestRun struct {
 	useGorelayer             bool // if false, Hermes is used as the relayer
 	gaiaTag                  string
 	// chains which are running, i.e. producing blocks, at the moment
-	runningChains map[chainID]bool
+	runningChains map[ChainID]bool
 	// Used with CometMock. The time by which chains have been advanced. Used to keep chains in sync: when a new chain is started, advance its time by this value to keep chains in sync.
 	timeOffset time.Duration
 
@@ -86,67 +86,67 @@ type TestRun struct {
 
 // Initialize initializes the TestRun instance by setting the runningChains field to an empty map.
 func (tr *TestRun) Initialize() {
-	tr.runningChains = make(map[chainID]bool)
+	tr.runningChains = make(map[ChainID]bool)
 }
 
-func getDefaultValidators() map[validatorID]ValidatorConfig {
-	return map[validatorID]ValidatorConfig{
-		validatorID("alice"): {
-			mnemonic:         "pave immune ethics wrap gain ceiling always holiday employ earth tumble real ice engage false unable carbon equal fresh sick tattoo nature pupil nuclear",
-			delAddress:       "cosmos19pe9pg5dv9k5fzgzmsrgnw9rl9asf7ddwhu7lm",
-			valoperAddress:   "cosmosvaloper19pe9pg5dv9k5fzgzmsrgnw9rl9asf7ddtrgtng",
-			valconsAddress:   "cosmosvalcons1qmq08eruchr5sf5s3rwz7djpr5a25f7xw4mceq",
-			privValidatorKey: `{"address":"06C0F3E47CC5C748269088DC2F36411D3AAA27C6","pub_key":{"type":"tendermint/PubKeyEd25519","value":"RrclQz9bIhkIy/gfL485g3PYMeiIku4qeo495787X10="},"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"uX+ZpDMg89a6gtqs/+MQpCTSqlkZ0nJQJOhLlCJvwvdGtyVDP1siGQjL+B8vjzmDc9gx6IiS7ip6jj3nvztfXQ=="}}`,
-			nodeKey:          `{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"fjw4/DAhyRPnwKgXns5SV7QfswRSXMWJpHS7TyULDmJ8ofUc5poQP8dgr8bZRbCV5RV8cPqDq3FPdqwpmUbmdA=="}}`,
-			ipSuffix:         "4",
+func getDefaultValidators() map[ValidatorID]ValidatorConfig {
+	return map[ValidatorID]ValidatorConfig{
+		ValidatorID("alice"): {
+			Mnemonic:         "pave immune ethics wrap gain ceiling always holiday employ earth tumble real ice engage false unable carbon equal fresh sick tattoo nature pupil nuclear",
+			DelAddress:       "cosmos19pe9pg5dv9k5fzgzmsrgnw9rl9asf7ddwhu7lm",
+			ValoperAddress:   "cosmosvaloper19pe9pg5dv9k5fzgzmsrgnw9rl9asf7ddtrgtng",
+			ValconsAddress:   "cosmosvalcons1qmq08eruchr5sf5s3rwz7djpr5a25f7xw4mceq",
+			PrivValidatorKey: `{"address":"06C0F3E47CC5C748269088DC2F36411D3AAA27C6","pub_key":{"type":"tendermint/PubKeyEd25519","value":"RrclQz9bIhkIy/gfL485g3PYMeiIku4qeo495787X10="},"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"uX+ZpDMg89a6gtqs/+MQpCTSqlkZ0nJQJOhLlCJvwvdGtyVDP1siGQjL+B8vjzmDc9gx6IiS7ip6jj3nvztfXQ=="}}`,
+			NodeKey:          `{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"fjw4/DAhyRPnwKgXns5SV7QfswRSXMWJpHS7TyULDmJ8ofUc5poQP8dgr8bZRbCV5RV8cPqDq3FPdqwpmUbmdA=="}}`,
+			IpSuffix:         "4",
 
 			// consumer chain assigned key
-			consumerMnemonic:         "exile install vapor thing little toss immune notable lounge december final easy strike title end program interest quote cloth forget forward job october twenty",
-			consumerDelAddress:       "cosmos1eeeggku6dzk3mv7wph3zq035rhtd890sjswszd",
-			consumerValoperAddress:   "cosmosvaloper1eeeggku6dzk3mv7wph3zq035rhtd890shy69w7",
-			consumerValconsAddress:   "cosmosvalcons1muys5jyqk4xd27e208nym85kn0t4zjcfeu63fe",
-			consumerValPubKey:        `{"@type":"/cosmos.crypto.ed25519.PubKey","key":"ujY14AgopV907IYgPAk/5x8c9267S4fQf89nyeCPTes="}`,
-			consumerPrivValidatorKey: `{"address":"DF090A4880B54CD57B2A79E64D9E969BD7514B09","pub_key":{"type":"tendermint/PubKeyEd25519","value":"ujY14AgopV907IYgPAk/5x8c9267S4fQf89nyeCPTes="},"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"TRJgf7lkTjs/sj43pyweEOanyV7H7fhnVivOi0A4yjW6NjXgCCilX3TshiA8CT/nHxz3brtLh9B/z2fJ4I9N6w=="}}`,
-			consumerNodeKey:          `{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"F966RL9pi20aXRzEBe4D0xRQJtZt696Xxz44XUON52cFc83FMn1WXJbP6arvA2JPyn2LA3DLKCFHSgALrCGXGA=="}}`,
-			useConsumerKey:           false,
+			ConsumerMnemonic:         "exile install vapor thing little toss immune notable lounge december final easy strike title end program interest quote cloth forget forward job october twenty",
+			ConsumerDelAddress:       "cosmos1eeeggku6dzk3mv7wph3zq035rhtd890sjswszd",
+			ConsumerValoperAddress:   "cosmosvaloper1eeeggku6dzk3mv7wph3zq035rhtd890shy69w7",
+			ConsumerValconsAddress:   "cosmosvalcons1muys5jyqk4xd27e208nym85kn0t4zjcfeu63fe",
+			ConsumerValPubKey:        `{"@type":"/cosmos.crypto.ed25519.PubKey","key":"ujY14AgopV907IYgPAk/5x8c9267S4fQf89nyeCPTes="}`,
+			ConsumerPrivValidatorKey: `{"address":"DF090A4880B54CD57B2A79E64D9E969BD7514B09","pub_key":{"type":"tendermint/PubKeyEd25519","value":"ujY14AgopV907IYgPAk/5x8c9267S4fQf89nyeCPTes="},"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"TRJgf7lkTjs/sj43pyweEOanyV7H7fhnVivOi0A4yjW6NjXgCCilX3TshiA8CT/nHxz3brtLh9B/z2fJ4I9N6w=="}}`,
+			ConsumerNodeKey:          `{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"F966RL9pi20aXRzEBe4D0xRQJtZt696Xxz44XUON52cFc83FMn1WXJbP6arvA2JPyn2LA3DLKCFHSgALrCGXGA=="}}`,
+			UseConsumerKey:           false,
 		},
-		validatorID("bob"): {
-			mnemonic:         "glass trip produce surprise diamond spin excess gaze wash drum human solve dress minor artefact canoe hard ivory orange dinner hybrid moral potato jewel",
-			delAddress:       "cosmos1dkas8mu4kyhl5jrh4nzvm65qz588hy9qcz08la",
-			valoperAddress:   "cosmosvaloper1dkas8mu4kyhl5jrh4nzvm65qz588hy9qakmjnw",
-			valconsAddress:   "cosmosvalcons1nx7n5uh0ztxsynn4sje6eyq2ud6rc6klc96w39",
-			privValidatorKey: `{"address":"99BD3A72EF12CD024E7584B3AC900AE3743C6ADF","pub_key":{"type":"tendermint/PubKeyEd25519","value":"mAN6RXYxSM4MNGSIriYiS7pHuwAcOHDQAy9/wnlSzOI="},"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"QePcwfWtOavNK7pBJrtoLMzarHKn6iBWfWPFeyV+IdmYA3pFdjFIzgw0ZIiuJiJLuke7ABw4cNADL3/CeVLM4g=="}}`,
-			nodeKey:          `{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"TQ4vHcO/vKdzGtWpelkX53WdMQd4kTsWGFrdcatdXFvWyO215Rewn5IRP0FszPLWr2DqPzmuH8WvxYGk5aeOXw=="}}`,
-			ipSuffix:         "5",
+		ValidatorID("bob"): {
+			Mnemonic:         "glass trip produce surprise diamond spin excess gaze wash drum human solve dress minor artefact canoe hard ivory orange dinner hybrid moral potato jewel",
+			DelAddress:       "cosmos1dkas8mu4kyhl5jrh4nzvm65qz588hy9qcz08la",
+			ValoperAddress:   "cosmosvaloper1dkas8mu4kyhl5jrh4nzvm65qz588hy9qakmjnw",
+			ValconsAddress:   "cosmosvalcons1nx7n5uh0ztxsynn4sje6eyq2ud6rc6klc96w39",
+			PrivValidatorKey: `{"address":"99BD3A72EF12CD024E7584B3AC900AE3743C6ADF","pub_key":{"type":"tendermint/PubKeyEd25519","value":"mAN6RXYxSM4MNGSIriYiS7pHuwAcOHDQAy9/wnlSzOI="},"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"QePcwfWtOavNK7pBJrtoLMzarHKn6iBWfWPFeyV+IdmYA3pFdjFIzgw0ZIiuJiJLuke7ABw4cNADL3/CeVLM4g=="}}`,
+			NodeKey:          `{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"TQ4vHcO/vKdzGtWpelkX53WdMQd4kTsWGFrdcatdXFvWyO215Rewn5IRP0FszPLWr2DqPzmuH8WvxYGk5aeOXw=="}}`,
+			IpSuffix:         "5",
 
 			// consumer chain assigned key
-			consumerMnemonic:         "grunt list hour endless observe better spoil penalty lab duck only layer vague fantasy satoshi record demise topple space shaft solar practice donor sphere",
-			consumerDelAddress:       "cosmos1q90l6j6lzzgt460ehjj56azknlt5yrd4s38n97",
-			consumerValoperAddress:   "cosmosvaloper1q90l6j6lzzgt460ehjj56azknlt5yrd449nxfd",
-			consumerValconsAddress:   "cosmosvalcons1uuec3cjxajv5te08p220usrjhkfhg9wyvqn0tm",
-			consumerValPubKey:        `{"@type":"/cosmos.crypto.ed25519.PubKey","key":"QlG+iYe6AyYpvY1z9RNJKCVlH14Q/qSz4EjGdGCru3o="}`,
-			consumerPrivValidatorKey: `{"address":"E73388E246EC9945E5E70A94FE4072BD937415C4","pub_key":{"type":"tendermint/PubKeyEd25519","value":"QlG+iYe6AyYpvY1z9RNJKCVlH14Q/qSz4EjGdGCru3o="},"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"OFR4w+FC6EMw5fAGTrHVexyPrjzQ7QfqgZOMgVf0izlCUb6Jh7oDJim9jXP1E0koJWUfXhD+pLPgSMZ0YKu7eg=="}}`,
-			consumerNodeKey:          `{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"uhPCqnL2KE8m/8OFNLQ5bN3CJr6mds+xfBi0E4umT/s2uWiJhet+vbYx88DHSdof3gGFNTIzAIxSppscBKX96w=="}}`,
-			useConsumerKey:           false,
+			ConsumerMnemonic:         "grunt list hour endless observe better spoil penalty lab duck only layer vague fantasy satoshi record demise topple space shaft solar practice donor sphere",
+			ConsumerDelAddress:       "cosmos1q90l6j6lzzgt460ehjj56azknlt5yrd4s38n97",
+			ConsumerValoperAddress:   "cosmosvaloper1q90l6j6lzzgt460ehjj56azknlt5yrd449nxfd",
+			ConsumerValconsAddress:   "cosmosvalcons1uuec3cjxajv5te08p220usrjhkfhg9wyvqn0tm",
+			ConsumerValPubKey:        `{"@type":"/cosmos.crypto.ed25519.PubKey","key":"QlG+iYe6AyYpvY1z9RNJKCVlH14Q/qSz4EjGdGCru3o="}`,
+			ConsumerPrivValidatorKey: `{"address":"E73388E246EC9945E5E70A94FE4072BD937415C4","pub_key":{"type":"tendermint/PubKeyEd25519","value":"QlG+iYe6AyYpvY1z9RNJKCVlH14Q/qSz4EjGdGCru3o="},"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"OFR4w+FC6EMw5fAGTrHVexyPrjzQ7QfqgZOMgVf0izlCUb6Jh7oDJim9jXP1E0koJWUfXhD+pLPgSMZ0YKu7eg=="}}`,
+			ConsumerNodeKey:          `{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"uhPCqnL2KE8m/8OFNLQ5bN3CJr6mds+xfBi0E4umT/s2uWiJhet+vbYx88DHSdof3gGFNTIzAIxSppscBKX96w=="}}`,
+			UseConsumerKey:           false,
 		},
-		validatorID("carol"): {
-			mnemonic:         "sight similar better jar bitter laptop solve fashion father jelly scissors chest uniform play unhappy convince silly clump another conduct behave reunion marble animal",
-			delAddress:       "cosmos19hz4m226ztankqramvt4a7t0shejv4dc79gp9u",
-			valoperAddress:   "cosmosvaloper19hz4m226ztankqramvt4a7t0shejv4dcm3u5f0",
-			valconsAddress:   "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6",
-			privValidatorKey: `{"address":"C888306A908A217B9A943D1DAD8790044D0947A4","pub_key":{"type":"tendermint/PubKeyEd25519","value":"IHo4QEikWZfIKmM0X+N+BjKttz8HOzGs2npyjiba3Xk="},"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"z08bmSB91uFVpVmR3t2ewd/bDjZ/AzwQpe5rKjWiPG0gejhASKRZl8gqYzRf434GMq23Pwc7MazaenKOJtrdeQ=="}}`,
-			nodeKey:          `{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"WLTcHEjbwB24Wp3z5oBSYTvtGQonz/7IQabOFw85BN0UkkyY5HDf38o8oHlFxVI26f+DFVeICuLbe9aXKGnUeg=="}}`,
-			ipSuffix:         "6",
+		ValidatorID("carol"): {
+			Mnemonic:         "sight similar better jar bitter laptop solve fashion father jelly scissors chest uniform play unhappy convince silly clump another conduct behave reunion marble animal",
+			DelAddress:       "cosmos19hz4m226ztankqramvt4a7t0shejv4dc79gp9u",
+			ValoperAddress:   "cosmosvaloper19hz4m226ztankqramvt4a7t0shejv4dcm3u5f0",
+			ValconsAddress:   "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6",
+			PrivValidatorKey: `{"address":"C888306A908A217B9A943D1DAD8790044D0947A4","pub_key":{"type":"tendermint/PubKeyEd25519","value":"IHo4QEikWZfIKmM0X+N+BjKttz8HOzGs2npyjiba3Xk="},"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"z08bmSB91uFVpVmR3t2ewd/bDjZ/AzwQpe5rKjWiPG0gejhASKRZl8gqYzRf434GMq23Pwc7MazaenKOJtrdeQ=="}}`,
+			NodeKey:          `{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"WLTcHEjbwB24Wp3z5oBSYTvtGQonz/7IQabOFw85BN0UkkyY5HDf38o8oHlFxVI26f+DFVeICuLbe9aXKGnUeg=="}}`,
+			IpSuffix:         "6",
 
 			// consumer chain assigned key
-			consumerMnemonic:         "clip choose cake west range gun slam cry village receive juice galaxy lend ritual range provide ritual can since verify breeze vacant play dragon",
-			consumerDelAddress:       "cosmos1sx6j9g2rh324a342a5f0rnx7me34r9nwgf0mc7",
-			consumerValoperAddress:   "cosmosvaloper1sx6j9g2rh324a342a5f0rnx7me34r9nwdamw5d",
-			consumerValconsAddress:   "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk",
-			consumerValPubKey:        `{"@type":"/cosmos.crypto.ed25519.PubKey","key":"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is="}`,
-			consumerPrivValidatorKey: `{"address":"B41C3A40142963AA5B12DDD1C4E5890C0B3926B1","pub_key":{"type":"tendermint/PubKeyEd25519","value":"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is="},"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"3YaBAZLA+sl/E73lLfbFbG0u6DYm33ayr/0UpCt/vFBSLkZ/X6a1ZR0fy7fGWbN0ogP4Xc8rSx9dnvcZnqrqKw=="}}`,
-			consumerNodeKey:          `{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"rxBzFedtD3pqgfJQblbxGusKOr47oBfr8ba0Iz14gobtDRZQZlSZ/UGP4pSHkVf+4vtkrkO1vRHBYJobuiP+7A=="}}`,
-			useConsumerKey:           true,
+			ConsumerMnemonic:         "clip choose cake west range gun slam cry village receive juice galaxy lend ritual range provide ritual can since verify breeze vacant play dragon",
+			ConsumerDelAddress:       "cosmos1sx6j9g2rh324a342a5f0rnx7me34r9nwgf0mc7",
+			ConsumerValoperAddress:   "cosmosvaloper1sx6j9g2rh324a342a5f0rnx7me34r9nwdamw5d",
+			ConsumerValconsAddress:   "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk",
+			ConsumerValPubKey:        `{"@type":"/cosmos.crypto.ed25519.PubKey","key":"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is="}`,
+			ConsumerPrivValidatorKey: `{"address":"B41C3A40142963AA5B12DDD1C4E5890C0B3926B1","pub_key":{"type":"tendermint/PubKeyEd25519","value":"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is="},"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"3YaBAZLA+sl/E73lLfbFbG0u6DYm33ayr/0UpCt/vFBSLkZ/X6a1ZR0fy7fGWbN0ogP4Xc8rSx9dnvcZnqrqKw=="}}`,
+			ConsumerNodeKey:          `{"priv_key":{"type":"tendermint/PrivKeyEd25519","value":"rxBzFedtD3pqgfJQblbxGusKOr47oBfr8ba0Iz14gobtDRZQZlSZ/UGP4pSHkVf+4vtkrkO1vRHBYJobuiP+7A=="}}`,
+			UseConsumerKey:           true,
 		},
 	}
 }
@@ -155,19 +155,19 @@ func SlashThrottleTestRun() TestRun {
 	tr := TestRun{
 		name: "slash-throttling",
 		containerConfig: ContainerConfig{
-			containerName: "interchain-security-slash-container",
-			instanceName:  "interchain-security-slash-instance",
-			ccvVersion:    "1",
-			now:           time.Now(),
+			ContainerName: "interchain-security-slash-container",
+			InstanceName:  "interchain-security-slash-instance",
+			CcvVersion:    "1",
+			Now:           time.Now(),
 		},
 		validatorConfigs: getDefaultValidators(),
-		chainConfigs: map[chainID]ChainConfig{
-			chainID("provi"): {
-				chainId:        chainID("provi"),
-				binaryName:     "interchain-security-pd",
-				ipPrefix:       "7.7.7",
-				votingWaitTime: 20,
-				genesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
+		chainConfigs: map[ChainID]ChainConfig{
+			ChainID("provi"): {
+				ChainId:        ChainID("provi"),
+				BinaryName:     "interchain-security-pd",
+				IpPrefix:       "7.7.7",
+				VotingWaitTime: 20,
+				GenesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
 					// Custom slashing parameters for testing validator downtime functionality
 					// See https://docs.cosmos.network/main/modules/slashing/04_begin_block.html#uptime-tracking
 					".app_state.slashing.params.signed_blocks_window = \"10\" | " +
@@ -177,12 +177,12 @@ func SlashThrottleTestRun() TestRun {
 					".app_state.provider.params.slash_meter_replenish_fraction = \"0.10\" | " +
 					".app_state.provider.params.slash_meter_replenish_period = \"20s\"",
 			},
-			chainID("consu"): {
-				chainId:        chainID("consu"),
-				binaryName:     "interchain-security-cd",
-				ipPrefix:       "7.7.8",
-				votingWaitTime: 20,
-				genesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
+			ChainID("consu"): {
+				ChainId:        ChainID("consu"),
+				BinaryName:     "interchain-security-cd",
+				IpPrefix:       "7.7.8",
+				VotingWaitTime: 20,
+				GenesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
 					".app_state.slashing.params.signed_blocks_window = \"15\" | " +
 					".app_state.slashing.params.min_signed_per_window = \"0.500000000000000000\" | " +
 					".app_state.slashing.params.downtime_jail_duration = \"60s\" | " +
@@ -200,19 +200,19 @@ func DefaultTestRun() TestRun {
 	tr := TestRun{
 		name: "default",
 		containerConfig: ContainerConfig{
-			containerName: "interchain-security-container",
-			instanceName:  "interchain-security-instance",
-			ccvVersion:    "1",
-			now:           time.Now(),
+			ContainerName: "interchain-security-container",
+			InstanceName:  "interchain-security-instance",
+			CcvVersion:    "1",
+			Now:           time.Now(),
 		},
 		validatorConfigs: getDefaultValidators(),
-		chainConfigs: map[chainID]ChainConfig{
-			chainID("provi"): {
-				chainId:        chainID("provi"),
-				binaryName:     "interchain-security-pd",
-				ipPrefix:       "7.7.7",
-				votingWaitTime: 20,
-				genesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
+		chainConfigs: map[ChainID]ChainConfig{
+			ChainID("provi"): {
+				ChainId:        ChainID("provi"),
+				BinaryName:     "interchain-security-pd",
+				IpPrefix:       "7.7.7",
+				VotingWaitTime: 20,
+				GenesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
 					// Custom slashing parameters for testing validator downtime functionality
 					// See https://docs.cosmos.network/main/modules/slashing/04_begin_block.html#uptime-tracking
 					".app_state.slashing.params.signed_blocks_window = \"10\" | " +
@@ -222,12 +222,12 @@ func DefaultTestRun() TestRun {
 					".app_state.provider.params.slash_meter_replenish_fraction = \"1.0\" | " + // This disables slash packet throttling
 					".app_state.provider.params.slash_meter_replenish_period = \"3s\"",
 			},
-			chainID("consu"): {
-				chainId:        chainID("consu"),
-				binaryName:     "interchain-security-cd",
-				ipPrefix:       "7.7.8",
-				votingWaitTime: 20,
-				genesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
+			ChainID("consu"): {
+				ChainId:        ChainID("consu"),
+				BinaryName:     "interchain-security-cd",
+				IpPrefix:       "7.7.8",
+				VotingWaitTime: 20,
+				GenesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
 					".app_state.slashing.params.signed_blocks_window = \"15\" | " +
 					".app_state.slashing.params.min_signed_per_window = \"0.500000000000000000\" | " +
 					".app_state.slashing.params.downtime_jail_duration = \"60s\" | " +
@@ -257,19 +257,19 @@ func DemocracyTestRun(allowReward bool) TestRun {
 	tr := TestRun{
 		name: "democracy",
 		containerConfig: ContainerConfig{
-			containerName: "interchain-security-democ-container",
-			instanceName:  "interchain-security-democ-instance",
-			ccvVersion:    "1",
-			now:           time.Now(),
+			ContainerName: "interchain-security-democ-container",
+			InstanceName:  "interchain-security-democ-instance",
+			CcvVersion:    "1",
+			Now:           time.Now(),
 		},
 		validatorConfigs: getDefaultValidators(),
-		chainConfigs: map[chainID]ChainConfig{
-			chainID("provi"): {
-				chainId:        chainID("provi"),
-				binaryName:     "interchain-security-pd",
-				ipPrefix:       "7.7.7",
-				votingWaitTime: 20,
-				genesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
+		chainConfigs: map[ChainID]ChainConfig{
+			ChainID("provi"): {
+				ChainId:        ChainID("provi"),
+				BinaryName:     "interchain-security-pd",
+				IpPrefix:       "7.7.7",
+				VotingWaitTime: 20,
+				GenesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
 					// Custom slashing parameters for testing validator downtime functionality
 					// See https://docs.cosmos.network/main/modules/slashing/04_begin_block.html#uptime-tracking
 					".app_state.slashing.params.signed_blocks_window = \"10\" | " +
@@ -278,12 +278,12 @@ func DemocracyTestRun(allowReward bool) TestRun {
 					".app_state.slashing.params.slash_fraction_downtime = \"0.010000000000000000\" | " +
 					".app_state.provider.params.slash_meter_replenish_fraction = \"1.0\"", // This disables slash packet throttling
 			},
-			chainID("democ"): {
-				chainId:        chainID("democ"),
-				binaryName:     "interchain-security-cdd",
-				ipPrefix:       "7.7.9",
-				votingWaitTime: 20,
-				genesisChanges: consumerGenChanges,
+			ChainID("democ"): {
+				ChainId:        ChainID("democ"),
+				BinaryName:     "interchain-security-cdd",
+				IpPrefix:       "7.7.9",
+				VotingWaitTime: 20,
+				GenesisChanges: consumerGenChanges,
 			},
 		},
 		tendermintConfigOverride: `s/timeout_commit = "5s"/timeout_commit = "1s"/;` +
@@ -297,19 +297,19 @@ func MultiConsumerTestRun() TestRun {
 	tr := TestRun{
 		name: "multi-consumer",
 		containerConfig: ContainerConfig{
-			containerName: "interchain-security-multic-container",
-			instanceName:  "interchain-security-multic-instance",
-			ccvVersion:    "1",
-			now:           time.Now(),
+			ContainerName: "interchain-security-multic-container",
+			InstanceName:  "interchain-security-multic-instance",
+			CcvVersion:    "1",
+			Now:           time.Now(),
 		},
 		validatorConfigs: getDefaultValidators(),
-		chainConfigs: map[chainID]ChainConfig{
-			chainID("provi"): {
-				chainId:        chainID("provi"),
-				binaryName:     "interchain-security-pd",
-				ipPrefix:       "7.7.7",
-				votingWaitTime: 20,
-				genesisChanges: ".app_state.gov.params.voting_period = \"30s\" | " +
+		chainConfigs: map[ChainID]ChainConfig{
+			ChainID("provi"): {
+				ChainId:        ChainID("provi"),
+				BinaryName:     "interchain-security-pd",
+				IpPrefix:       "7.7.7",
+				VotingWaitTime: 20,
+				GenesisChanges: ".app_state.gov.params.voting_period = \"30s\" | " +
 					// Custom slashing parameters for testing validator downtime functionality
 					// See https://docs.cosmos.network/main/modules/slashing/04_begin_block.html#uptime-tracking
 					".app_state.slashing.params.signed_blocks_window = \"10\" | " +
@@ -318,23 +318,23 @@ func MultiConsumerTestRun() TestRun {
 					".app_state.slashing.params.slash_fraction_downtime = \"0.010000000000000000\" | " +
 					".app_state.provider.params.slash_meter_replenish_fraction = \"1.0\"", // This disables slash packet throttling
 			},
-			chainID("consu"): {
-				chainId:        chainID("consu"),
-				binaryName:     "interchain-security-cd",
-				ipPrefix:       "7.7.8",
-				votingWaitTime: 20,
-				genesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
+			ChainID("consu"): {
+				ChainId:        ChainID("consu"),
+				BinaryName:     "interchain-security-cd",
+				IpPrefix:       "7.7.8",
+				VotingWaitTime: 20,
+				GenesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
 					".app_state.slashing.params.signed_blocks_window = \"10\" | " +
 					".app_state.slashing.params.min_signed_per_window = \"0.500000000000000000\" | " +
 					".app_state.slashing.params.downtime_jail_duration = \"60s\" | " +
 					".app_state.slashing.params.slash_fraction_downtime = \"0.010000000000000000\"",
 			},
-			chainID("densu"): {
-				chainId:        chainID("densu"),
-				binaryName:     "interchain-security-cd",
-				ipPrefix:       "7.7.9",
-				votingWaitTime: 20,
-				genesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
+			ChainID("densu"): {
+				ChainId:        ChainID("densu"),
+				BinaryName:     "interchain-security-cd",
+				IpPrefix:       "7.7.9",
+				VotingWaitTime: 20,
+				GenesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
 					".app_state.slashing.params.signed_blocks_window = \"10\" | " +
 					".app_state.slashing.params.min_signed_per_window = \"0.500000000000000000\" | " +
 					".app_state.slashing.params.downtime_jail_duration = \"60s\" | " +
@@ -352,19 +352,19 @@ func ChangeoverTestRun() TestRun {
 	tr := TestRun{
 		name: "changeover",
 		containerConfig: ContainerConfig{
-			containerName: "interchain-security-changeover-container",
-			instanceName:  "interchain-security-changeover-instance",
-			ccvVersion:    "1",
-			now:           time.Now(),
+			ContainerName: "interchain-security-changeover-container",
+			InstanceName:  "interchain-security-changeover-instance",
+			CcvVersion:    "1",
+			Now:           time.Now(),
 		},
 		validatorConfigs: getDefaultValidators(),
-		chainConfigs: map[chainID]ChainConfig{
-			chainID("provi"): {
-				chainId:        chainID("provi"),
-				binaryName:     "interchain-security-pd",
-				ipPrefix:       "7.7.7",
-				votingWaitTime: 20,
-				genesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
+		chainConfigs: map[ChainID]ChainConfig{
+			ChainID("provi"): {
+				ChainId:        ChainID("provi"),
+				BinaryName:     "interchain-security-pd",
+				IpPrefix:       "7.7.7",
+				VotingWaitTime: 20,
+				GenesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
 					// Custom slashing parameters for testing validator downtime functionality
 					// See https://docs.cosmos.network/main/modules/slashing/04_begin_block.html#uptime-tracking
 					".app_state.slashing.params.signed_blocks_window = \"10\" | " +
@@ -374,13 +374,13 @@ func ChangeoverTestRun() TestRun {
 					".app_state.provider.params.slash_meter_replenish_fraction = \"1.0\" | " + // This disables slash packet throttling
 					".app_state.provider.params.slash_meter_replenish_period = \"3s\"",
 			},
-			chainID("sover"): {
-				chainId:        chainID("sover"),
-				binaryName:     "interchain-security-sd",
-				upgradeBinary:  "interchain-security-cdd",
-				ipPrefix:       "7.7.8",
-				votingWaitTime: 20,
-				genesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
+			ChainID("sover"): {
+				ChainId:        ChainID("sover"),
+				BinaryName:     "interchain-security-sd",
+				UpgradeBinary:  "interchain-security-cdd",
+				IpPrefix:       "7.7.8",
+				VotingWaitTime: 20,
+				GenesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
 					".app_state.slashing.params.signed_blocks_window = \"15\" | " +
 					".app_state.slashing.params.min_signed_per_window = \"0.500000000000000000\" | " +
 					".app_state.slashing.params.downtime_jail_duration = \"60s\" | " +
@@ -430,7 +430,7 @@ func (s *TestRun) validateStringLiterals() {
 			panic("validator id string literal must be 5 char or less")
 		}
 
-		ipSuffix, err := strconv.Atoi(valConfig.ipSuffix)
+		ipSuffix, err := strconv.Atoi(valConfig.IpSuffix)
 		if err != nil {
 			panic(fmt.Sprintf("ip suffix must be an int: %v\n", err))
 		}
@@ -453,7 +453,7 @@ func (s *TestRun) validateStringLiterals() {
 			panic("chain id string literal must be 5 char or less")
 		}
 
-		if chainID != chainConfig.chainId {
+		if chainID != chainConfig.ChainId {
 			panic("chain config is mapped to a chain id that is different than what's stored in the config")
 		}
 	}

--- a/tests/e2e/main.go
+++ b/tests/e2e/main.go
@@ -65,8 +65,8 @@ since causing light client attacks is not implemented.`,
 		},
 		"happy-path":       {testRun: DefaultTestRun(), steps: happyPathSteps, description: "happy path tests"},
 		"changeover":       {testRun: ChangeoverTestRun(), steps: changeoverSteps, description: "changeover tests"},
-		"democracy-reward": {testRun: DemocracyTestRun(true), steps: democracySteps, description: "democracy tests allowing rewards"},
-		"democracy":        {testRun: DemocracyTestRun(false), steps: rewardDenomConsumerSteps, description: "democracy tests"},
+		"democracy-reward": {testRun: DemocracyTestRun(true), steps: democracyRewardsSteps, description: "democracy tests allowing rewards"},
+		"democracy":        {testRun: DemocracyTestRun(false), steps: democracySteps, description: "democracy tests"},
 		"slash-throttle":   {testRun: SlashThrottleTestRun(), steps: slashThrottleSteps, description: "slash throttle tests"},
 		"multiconsumer":    {testRun: MultiConsumerTestRun(), steps: multipleConsumers, description: "multi consumer tests"},
 	}
@@ -189,7 +189,7 @@ type testRunWithSteps struct {
 }
 
 func (tr *TestRun) runStep(step Step, verbose bool) {
-	switch action := step.action.(type) {
+	switch action := step.Action.(type) {
 	case StartChainAction:
 		tr.startChain(action, verbose)
 	case StartSovereignChainAction:
@@ -264,13 +264,13 @@ func (tr *TestRun) runStep(step Step, verbose bool) {
 		log.Fatalf("unknown action in testRun %s: %#v", tr.name, action)
 	}
 
-	modelState := step.state
-	actualState := tr.getState(step.state)
+	modelState := step.State
+	actualState := tr.getState(step.State)
 
 	// Check state
 	if !reflect.DeepEqual(actualState, modelState) {
 		fmt.Printf("=============== %s FAILED ===============\n", tr.name)
-		fmt.Println("FAILED action", reflect.TypeOf(step.action).Name())
+		fmt.Println("FAILED action", reflect.TypeOf(step.Action).Name())
 		pretty.Print("actual state", actualState)
 		pretty.Print("model state", modelState)
 		log.Fatal(`actual state (-) not equal to model state (+): ` + pretty.Compare(actualState, modelState))
@@ -285,7 +285,7 @@ func (tr *TestRun) executeSteps(steps []Step) {
 	for i, step := range steps {
 		// print something the show the test is alive
 		fmt.Printf("running %s: step %d == %s \n",
-			tr.name, i+1, reflect.TypeOf(step.action).Name())
+			tr.name, i+1, reflect.TypeOf(step.Action).Name())
 		tr.runStep(step, *verbose)
 	}
 
@@ -315,8 +315,8 @@ func (tr *TestRun) startDocker() {
 	}
 	scriptStr := fmt.Sprintf(
 		"tests/e2e/testnet-scripts/start-docker.sh %s %s %s %s %s",
-		tr.containerConfig.containerName,
-		tr.containerConfig.instanceName,
+		tr.containerConfig.ContainerName,
+		tr.containerConfig.InstanceName,
 		localSdk,
 		useGaia,
 		gaiaTag,
@@ -359,7 +359,7 @@ func (tr *TestRun) startDocker() {
 func (tr *TestRun) teardownDocker() {
 	fmt.Printf("===============  tearing down %s testRun ===============\n", tr.name)
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "kill", tr.containerConfig.instanceName)
+	cmd := exec.Command("docker", "kill", tr.containerConfig.InstanceName)
 
 	bz, err := cmd.CombinedOutput()
 	if err != nil {

--- a/tests/e2e/state.go
+++ b/tests/e2e/state.go
@@ -14,19 +14,19 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type State map[chainID]ChainState
+type State map[ChainID]ChainState
 
 type ChainState struct {
-	ValBalances                    *map[validatorID]uint
+	ValBalances                    *map[ValidatorID]uint
 	Proposals                      *map[uint]Proposal
-	ValPowers                      *map[validatorID]uint
-	RepresentativePowers           *map[validatorID]uint
+	ValPowers                      *map[ValidatorID]uint
+	RepresentativePowers           *map[ValidatorID]uint
 	Params                         *[]Param
 	Rewards                        *Rewards
-	ConsumerChains                 *map[chainID]bool
-	AssignedKeys                   *map[validatorID]string
-	ProviderKeys                   *map[validatorID]string // validatorID: validator provider key
-	ConsumerChainQueueSizes        *map[chainID]uint
+	ConsumerChains                 *map[ChainID]bool
+	AssignedKeys                   *map[ValidatorID]string
+	ProviderKeys                   *map[ValidatorID]string // validatorID: validator provider key
+	ConsumerChainQueueSizes        *map[ChainID]uint
 	GlobalSlashQueueSize           *uint
 	RegisteredConsumerRewardDenoms *[]string
 }
@@ -45,7 +45,7 @@ func (p TextProposal) isProposal() {}
 
 type ConsumerAdditionProposal struct {
 	Deposit       uint
-	Chain         chainID
+	Chain         ChainID
 	SpawnTime     int
 	InitialHeight clienttypes.Height
 	Status        string
@@ -66,7 +66,7 @@ func (p ConsumerAdditionProposal) isProposal() {}
 
 type ConsumerRemovalProposal struct {
 	Deposit  uint
-	Chain    chainID
+	Chain    ChainID
 	StopTime int
 	Status   string
 }
@@ -84,7 +84,7 @@ type EquivocationProposal struct {
 func (p EquivocationProposal) isProposal() {}
 
 type Rewards struct {
-	IsRewarded map[validatorID]bool
+	IsRewarded map[ValidatorID]bool
 	// if true it will calculate if the validator/delegator is rewarded between 2 successive blocks,
 	// otherwise it will calculate if it received any rewards since the 1st block
 	IsIncrementalReward bool
@@ -119,7 +119,7 @@ func (tr TestRun) getState(modelState State) State {
 	return systemState
 }
 
-func (tr TestRun) getChainState(chain chainID, modelState ChainState) ChainState {
+func (tr TestRun) getChainState(chain ChainID, modelState ChainState) ChainState {
 	chainState := ChainState{}
 
 	if modelState.ValBalances != nil {
@@ -174,7 +174,7 @@ func (tr TestRun) getChainState(chain chainID, modelState ChainState) ChainState
 	}
 
 	if modelState.ConsumerChainQueueSizes != nil {
-		consumerChainQueueSizes := map[chainID]uint{}
+		consumerChainQueueSizes := map[ChainID]uint{}
 		for c := range *modelState.ConsumerChainQueueSizes {
 			consumerChainQueueSizes[c] = tr.getConsumerChainPacketQueueSize(c)
 		}
@@ -195,9 +195,9 @@ func (tr TestRun) getChainState(chain chainID, modelState ChainState) ChainState
 
 var blockHeightRegex = regexp.MustCompile(`block_height: "(\d+)"`)
 
-func (tr TestRun) getBlockHeight(chain chainID) uint {
+func (tr TestRun) getBlockHeight(chain ChainID) uint {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[chain].binaryName,
+	bz, err := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[chain].BinaryName,
 
 		"query", "tendermint-validator-set",
 
@@ -215,7 +215,7 @@ func (tr TestRun) getBlockHeight(chain chainID) uint {
 	return uint(blockHeight)
 }
 
-func (tr TestRun) waitBlocks(chain chainID, blocks uint, timeout time.Duration) {
+func (tr TestRun) waitBlocks(chain ChainID, blocks uint, timeout time.Duration) {
 	if tr.useCometmock {
 		// call advance_blocks method on cometmock
 		// curl -H 'Content-Type: application/json' -H 'Accept:application/json' --data '{"jsonrpc":"2.0","method":"advance_blocks","params":{"num_blocks": "36000000"},"id":1}' 127.0.0.1:22331
@@ -241,7 +241,7 @@ func (tr TestRun) waitBlocks(chain chainID, blocks uint, timeout time.Duration) 
 	}
 }
 
-func (tr TestRun) waitUntilBlock(chain chainID, block uint, timeout time.Duration) {
+func (tr TestRun) waitUntilBlock(chain ChainID, block uint, timeout time.Duration) {
 	start := time.Now()
 	for {
 		thisBlock := tr.getBlockHeight(chain)
@@ -255,8 +255,8 @@ func (tr TestRun) waitUntilBlock(chain chainID, block uint, timeout time.Duratio
 	}
 }
 
-func (tr TestRun) getBalances(chain chainID, modelState map[validatorID]uint) map[validatorID]uint {
-	actualState := map[validatorID]uint{}
+func (tr TestRun) getBalances(chain ChainID, modelState map[ValidatorID]uint) map[ValidatorID]uint {
+	actualState := map[ValidatorID]uint{}
 	for k := range modelState {
 		actualState[k] = tr.getBalance(chain, k)
 	}
@@ -264,7 +264,7 @@ func (tr TestRun) getBalances(chain chainID, modelState map[validatorID]uint) ma
 	return actualState
 }
 
-func (tr TestRun) getProposals(chain chainID, modelState map[uint]Proposal) map[uint]Proposal {
+func (tr TestRun) getProposals(chain ChainID, modelState map[uint]Proposal) map[uint]Proposal {
 	actualState := map[uint]Proposal{}
 	for k := range modelState {
 		actualState[k] = tr.getProposal(chain, k)
@@ -273,8 +273,8 @@ func (tr TestRun) getProposals(chain chainID, modelState map[uint]Proposal) map[
 	return actualState
 }
 
-func (tr TestRun) getValPowers(chain chainID, modelState map[validatorID]uint) map[validatorID]uint {
-	actualState := map[validatorID]uint{}
+func (tr TestRun) getValPowers(chain ChainID, modelState map[ValidatorID]uint) map[ValidatorID]uint {
+	actualState := map[ValidatorID]uint{}
 	for k := range modelState {
 		actualState[k] = tr.getValPower(chain, k)
 	}
@@ -282,8 +282,8 @@ func (tr TestRun) getValPowers(chain chainID, modelState map[validatorID]uint) m
 	return actualState
 }
 
-func (tr TestRun) getRepresentativePowers(chain chainID, modelState map[validatorID]uint) map[validatorID]uint {
-	actualState := map[validatorID]uint{}
+func (tr TestRun) getRepresentativePowers(chain ChainID, modelState map[ValidatorID]uint) map[ValidatorID]uint {
+	actualState := map[ValidatorID]uint{}
 	for k := range modelState {
 		actualState[k] = tr.getRepresentativePower(chain, k)
 	}
@@ -291,7 +291,7 @@ func (tr TestRun) getRepresentativePowers(chain chainID, modelState map[validato
 	return actualState
 }
 
-func (tr TestRun) getParams(chain chainID, modelState []Param) []Param {
+func (tr TestRun) getParams(chain ChainID, modelState []Param) []Param {
 	actualState := []Param{}
 	for _, p := range modelState {
 		actualState = append(actualState, Param{Subspace: p.Subspace, Key: p.Key, Value: tr.getParam(chain, p)})
@@ -300,8 +300,8 @@ func (tr TestRun) getParams(chain chainID, modelState []Param) []Param {
 	return actualState
 }
 
-func (tr TestRun) getRewards(chain chainID, modelState Rewards) Rewards {
-	receivedRewards := map[validatorID]bool{}
+func (tr TestRun) getRewards(chain ChainID, modelState Rewards) Rewards {
+	receivedRewards := map[ValidatorID]bool{}
 
 	currentBlock := tr.getBlockHeight(chain)
 	tr.waitBlocks(chain, 1, 10*time.Second)
@@ -318,13 +318,13 @@ func (tr TestRun) getRewards(chain chainID, modelState Rewards) Rewards {
 	return Rewards{IsRewarded: receivedRewards, IsIncrementalReward: modelState.IsIncrementalReward, IsNativeDenom: modelState.IsNativeDenom}
 }
 
-func (tr TestRun) getReward(chain chainID, validator validatorID, blockHeight uint, isNativeDenom bool) float64 {
-	delAddresss := tr.validatorConfigs[validator].delAddress
-	if chain != chainID("provi") && tr.validatorConfigs[validator].useConsumerKey {
-		delAddresss = tr.validatorConfigs[validator].consumerDelAddress
+func (tr TestRun) getReward(chain ChainID, validator ValidatorID, blockHeight uint, isNativeDenom bool) float64 {
+	delAddresss := tr.validatorConfigs[validator].DelAddress
+	if chain != ChainID("provi") && tr.validatorConfigs[validator].UseConsumerKey {
+		delAddresss = tr.validatorConfigs[validator].ConsumerDelAddress
 	}
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[chain].binaryName,
+	bz, err := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[chain].BinaryName,
 
 		"query", "distribution", "rewards",
 		delAddresss,
@@ -345,15 +345,15 @@ func (tr TestRun) getReward(chain chainID, validator validatorID, blockHeight ui
 	return gjson.Get(string(bz), denomCondition).Float()
 }
 
-func (tr TestRun) getBalance(chain chainID, validator validatorID) uint {
+func (tr TestRun) getBalance(chain ChainID, validator ValidatorID) uint {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	valDelAddress := tr.validatorConfigs[validator].delAddress
-	if chain != chainID("provi") && tr.validatorConfigs[validator].useConsumerKey {
-		valDelAddress = tr.validatorConfigs[validator].consumerDelAddress
+	valDelAddress := tr.validatorConfigs[validator].DelAddress
+	if chain != ChainID("provi") && tr.validatorConfigs[validator].UseConsumerKey {
+		valDelAddress = tr.validatorConfigs[validator].ConsumerDelAddress
 	}
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[chain].binaryName,
+	bz, err := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[chain].BinaryName,
 
 		"query", "bank", "balances",
 		valDelAddress,
@@ -373,9 +373,9 @@ func (tr TestRun) getBalance(chain chainID, validator validatorID) uint {
 var noProposalRegex = regexp.MustCompile(`doesn't exist: key not found`)
 
 // interchain-securityd query gov proposals
-func (tr TestRun) getProposal(chain chainID, proposal uint) Proposal {
+func (tr TestRun) getProposal(chain ChainID, proposal uint) Proposal {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[chain].binaryName,
+	bz, err := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[chain].BinaryName,
 
 		"query", "gov", "proposal",
 		fmt.Sprint(proposal),
@@ -411,11 +411,11 @@ func (tr TestRun) getProposal(chain chainID, proposal uint) Proposal {
 		}
 	case "/interchain_security.ccv.provider.v1.ConsumerAdditionProposal":
 		chainId := gjson.Get(string(bz), `messages.0.content.chain_id`).String()
-		spawnTime := gjson.Get(string(bz), `messages.0.content.spawn_time`).Time().Sub(tr.containerConfig.now)
+		spawnTime := gjson.Get(string(bz), `messages.0.content.spawn_time`).Time().Sub(tr.containerConfig.Now)
 
-		var chain chainID
+		var chain ChainID
 		for i, conf := range tr.chainConfigs {
-			if string(conf.chainId) == chainId {
+			if string(conf.ChainId) == chainId {
 				chain = i
 				break
 			}
@@ -443,11 +443,11 @@ func (tr TestRun) getProposal(chain chainID, proposal uint) Proposal {
 		}
 	case "/interchain_security.ccv.provider.v1.ConsumerRemovalProposal":
 		chainId := gjson.Get(string(bz), `messages.0.content.chain_id`).String()
-		stopTime := gjson.Get(string(bz), `messages.0.content.stop_time`).Time().Sub(tr.containerConfig.now)
+		stopTime := gjson.Get(string(bz), `messages.0.content.stop_time`).Time().Sub(tr.containerConfig.Now)
 
-		var chain chainID
+		var chain ChainID
 		for i, conf := range tr.chainConfigs {
-			if string(conf.chainId) == chainId {
+			if string(conf.ChainId) == chainId {
 				chain = i
 				break
 			}
@@ -497,12 +497,12 @@ type ValPubKey struct {
 	Value string `yaml:"value"`
 }
 
-func (tr TestRun) getValPower(chain chainID, validator validatorID) uint {
+func (tr TestRun) getValPower(chain ChainID, validator ValidatorID) uint {
 	if *verbose {
 		log.Println("getting validator power for chain: ", chain, " validator: ", validator)
 	}
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	command := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[chain].binaryName,
+	command := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[chain].BinaryName,
 
 		"query", "tendermint-validator-set",
 
@@ -531,8 +531,8 @@ func (tr TestRun) getValPower(chain chainID, validator validatorID) uint {
 	}
 
 	for _, val := range valset.Validators {
-		if val.Address == tr.validatorConfigs[validator].valconsAddress ||
-			val.Address == tr.validatorConfigs[validator].consumerValconsAddress {
+		if val.Address == tr.validatorConfigs[validator].ValconsAddress ||
+			val.Address == tr.validatorConfigs[validator].ConsumerValconsAddress {
 
 			votingPower, err := strconv.Atoi(val.VotingPower)
 			if err != nil {
@@ -547,12 +547,12 @@ func (tr TestRun) getValPower(chain chainID, validator validatorID) uint {
 	return 0
 }
 
-func (tr TestRun) getRepresentativePower(chain chainID, validator validatorID) uint {
+func (tr TestRun) getRepresentativePower(chain ChainID, validator ValidatorID) uint {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[chain].binaryName,
+	bz, err := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[chain].BinaryName,
 
 		"query", "staking", "validator",
-		tr.validatorConfigs[validator].valoperAddress,
+		tr.validatorConfigs[validator].ValoperAddress,
 
 		`--node`, tr.getQueryNode(chain),
 		`-o`, `json`,
@@ -566,9 +566,9 @@ func (tr TestRun) getRepresentativePower(chain chainID, validator validatorID) u
 	return uint(amount.Uint())
 }
 
-func (tr TestRun) getParam(chain chainID, param Param) string {
+func (tr TestRun) getParam(chain ChainID, param Param) string {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	bz, err := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[chain].binaryName,
+	bz, err := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[chain].BinaryName,
 
 		"query", "params", "subspace",
 		param.Subspace,
@@ -588,9 +588,9 @@ func (tr TestRun) getParam(chain chainID, param Param) string {
 
 // getConsumerChains returns a list of consumer chains that're being secured by the provider chain,
 // determined by querying the provider chain.
-func (tr TestRun) getConsumerChains(chain chainID) map[chainID]bool {
+func (tr TestRun) getConsumerChains(chain ChainID) map[ChainID]bool {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[chain].binaryName,
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[chain].BinaryName,
 
 		"query", "provider", "list-consumer-chains",
 		`--node`, tr.getQueryNode(chain),
@@ -603,17 +603,17 @@ func (tr TestRun) getConsumerChains(chain chainID) map[chainID]bool {
 	}
 
 	arr := gjson.Get(string(bz), "chains").Array()
-	chains := make(map[chainID]bool)
+	chains := make(map[ChainID]bool)
 	for _, c := range arr {
 		id := c.Get("chain_id").String()
-		chains[chainID(id)] = true
+		chains[ChainID(id)] = true
 	}
 
 	return chains
 }
 
-func (tr TestRun) getConsumerAddresses(chain chainID, modelState map[validatorID]string) map[validatorID]string {
-	actualState := map[validatorID]string{}
+func (tr TestRun) getConsumerAddresses(chain ChainID, modelState map[ValidatorID]string) map[ValidatorID]string {
+	actualState := map[ValidatorID]string{}
 	for k := range modelState {
 		actualState[k] = tr.getConsumerAddress(chain, k)
 	}
@@ -621,8 +621,8 @@ func (tr TestRun) getConsumerAddresses(chain chainID, modelState map[validatorID
 	return actualState
 }
 
-func (tr TestRun) getProviderAddresses(chain chainID, modelState map[validatorID]string) map[validatorID]string {
-	actualState := map[validatorID]string{}
+func (tr TestRun) getProviderAddresses(chain ChainID, modelState map[ValidatorID]string) map[ValidatorID]string {
+	actualState := map[ValidatorID]string{}
 	for k := range modelState {
 		actualState[k] = tr.getProviderAddressFromConsumer(chain, k)
 	}
@@ -630,13 +630,13 @@ func (tr TestRun) getProviderAddresses(chain chainID, modelState map[validatorID
 	return actualState
 }
 
-func (tr TestRun) getConsumerAddress(consumerChain chainID, validator validatorID) string {
+func (tr TestRun) getConsumerAddress(consumerChain ChainID, validator ValidatorID) string {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[chainID("provi")].binaryName,
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[ChainID("provi")].BinaryName,
 
 		"query", "provider", "validator-consumer-key",
-		string(consumerChain), tr.validatorConfigs[validator].valconsAddress,
-		`--node`, tr.getQueryNode(chainID("provi")),
+		string(consumerChain), tr.validatorConfigs[validator].ValconsAddress,
+		`--node`, tr.getQueryNode(ChainID("provi")),
 		`-o`, `json`,
 	)
 	bz, err := cmd.CombinedOutput()
@@ -648,13 +648,13 @@ func (tr TestRun) getConsumerAddress(consumerChain chainID, validator validatorI
 	return addr
 }
 
-func (tr TestRun) getProviderAddressFromConsumer(consumerChain chainID, validator validatorID) string {
+func (tr TestRun) getProviderAddressFromConsumer(consumerChain ChainID, validator ValidatorID) string {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[chainID("provi")].binaryName,
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[ChainID("provi")].BinaryName,
 
 		"query", "provider", "validator-provider-key",
-		string(consumerChain), tr.validatorConfigs[validator].consumerValconsAddress,
-		`--node`, tr.getQueryNode(chainID("provi")),
+		string(consumerChain), tr.validatorConfigs[validator].ConsumerValconsAddress,
+		`--node`, tr.getQueryNode(ChainID("provi")),
 		`-o`, `json`,
 	)
 
@@ -669,10 +669,10 @@ func (tr TestRun) getProviderAddressFromConsumer(consumerChain chainID, validato
 
 func (tr TestRun) getGlobalSlashQueueSize() uint {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[chainID("provi")].binaryName,
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[ChainID("provi")].BinaryName,
 
 		"query", "provider", "throttle-state",
-		`--node`, tr.getQueryNode(chainID("provi")),
+		`--node`, tr.getQueryNode(ChainID("provi")),
 		`-o`, `json`,
 	)
 	bz, err := cmd.CombinedOutput()
@@ -684,13 +684,13 @@ func (tr TestRun) getGlobalSlashQueueSize() uint {
 	return uint(len(packets))
 }
 
-func (tr TestRun) getConsumerChainPacketQueueSize(consumerChain chainID) uint {
+func (tr TestRun) getConsumerChainPacketQueueSize(consumerChain ChainID) uint {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[chainID("provi")].binaryName,
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[ChainID("provi")].BinaryName,
 
 		"query", "provider", "throttled-consumer-packet-data",
 		string(consumerChain),
-		`--node`, tr.getQueryNode(chainID("provi")),
+		`--node`, tr.getQueryNode(ChainID("provi")),
 		`-o`, `json`,
 	)
 	bz, err := cmd.CombinedOutput()
@@ -702,9 +702,9 @@ func (tr TestRun) getConsumerChainPacketQueueSize(consumerChain chainID) uint {
 	return uint(size)
 }
 
-func (tr TestRun) getRegisteredConsumerRewardDenoms(chain chainID) []string {
+func (tr TestRun) getRegisteredConsumerRewardDenoms(chain ChainID) []string {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, tr.chainConfigs[chain].binaryName,
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[chain].BinaryName,
 
 		"query", "provider", "registered-consumer-reward-denoms",
 		`--node`, tr.getQueryNode(chain),
@@ -724,7 +724,7 @@ func (tr TestRun) getRegisteredConsumerRewardDenoms(chain chainID) []string {
 	return rewardDenoms
 }
 
-func (tr TestRun) getValidatorNode(chain chainID, validator validatorID) string {
+func (tr TestRun) getValidatorNode(chain ChainID, validator ValidatorID) string {
 	// for CometMock, validatorNodes are all the same address as the query node (which is CometMocks address)
 	if tr.useCometmock {
 		return tr.getQueryNode(chain)
@@ -733,41 +733,41 @@ func (tr TestRun) getValidatorNode(chain chainID, validator validatorID) string 
 	return "tcp://" + tr.getValidatorIP(chain, validator) + ":26658"
 }
 
-func (tr TestRun) getValidatorIP(chain chainID, validator validatorID) string {
-	return tr.chainConfigs[chain].ipPrefix + "." + tr.validatorConfigs[validator].ipSuffix
+func (tr TestRun) getValidatorIP(chain ChainID, validator ValidatorID) string {
+	return tr.chainConfigs[chain].IpPrefix + "." + tr.validatorConfigs[validator].IpSuffix
 }
 
-func (tr TestRun) getValidatorHome(chain chainID, validator validatorID) string {
-	return `/` + string(tr.chainConfigs[chain].chainId) + `/validator` + fmt.Sprint(validator)
+func (tr TestRun) getValidatorHome(chain ChainID, validator ValidatorID) string {
+	return `/` + string(tr.chainConfigs[chain].ChainId) + `/validator` + fmt.Sprint(validator)
 }
 
 // getQueryNode returns query node tcp address on chain.
-func (tr TestRun) getQueryNode(chain chainID) string {
+func (tr TestRun) getQueryNode(chain ChainID) string {
 	return fmt.Sprintf("tcp://%s", tr.getQueryNodeRPCAddress(chain))
 }
 
-func (tr TestRun) getQueryNodeRPCAddress(chain chainID) string {
+func (tr TestRun) getQueryNodeRPCAddress(chain ChainID) string {
 	return fmt.Sprintf("%s:26658", tr.getQueryNodeIP(chain))
 }
 
 // getQueryNodeIP returns query node IP for chain,
 // ipSuffix is hardcoded to be 253 on all query nodes
 // except for "sover" chain where there's only one node
-func (tr TestRun) getQueryNodeIP(chain chainID) string {
-	if chain == chainID("sover") {
+func (tr TestRun) getQueryNodeIP(chain ChainID) string {
+	if chain == ChainID("sover") {
 		// return address of first and only validator
 		return fmt.Sprintf("%s.%s",
-			tr.chainConfigs[chain].ipPrefix,
-			tr.validatorConfigs[validatorID("alice")].ipSuffix)
+			tr.chainConfigs[chain].IpPrefix,
+			tr.validatorConfigs[ValidatorID("alice")].IpSuffix)
 	}
-	return fmt.Sprintf("%s.253", tr.chainConfigs[chain].ipPrefix)
+	return fmt.Sprintf("%s.253", tr.chainConfigs[chain].IpPrefix)
 }
 
 func (tr TestRun) curlJsonRPCRequest(method, params, address string) {
 	cmd_template := `curl -H 'Content-Type: application/json' -H 'Accept:application/json' --data '{"jsonrpc":"2.0","method":"%s","params":%s,"id":1}' %s`
 
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
-	cmd := exec.Command("docker", "exec", tr.containerConfig.instanceName, "bash", "-c", fmt.Sprintf(cmd_template, method, params, address))
+	cmd := exec.Command("docker", "exec", tr.containerConfig.InstanceName, "bash", "-c", fmt.Sprintf(cmd_template, method, params, address))
 
 	verbosity := false
 	executeCommandWithVerbosity(cmd, "curlJsonRPCRequest", verbosity)

--- a/tests/e2e/step_delegation.go
+++ b/tests/e2e/step_delegation.go
@@ -4,76 +4,76 @@ package main
 func stepsDelegate(consumerName string) []Step {
 	return []Step{
 		{
-			action: delegateTokensAction{
-				chain:  chainID("provi"),
-				from:   validatorID("alice"),
-				to:     validatorID("alice"),
-				amount: 11000000,
+			Action: delegateTokensAction{
+				Chain:  ChainID("provi"),
+				From:   ValidatorID("alice"),
+				To:     ValidatorID("alice"),
+				Amount: 11000000,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 500,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 500,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: SendTokensAction{
-				chain:  chainID(consumerName),
-				from:   validatorID("alice"),
-				to:     validatorID("bob"),
-				amount: 1,
+			Action: SendTokensAction{
+				Chain:  ChainID(consumerName),
+				From:   ValidatorID("alice"),
+				To:     ValidatorID("bob"),
+				Amount: 1,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
+			State: State{
+				ChainID(consumerName): ChainState{
 					// Tx should not go through, ICS channel is not setup until first VSC packet has been relayed to consumer
-					ValBalances: &map[validatorID]uint{
-						validatorID("alice"): 10000000000,
-						validatorID("bob"):   10000000000,
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("alice"): 10000000000,
+						ValidatorID("bob"):   10000000000,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: SendTokensAction{
-				chain:  chainID(consumerName),
-				from:   validatorID("alice"),
-				to:     validatorID("bob"),
-				amount: 1,
+			Action: SendTokensAction{
+				Chain:  ChainID(consumerName),
+				From:   ValidatorID("alice"),
+				To:     ValidatorID("bob"),
+				Amount: 1,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
+			State: State{
+				ChainID(consumerName): ChainState{
 					// Now tx should execute
-					ValBalances: &map[validatorID]uint{
-						validatorID("alice"): 9999999999,
-						validatorID("bob"):   10000000001,
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("alice"): 9999999999,
+						ValidatorID("bob"):   10000000001,
 					},
 				},
 			},
@@ -85,43 +85,43 @@ func stepsDelegate(consumerName string) []Step {
 func stepsUnbond(consumerName string) []Step {
 	return []Step{
 		{
-			action: unbondTokensAction{
-				chain:      chainID("provi"),
-				unbondFrom: validatorID("alice"),
-				sender:     validatorID("alice"),
-				amount:     1000000,
+			Action: unbondTokensAction{
+				Chain:      ChainID("provi"),
+				UnbondFrom: ValidatorID("alice"),
+				Sender:     ValidatorID("alice"),
+				Amount:     1000000,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 510,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 510,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID("consu"): ChainState{
-					ValPowers: &map[validatorID]uint{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// Voting power on consumer should not be affected yet
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("consu"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 510,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 510,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
@@ -134,85 +134,85 @@ func stepsUnbond(consumerName string) []Step {
 func stepsCancelUnbond(consumerName string) []Step {
 	return []Step{
 		{
-			action: unbondTokensAction{
-				chain:      chainID("provi"),
-				unbondFrom: validatorID("alice"),
-				sender:     validatorID("alice"),
-				amount:     1000000,
+			Action: unbondTokensAction{
+				Chain:      ChainID("provi"),
+				UnbondFrom: ValidatorID("alice"),
+				Sender:     ValidatorID("alice"),
+				Amount:     1000000,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID("consu"): ChainState{
-					ValPowers: &map[validatorID]uint{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// Voting power on consumer should not be affected yet
-						validatorID("alice"): 510,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+						ValidatorID("alice"): 510,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("consu"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: cancelUnbondTokensAction{
-				chain:     chainID("provi"),
-				delegator: validatorID("alice"),
-				validator: validatorID("alice"),
-				amount:    1000000, // cancel unbonding the full amount
+			Action: cancelUnbondTokensAction{
+				Chain:     ChainID("provi"),
+				Delegator: ValidatorID("alice"),
+				Validator: ValidatorID("alice"),
+				Amount:    1000000, // cancel unbonding the full amount
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 510, // power restored
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 510, // power restored
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID("consu"): ChainState{
-					ValPowers: &map[validatorID]uint{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// Voting power on consumer should not be affected yet
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("consu"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 510, // power restored on consumer
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 510, // power restored on consumer
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
@@ -226,45 +226,45 @@ func stepsCancelUnbond(consumerName string) []Step {
 func stepsRedelegateForOptOut(consumerName string) []Step {
 	return []Step{
 		{
-			action: redelegateTokensAction{
-				chain:    chainID("provi"),
-				src:      validatorID("alice"),
-				dst:      validatorID("carol"),
-				txSender: validatorID("alice"),
-				amount:   450000000,
+			Action: redelegateTokensAction{
+				Chain:    ChainID("provi"),
+				Src:      ValidatorID("alice"),
+				Dst:      ValidatorID("carol"),
+				TxSender: ValidatorID("alice"),
+				Amount:   450000000,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 60,
-						validatorID("bob"):   500,
-						validatorID("carol"): 950,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 60,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 950,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// Voting power changes not seen by consumer yet
-						validatorID("alice"): 510,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+						ValidatorID("alice"): 510,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// Now power changes are seen by consumer
-						validatorID("alice"): 60,
-						validatorID("bob"):   500,
-						validatorID("carol"): 950,
+						ValidatorID("alice"): 60,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 950,
 					},
 				},
 			},
@@ -276,48 +276,48 @@ func stepsRedelegateForOptOut(consumerName string) []Step {
 func stepsRedelegate(consumerName string) []Step {
 	return []Step{
 		{
-			action: redelegateTokensAction{
-				chain:    chainID("provi"),
-				src:      validatorID("carol"),
-				dst:      validatorID("alice"),
-				txSender: validatorID("carol"),
+			Action: redelegateTokensAction{
+				Chain:    ChainID("provi"),
+				Src:      ValidatorID("carol"),
+				Dst:      ValidatorID("alice"),
+				TxSender: ValidatorID("carol"),
 				// redelegate s.t. alice has majority stake so non-faulty validators maintain more than
 				// 2/3 voting power during downtime tests below, avoiding chain halt
-				amount: 449000000,
+				Amount: 449000000,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
 						// carol always uses a consumer assigned key
-						validatorID("carol"): 501,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// Voting power changes not seen by consumer yet
-						validatorID("alice"): 60,
-						validatorID("bob"):   500,
-						validatorID("carol"): 950,
+						ValidatorID("alice"): 60,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 950,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// Now power changes are seen by consumer
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
 			},
@@ -329,48 +329,48 @@ func stepsRedelegate(consumerName string) []Step {
 func stepsRedelegateShort(consumerName string) []Step {
 	return []Step{
 		{
-			action: redelegateTokensAction{
-				chain:    chainID("provi"),
-				src:      validatorID("alice"),
-				dst:      validatorID("carol"),
-				txSender: validatorID("alice"),
+			Action: redelegateTokensAction{
+				Chain:    ChainID("provi"),
+				Src:      ValidatorID("alice"),
+				Dst:      ValidatorID("carol"),
+				TxSender: ValidatorID("alice"),
 				// Leave alice with majority stake so non-faulty validators maintain more than
 				// 2/3 voting power during downtime tests below, avoiding chain halt
-				amount: 1000000,
+				Amount: 1000000,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
 						// carol always uses a consumer assigned key
-						validatorID("carol"): 501,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// Voting power changes not seen by consumer yet
-						validatorID("alice"): 510,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+						ValidatorID("alice"): 510,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// Now power changes are seen by consumer
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
 			},

--- a/tests/e2e/steps.go
+++ b/tests/e2e/steps.go
@@ -1,8 +1,8 @@
 package main
 
 type Step struct {
-	action interface{}
-	state  State
+	Action interface{}
+	State  State
 }
 
 func concatSteps(steps ...[]Step) []Step {
@@ -66,7 +66,7 @@ var slashThrottleSteps = concatSteps(
 	stepsStopChain("consu", 2),
 )
 
-var democracySteps = concatSteps(
+var democracyRewardsSteps = concatSteps(
 	// democracySteps requires a transfer channel
 	stepsStartChains([]string{"democ"}, true),
 	// delegation needs to happen so the first VSC packet can be delivered
@@ -74,7 +74,7 @@ var democracySteps = concatSteps(
 	stepsDemocracy("democ"),
 )
 
-var rewardDenomConsumerSteps = concatSteps(
+var democracySteps = concatSteps(
 	// democracySteps requires a transfer channel
 	stepsStartChains([]string{"democ"}, true),
 	// delegation needs to happen so the first VSC packet can be delivered

--- a/tests/e2e/steps_democracy.go
+++ b/tests/e2e/steps_democracy.go
@@ -5,22 +5,22 @@ const consumerRewardDenom = "ibc/3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821
 func stepsDemocracy(consumerName string) []Step {
 	return []Step{
 		{
-			action: registerRepresentativeAction{
-				chain:           chainID(consumerName),
-				representatives: []validatorID{validatorID("alice"), validatorID("bob")},
-				stakes:          []uint{100000000, 40000000},
+			Action: registerRepresentativeAction{
+				Chain:           ChainID(consumerName),
+				Representatives: []ValidatorID{ValidatorID("alice"), ValidatorID("bob")},
+				Stakes:          []uint{100000000, 40000000},
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					RepresentativePowers: &map[validatorID]uint{
-						validatorID("alice"): 100000000,
-						validatorID("bob"):   40000000,
+			State: State{
+				ChainID(consumerName): ChainState{
+					RepresentativePowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 100000000,
+						ValidatorID("bob"):   40000000,
 					},
 					Rewards: &Rewards{
-						IsRewarded: map[validatorID]bool{
-							validatorID("alice"): true,
-							validatorID("bob"):   true,
-							validatorID("carol"): false,
+						IsRewarded: map[ValidatorID]bool{
+							ValidatorID("alice"): true,
+							ValidatorID("bob"):   true,
+							ValidatorID("carol"): false,
 						},
 						IsIncrementalReward: true,
 						IsNativeDenom:       true,
@@ -29,31 +29,31 @@ func stepsDemocracy(consumerName string) []Step {
 			},
 		},
 		{
-			action: delegateTokensAction{
-				chain:  chainID(consumerName),
-				from:   validatorID("carol"),
-				to:     validatorID("alice"),
-				amount: 500000,
+			Action: delegateTokensAction{
+				Chain:  ChainID(consumerName),
+				From:   ValidatorID("carol"),
+				To:     ValidatorID("alice"),
+				Amount: 500000,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
+			State: State{
+				ChainID(consumerName): ChainState{
 					// Check that delegators on gov-consumer chain can change representative powers
-					RepresentativePowers: &map[validatorID]uint{
-						validatorID("alice"): 100500000,
-						validatorID("bob"):   40000000,
+					RepresentativePowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 100500000,
+						ValidatorID("bob"):   40000000,
 					},
 					// Check that delegating on gov-consumer does not change validator powers
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 					// Check that tokens are minted and distributed to representatives and their delegators
 					Rewards: &Rewards{
-						IsRewarded: map[validatorID]bool{
-							validatorID("alice"): true,
-							validatorID("bob"):   true,
-							validatorID("carol"): true,
+						IsRewarded: map[ValidatorID]bool{
+							ValidatorID("alice"): true,
+							ValidatorID("bob"):   true,
+							ValidatorID("carol"): true,
 						},
 						IsIncrementalReward: true,
 						IsNativeDenom:       true,
@@ -63,19 +63,19 @@ func stepsDemocracy(consumerName string) []Step {
 		},
 		{
 			// whitelisted legacy proposal can only handle ibctransfer.SendEnabled/ReceiveEnabled
-			action: submitParamChangeLegacyProposalAction{
-				chain:    chainID(consumerName),
-				from:     validatorID("alice"),
-				deposit:  10000001,
-				subspace: "transfer",
-				key:      "SendEnabled",
-				value:    true,
+			Action: submitParamChangeLegacyProposalAction{
+				Chain:    ChainID(consumerName),
+				From:     ValidatorID("alice"),
+				Deposit:  10000001,
+				Subspace: "transfer",
+				Key:      "SendEnabled",
+				Value:    true,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValBalances: &map[validatorID]uint{
-						validatorID("alice"): 9889999998,
-						validatorID("bob"):   9960000001,
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("alice"): 9889999998,
+						ValidatorID("bob"):   9960000001,
 					},
 					Proposals: &map[uint]Proposal{
 						1: ParamsProposal{
@@ -91,17 +91,17 @@ func stepsDemocracy(consumerName string) []Step {
 		},
 		{
 			// Have accounts vote on something on the gov-consumer chain
-			action: voteGovProposalAction{
-				chain:      chainID(consumerName),
-				from:       []validatorID{validatorID("alice"), validatorID("bob")},
-				vote:       []string{"yes", "no"},
-				propNumber: 1,
+			Action: voteGovProposalAction{
+				Chain:      ChainID(consumerName),
+				From:       []ValidatorID{ValidatorID("alice"), ValidatorID("bob")},
+				Vote:       []string{"yes", "no"},
+				PropNumber: 1,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValBalances: &map[validatorID]uint{
-						validatorID("alice"): 9889999998,
-						validatorID("bob"):   9960000001,
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("alice"): 9889999998,
+						ValidatorID("bob"):   9960000001,
 					},
 					// Check that the parameter is changed on gov-consumer chain
 					Params: &([]Param{{Subspace: "transfer", Key: "SendEnabled", Value: "true"}}),
@@ -109,20 +109,20 @@ func stepsDemocracy(consumerName string) []Step {
 			},
 		},
 		{
-			action: relayRewardPacketsToProviderAction{
-				consumerChain: chainID(consumerName),
-				providerChain: chainID("provi"),
-				port:          "transfer",
-				channel:       1,
+			Action: relayRewardPacketsToProviderAction{
+				ConsumerChain: ChainID(consumerName),
+				ProviderChain: ChainID("provi"),
+				Port:          "transfer",
+				Channel:       1,
 			},
-			state: State{
-				chainID("provi"): ChainState{
+			State: State{
+				ChainID("provi"): ChainState{
 					// Check that tokens are not distributed before the denom has been registered
 					Rewards: &Rewards{
-						IsRewarded: map[validatorID]bool{
-							validatorID("alice"): false,
-							validatorID("bob"):   false,
-							validatorID("carol"): false,
+						IsRewarded: map[ValidatorID]bool{
+							ValidatorID("alice"): false,
+							ValidatorID("bob"):   false,
+							ValidatorID("carol"): false,
 						},
 						IsIncrementalReward: false,
 						IsNativeDenom:       false,
@@ -133,47 +133,47 @@ func stepsDemocracy(consumerName string) []Step {
 			},
 		},
 		{
-			action: submitChangeRewardDenomsProposalAction{
-				denom:   consumerRewardDenom,
-				deposit: 10000001,
-				from:    validatorID("bob"),
+			Action: submitChangeRewardDenomsProposalAction{
+				Denom:   consumerRewardDenom,
+				Deposit: 10000001,
+				From:    ValidatorID("bob"),
 			},
-			state: State{
-				chainID("provi"): ChainState{
+			State: State{
+				ChainID("provi"): ChainState{
 					// Denom not yet registered, gov prop needs to pass first
 					RegisteredConsumerRewardDenoms: &[]string{},
 				},
 			},
 		},
 		{
-			action: voteGovProposalAction{
-				chain:      chainID("provi"),
-				from:       []validatorID{validatorID("alice"), validatorID("bob"), validatorID("carol")},
-				vote:       []string{"yes", "yes", "yes"},
-				propNumber: 2,
+			Action: voteGovProposalAction{
+				Chain:      ChainID("provi"),
+				From:       []ValidatorID{ValidatorID("alice"), ValidatorID("bob"), ValidatorID("carol")},
+				Vote:       []string{"yes", "yes", "yes"},
+				PropNumber: 2,
 			},
-			state: State{
-				chainID("provi"): ChainState{
+			State: State{
+				ChainID("provi"): ChainState{
 					// Check that the denom is registered on provider chain
 					RegisteredConsumerRewardDenoms: &[]string{consumerRewardDenom},
 				},
 			},
 		},
 		{
-			action: relayRewardPacketsToProviderAction{
-				consumerChain: chainID(consumerName),
-				providerChain: chainID("provi"),
-				port:          "transfer",
-				channel:       1,
+			Action: relayRewardPacketsToProviderAction{
+				ConsumerChain: ChainID(consumerName),
+				ProviderChain: ChainID("provi"),
+				Port:          "transfer",
+				Channel:       1,
 			},
-			state: State{
-				chainID("provi"): ChainState{
+			State: State{
+				ChainID("provi"): ChainState{
 					// Check that tokens are minted and sent to provider chain and distributed to validators and their delegators on provider chain
 					Rewards: &Rewards{
-						IsRewarded: map[validatorID]bool{
-							validatorID("alice"): true,
-							validatorID("bob"):   true,
-							validatorID("carol"): true,
+						IsRewarded: map[ValidatorID]bool{
+							ValidatorID("alice"): true,
+							ValidatorID("bob"):   true,
+							ValidatorID("carol"): true,
 						},
 						IsIncrementalReward: false,
 						IsNativeDenom:       false,
@@ -182,49 +182,49 @@ func stepsDemocracy(consumerName string) []Step {
 			},
 		},
 		{
-			action: downtimeSlashAction{
-				chain:     chainID(consumerName),
-				validator: validatorID("bob"),
+			Action: downtimeSlashAction{
+				Chain:     ChainID(consumerName),
+				Validator: ValidatorID("bob"),
 			},
-			state: State{
+			State: State{
 				// validator should be slashed on consumer, powers not affected on either chain yet
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
 						// Downtime jailing and corresponding voting power change are processed by provider
-						validatorID("bob"):   0,
-						validatorID("carol"): 500,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
@@ -232,63 +232,63 @@ func stepsDemocracy(consumerName string) []Step {
 		// A block is incremented each action, hence why VSC is committed on provider,
 		// and can now be relayed as packet to consumer
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
 						// VSC now seen on consumer
-						validatorID("bob"):   0,
-						validatorID("carol"): 500,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: unjailValidatorAction{
-				provider:  chainID("provi"),
-				validator: validatorID("bob"),
+			Action: unjailValidatorAction{
+				Provider:  ChainID("provi"),
+				Validator: ValidatorID("bob"),
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   0,
-						validatorID("carol"): 500,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 					// Check that slashing on the gov-consumer chain does not result in slashing for the representatives or their delegators
-					RepresentativePowers: &map[validatorID]uint{
-						validatorID("alice"): 100500000,
-						validatorID("bob"):   40000000,
+					RepresentativePowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 100500000,
+						ValidatorID("bob"):   40000000,
 					},
 				},
 			},

--- a/tests/e2e/steps_double_sign.go
+++ b/tests/e2e/steps_double_sign.go
@@ -5,49 +5,49 @@ func stepsDoubleSignOnProviderAndConsumer(consumerName string) []Step {
 	return []Step{
 		{
 			// provider double sign
-			action: doublesignSlashAction{
-				chain:     chainID("provi"),
-				validator: validatorID("carol"),
+			Action: doublesignSlashAction{
+				Chain:     ChainID("provi"),
+				Validator: ValidatorID("carol"),
 			},
-			state: State{
+			State: State{
 				// slash on provider
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0, // from 500 to 0
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0, // from 500 to 0
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 495, // not tombstoned on consumerName yet
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 495, // not tombstoned on consumerName yet
 					},
 				},
 			},
 		},
 		{
 			// relay power change to consumerName
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0, // consumerName channel
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0, // consumerName channel
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0, // tombstoning visible on consumerName
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0, // tombstoning visible on consumerName
 					},
 				},
 			},
@@ -56,72 +56,72 @@ func stepsDoubleSignOnProviderAndConsumer(consumerName string) []Step {
 			// consumer double sign
 			// provider will only log the double sign slash
 			// stepsSubmitEquivocationProposal will cause the double sign slash to be executed
-			action: doublesignSlashAction{
-				chain:     chainID("consu"),
-				validator: validatorID("bob"),
+			Action: doublesignSlashAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("bob"),
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500, // not tombstoned
-						validatorID("carol"): 0,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500, // not tombstoned
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500, // not tombstoned
-						validatorID("carol"): 0,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500, // not tombstoned
+						ValidatorID("carol"): 0,
 					},
 				},
 			},
 		},
 		{
 			// consumer learns about the double sign
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500, // not tombstoned
-						validatorID("carol"): 0,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500, // not tombstoned
+						ValidatorID("carol"): 0,
 					},
 				},
 			},

--- a/tests/e2e/steps_downtime.go
+++ b/tests/e2e/steps_downtime.go
@@ -15,49 +15,49 @@ import "time"
 func stepsDowntime(consumerName string) []Step {
 	return []Step{
 		{
-			action: downtimeSlashAction{
-				chain:     chainID(consumerName),
-				validator: validatorID("bob"),
+			Action: downtimeSlashAction{
+				Chain:     ChainID(consumerName),
+				Validator: ValidatorID("bob"),
 			},
-			state: State{
+			State: State{
 				// validator should be slashed on consumer, powers not affected on either chain yet
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
 						// Downtime jailing and corresponding voting power change are processed by provider
-						validatorID("bob"):   0,
-						validatorID("carol"): 501,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
 			},
@@ -65,144 +65,144 @@ func stepsDowntime(consumerName string) []Step {
 		// A block is incremented each action, hence why VSC is committed on provider,
 		// and can now be relayed as packet to consumer
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
 						// VSC now seen on consumer
-						validatorID("bob"):   0,
-						validatorID("carol"): 501,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 501,
 					},
 				},
 			},
 		},
 		{
-			action: unjailValidatorAction{
-				provider:  chainID("provi"),
-				validator: validatorID("bob"),
+			Action: unjailValidatorAction{
+				Provider:  ChainID("provi"),
+				Validator: ValidatorID("bob"),
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
 						// bob's stake should not be slashed
 						// since the slash was initiated from consumer
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   0,
-						validatorID("carol"): 501,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 501,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
 						// bob's stake should not be slashed
 						// since the slash was initiated from consumer
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
 			},
 		},
 		// Now we test provider initiated downtime/slashing
 		{
-			action: downtimeSlashAction{
-				chain:     chainID("provi"),
-				validator: validatorID("carol"),
+			Action: downtimeSlashAction{
+				Chain:     ChainID("provi"),
+				Validator: ValidatorID("carol"),
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// Non faulty validators still maintain just above 2/3 power here
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
 						// Carol's stake should be slashed and jailed
 						// downtime slash was initiated from provider
-						validatorID("carol"): 0,
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
-					},
-				},
-			},
-		},
-		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
-			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
 			},
 		},
 		{
-			action: unjailValidatorAction{
-				provider:  chainID("provi"),
-				validator: validatorID("carol"),
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 495,
-					},
-				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: unjailValidatorAction{
+				Provider:  ChainID("provi"),
+				Validator: ValidatorID("carol"),
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 495,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 495,
+					},
+				},
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
+					},
+				},
+			},
+		},
+		{
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
+			},
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 495,
 					},
 				},
 			},
@@ -217,49 +217,49 @@ func stepsDowntime(consumerName string) []Step {
 func stepsDowntimeWithOptOut(consumerName string) []Step {
 	return []Step{
 		{
-			action: downtimeSlashAction{
-				chain:     chainID(consumerName),
-				validator: validatorID("alice"),
+			Action: downtimeSlashAction{
+				Chain:     ChainID(consumerName),
+				Validator: ValidatorID("alice"),
 			},
-			state: State{
+			State: State{
 				// powers not affected on either chain
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 60,
-						validatorID("bob"):   500,
-						validatorID("carol"): 950,
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 60,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 950,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 60,
-						validatorID("bob"):   500,
-						validatorID("carol"): 950,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 60,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 950,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// alice is not slashed or jailed due to soft opt out
-						validatorID("alice"): 60,
-						validatorID("bob"):   500,
-						validatorID("carol"): 950,
+						ValidatorID("alice"): 60,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 950,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 60,
-						validatorID("bob"):   500,
-						validatorID("carol"): 950,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 60,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 950,
 					},
 				},
 			},
@@ -273,24 +273,24 @@ func stepsDowntimeWithOptOut(consumerName string) []Step {
 func stepsThrottledDowntime(consumerName string) []Step {
 	return []Step{
 		{
-			action: downtimeSlashAction{
-				chain:     chainID(consumerName),
-				validator: validatorID("bob"),
+			Action: downtimeSlashAction{
+				Chain:     ChainID(consumerName),
+				Validator: ValidatorID("bob"),
 			},
-			state: State{
+			State: State{
 				// slash packet queued on consumer, but powers not affected on either chain yet
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
@@ -299,115 +299,115 @@ func stepsThrottledDowntime(consumerName string) []Step {
 		// and consumer receives ack that provider recv the downtime slash.
 		// The latter is necessary for the consumer to send the second downtime slash.
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   0, // bob is jailed
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   0, // bob is jailed
+						ValidatorID("carol"): 500,
 					},
 					// no provider throttling engaged yet
 					GlobalSlashQueueSize: uintPointer(0),
-					ConsumerChainQueueSizes: &map[chainID]uint{
-						chainID(consumerName): uint(0),
+					ConsumerChainQueueSizes: &map[ChainID]uint{
+						ChainID(consumerName): uint(0),
 					},
 				},
-				chainID(consumerName): ChainState{
+				ChainID(consumerName): ChainState{
 					// VSC packet applying jailing is not yet relayed to consumer
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: downtimeSlashAction{
-				chain:     chainID(consumerName),
-				validator: validatorID("carol"),
+			Action: downtimeSlashAction{
+				Chain:     ChainID(consumerName),
+				Validator: ValidatorID("carol"),
 			},
-			state: State{
+			State: State{
 				// powers not affected on either chain yet
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   0,
-						validatorID("carol"): 500,
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumerName): ChainState{
+				ChainID(consumerName): ChainState{
 					// VSC packet applying jailing is not yet relayed to consumer
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   0,
-						validatorID("carol"): 500, // not slashed due to throttling
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 500, // not slashed due to throttling
 					},
 					GlobalSlashQueueSize: uintPointer(1), // carol's slash request is throttled
-					ConsumerChainQueueSizes: &map[chainID]uint{
-						chainID(consumerName): uint(1),
+					ConsumerChainQueueSizes: &map[ChainID]uint{
+						ChainID(consumerName): uint(1),
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   0,
-						validatorID("carol"): 500,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: slashThrottleDequeue{
-				chain:            chainID(consumerName),
-				currentQueueSize: 1,
-				nextQueueSize:    0,
+			Action: slashThrottleDequeue{
+				Chain:            ChainID(consumerName),
+				CurrentQueueSize: 1,
+				NextQueueSize:    0,
 				// Slash meter replenish fraction is set to 10%, replenish period is 20 seconds, see config.go
 				// Meter is initially at 10%, decremented to -23% from bob being jailed. It'll then take three replenishments
 				// for meter to become positive again. 3*20 = 60 seconds + buffer = 80 seconds
-				timeout: 80 * time.Second,
+				Timeout: 80 * time.Second,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   0,
-						validatorID("carol"): 0, // Carol is jailed upon packet being handled on provider
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 0, // Carol is jailed upon packet being handled on provider
 					},
 					GlobalSlashQueueSize: uintPointer(0), // slash packets dequeued
-					ConsumerChainQueueSizes: &map[chainID]uint{
-						chainID(consumerName): 0,
+					ConsumerChainQueueSizes: &map[ChainID]uint{
+						ChainID(consumerName): 0,
 					},
 				},
-				chainID(consumerName): ChainState{
+				ChainID(consumerName): ChainState{
 					// no updates received on consumer
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   0,
-						validatorID("carol"): 500,
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
@@ -415,30 +415,30 @@ func stepsThrottledDowntime(consumerName string) []Step {
 		// A block is incremented each action, hence why VSC is committed on provider,
 		// and can now be relayed as packet to consumer
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   0,
-						validatorID("carol"): 0,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 0,
 					},
 					GlobalSlashQueueSize: uintPointer(0),
-					ConsumerChainQueueSizes: &map[chainID]uint{
-						chainID(consumerName): 0,
+					ConsumerChainQueueSizes: &map[ChainID]uint{
+						ChainID(consumerName): 0,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
 						// throttled update gets to consumer
-						validatorID("bob"):   0,
-						validatorID("carol"): 0,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 0,
 					},
 				},
 			},

--- a/tests/e2e/steps_light_client_attack.go
+++ b/tests/e2e/steps_light_client_attack.go
@@ -4,124 +4,124 @@ package main
 func stepsLightClientAttackOnProviderAndConsumer(consumerName string) []Step {
 	return []Step{
 		{
-			// provider double sign
-			action: lightClientEquivocationAttackAction{
-				chain:     chainID("provi"),
-				validator: validatorID("carol"),
+			// Provider double sign
+			Action: lightClientEquivocationAttackAction{
+				Chain:     ChainID("provi"),
+				Validator: ValidatorID("carol"),
 			},
-			state: State{
-				// slash on provider
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0, // from 500 to 0
+			State: State{
+				// Slash on provider
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0, // from 500 to 0
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 495, // not tombstoned on consumerName yet
-					},
-				},
-			},
-		},
-		{
-			// relay power change to consumerName
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0, // consumerName channel
-			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
-					},
-				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0, // tombstoning visible on consumerName
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 495, // not tombstoned on consumerName yet
 					},
 				},
 			},
 		},
 		{
-			// consumer double sign
-			// provider will only log the double sign slash
+			// Relay power change to consumerName
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0, // consumerName channel
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
+					},
+				},
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0, // tombstoning visible on consumerName
+					},
+				},
+			},
+		},
+		{
+			// Consumer double sign
+			// Provider will only log the double sign slash
 			// stepsSubmitEquivocationProposal will cause the double sign slash to be executed
-			action: lightClientEquivocationAttackAction{
-				chain:     chainID(consumerName),
-				validator: validatorID("bob"),
+			Action: lightClientEquivocationAttackAction{
+				Chain:     ChainID(consumerName),
+				Validator: ValidatorID("bob"),
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
-					},
-				},
-			},
-		},
-		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
-			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500, // not tombstoned
-						validatorID("carol"): 0,
-					},
-				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500, // not tombstoned
-						validatorID("carol"): 0,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
 			},
 		},
 		{
-			// consumer learns about the double sign
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500, // not tombstoned
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500, // not tombstoned
-						validatorID("carol"): 0,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500, // not tombstoned
+						ValidatorID("carol"): 0,
+					},
+				},
+			},
+		},
+		{
+			// Consumer learns about the double sign
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
+					},
+				},
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500, // not tombstoned
+						ValidatorID("carol"): 0,
 					},
 				},
 			},

--- a/tests/e2e/steps_multi_consumer_delegation.go
+++ b/tests/e2e/steps_multi_consumer_delegation.go
@@ -5,96 +5,96 @@ func stepsMultiConsumerDelegate(consumer1, consumer2 string) []Step {
 	return []Step{
 		{
 			// changes not visible on any consumer
-			action: delegateTokensAction{
-				chain:  chainID("provi"),
-				from:   validatorID("alice"),
-				to:     validatorID("alice"),
-				amount: 11000000,
+			Action: delegateTokensAction{
+				Chain:  ChainID("provi"),
+				From:   ValidatorID("alice"),
+				To:     ValidatorID("alice"),
+				Amount: 11000000,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511, // this changes from 500
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511, // this changes from 500
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 500,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 500,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 500,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 500,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
 			// relay changes to consumer1
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer1),
-				port:    "provider",
-				channel: 0, // consumer1 channel
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer1),
+				Port:    "provider",
+				Channel: 0, // consumer1 Channel
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511, // changed
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511, // changed
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 500, // unchanged
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 500, // unchanged
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
 			// relay changes to consumer2
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer2),
-				port:    "provider",
-				channel: 1, // consumer2 channel
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer2),
+				Port:    "provider",
+				Channel: 1, // consumer2 Channel
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511, // changed
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511, // changed
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
@@ -107,96 +107,96 @@ func stepsMultiConsumerDelegate(consumer1, consumer2 string) []Step {
 func stepsMultiConsumerUnbond(consumer1, consumer2 string) []Step {
 	return []Step{
 		{
-			action: unbondTokensAction{
-				chain:      chainID("provi"),
-				unbondFrom: validatorID("alice"),
-				sender:     validatorID("alice"),
-				amount:     1000000,
+			Action: unbondTokensAction{
+				Chain:      ChainID("provi"),
+				UnbondFrom: ValidatorID("alice"),
+				Sender:     ValidatorID("alice"),
+				Amount:     1000000,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 510, // change from 511
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 510, // change from 511
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511, // no change
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511, // no change
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511, // no change
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511, // no change
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
 			// relay to consumer1
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer1),
-				port:    "provider",
-				channel: 0, // consumer1 channel
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer1),
+				Port:    "provider",
+				Channel: 0, // consumer1 Channel
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 510,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 510,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 510, // change from 511
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 510, // change from 511
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511, // no change
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511, // no change
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
 			// relay to consumer2
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer2),
-				port:    "provider",
-				channel: 1, // consumer2 channel
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer2),
+				Port:    "provider",
+				Channel: 1, // consumer2 Channel
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 510,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 510,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 510,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 510,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 510, // change from 511
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 510, // change from 511
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
@@ -209,35 +209,35 @@ func stepsMultiConsumerUnbond(consumer1, consumer2 string) []Step {
 func stepsMultiConsumerRedelegate(consumer1, consumer2 string) []Step {
 	return []Step{
 		{
-			action: redelegateTokensAction{
-				chain:    chainID("provi"),
-				src:      validatorID("alice"),
-				dst:      validatorID("carol"),
-				txSender: validatorID("alice"),
+			Action: redelegateTokensAction{
+				Chain:    ChainID("provi"),
+				Src:      ValidatorID("alice"),
+				Dst:      ValidatorID("carol"),
+				TxSender: ValidatorID("alice"),
 				// Leave alice with majority stake so non-faulty validators maintain more than
 				// 2/3 voting power during downtime tests below, avoiding chain halt
-				amount: 1000000,
+				Amount: 1000000,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 510, // no change
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 510, // no change
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 510, // no change
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 510, // no change
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
@@ -245,64 +245,64 @@ func stepsMultiConsumerRedelegate(consumer1, consumer2 string) []Step {
 
 		{
 			// relay to consumer1
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer1),
-				port:    "provider",
-				channel: 0, // consumer1 channel
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer1),
+				Port:    "provider",
+				Channel: 0, // consumer1 Channel
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509, // change from 510
-						validatorID("bob"):   500,
-						validatorID("carol"): 501, // change from 500
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509, // change from 510
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501, // change from 500
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 510, // no change
-						validatorID("bob"):   500,
-						validatorID("carol"): 500, // no change
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 510, // no change
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500, // no change
 					},
 				},
 			},
 		},
 		{
 			// relay to consumer2
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer2),
-				port:    "provider",
-				channel: 1, // consumer1 channel
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer2),
+				Port:    "provider",
+				Channel: 1, // consumer1 Channel
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509, // change from 510
-						validatorID("bob"):   500,
-						validatorID("carol"): 501, // change from 500
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509, // change from 510
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501, // change from 500
 					},
 				},
 			},

--- a/tests/e2e/steps_multi_consumer_double_sign.go
+++ b/tests/e2e/steps_multi_consumer_double_sign.go
@@ -13,95 +13,95 @@ func stepsMultiConsumerDoubleSign(consumer1, consumer2 string) []Step {
 	return []Step{
 		{
 			// provider double sign
-			action: doublesignSlashAction{
-				chain:     chainID("provi"),
-				validator: validatorID("carol"),
+			Action: doublesignSlashAction{
+				Chain:     ChainID("provi"),
+				Validator: ValidatorID("carol"),
 			},
-			state: State{
+			State: State{
 				// slash on provider
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0, // from 500 to 0
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0, // from 500 to 0
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 495, // not tombstoned on consumer1 yet
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 495, // not tombstoned on consumer1 yet
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 495, // not tombstoned on consumer2 yet
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 495, // not tombstoned on consumer2 yet
 					},
 				},
 			},
 		},
 		{
 			// relay power change to consumer1
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer1),
-				port:    "provider",
-				channel: 0, // consumer1 channel
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer1),
+				Port:    "provider",
+				Channel: 0, // consumer1 Channel
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0, // tombstoning visible on consumer1
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0, // tombstoning visible on consumer1
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 495, // tombstoning NOT YET visible on consumer2
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 495, // tombstoning NOT YET visible on consumer2
 					},
 				},
 			},
 		},
 		{
 			// relay power change to consumer2
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer2),
-				port:    "provider",
-				channel: 1, // consumer2 channel
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer2),
+				Port:    "provider",
+				Channel: 1, // consumer2 Channel
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0, // tombstoned on consumer2
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0, // tombstoned on consumer2
 					},
 				},
 			},
@@ -109,118 +109,118 @@ func stepsMultiConsumerDoubleSign(consumer1, consumer2 string) []Step {
 		{
 			// consumer double sign
 			// nothing should happen - double sign from consumer is dropped
-			action: doublesignSlashAction{
-				chain:     chainID("consu"),
-				validator: validatorID("bob"),
+			Action: doublesignSlashAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("bob"),
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer1),
-				port:    "provider",
-				channel: 0, // consumer1 channel
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer1),
+				Port:    "provider",
+				Channel: 0, // consumer1 Channel
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500, // not tombstoned
-						validatorID("carol"): 0,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500, // not tombstoned
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500, // not tombstoned
-						validatorID("carol"): 0,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500, // not tombstoned
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500, // not tombstoned
-						validatorID("carol"): 0,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500, // not tombstoned
+						ValidatorID("carol"): 0,
 					},
 				},
 			},
 		},
 		{
 			// consumer1 learns about the double sign
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer1),
-				port:    "provider",
-				channel: 0, // consumer1 channel
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer1),
+				Port:    "provider",
+				Channel: 0, // consumer1 Channel
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500, // not tombstoned
-						validatorID("carol"): 0,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500, // not tombstoned
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500, // not tombstoned
-						validatorID("carol"): 0,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500, // not tombstoned
+						ValidatorID("carol"): 0,
 					},
 				},
 			},
 		},
 		{
 			// consumer2 learns about the double sign
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer2),
-				port:    "provider",
-				channel: 1, // consumer2 channel
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer2),
+				Port:    "provider",
+				Channel: 1, // consumer2 Channel
 			},
-			state: State{
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+			State: State{
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
 			},

--- a/tests/e2e/steps_multi_consumer_double_sign.go
+++ b/tests/e2e/steps_multi_consumer_double_sign.go
@@ -48,7 +48,7 @@ func stepsMultiConsumerDoubleSign(consumer1, consumer2 string) []Step {
 				ChainA:  ChainID("provi"),
 				ChainB:  ChainID(consumer1),
 				Port:    "provider",
-				Channel: 0, // consumer1 Channel
+				Channel: 0, // consumer1 channel
 			},
 			State: State{
 				ChainID("provi"): ChainState{
@@ -80,7 +80,7 @@ func stepsMultiConsumerDoubleSign(consumer1, consumer2 string) []Step {
 				ChainA:  ChainID("provi"),
 				ChainB:  ChainID(consumer2),
 				Port:    "provider",
-				Channel: 1, // consumer2 Channel
+				Channel: 1, // consumer2 channel
 			},
 			State: State{
 				ChainID("provi"): ChainState{
@@ -142,7 +142,7 @@ func stepsMultiConsumerDoubleSign(consumer1, consumer2 string) []Step {
 				ChainA:  ChainID("provi"),
 				ChainB:  ChainID(consumer1),
 				Port:    "provider",
-				Channel: 0, // consumer1 Channel
+				Channel: 0, // consumer1 channel
 			},
 			State: State{
 				ChainID("provi"): ChainState{
@@ -174,7 +174,7 @@ func stepsMultiConsumerDoubleSign(consumer1, consumer2 string) []Step {
 				ChainA:  ChainID("provi"),
 				ChainB:  ChainID(consumer1),
 				Port:    "provider",
-				Channel: 0, // consumer1 Channel
+				Channel: 0, // consumer1 channel
 			},
 			State: State{
 				ChainID("provi"): ChainState{
@@ -206,7 +206,7 @@ func stepsMultiConsumerDoubleSign(consumer1, consumer2 string) []Step {
 				ChainA:  ChainID("provi"),
 				ChainB:  ChainID(consumer2),
 				Port:    "provider",
-				Channel: 1, // consumer2 Channel
+				Channel: 1, // consumer2 channel
 			},
 			State: State{
 				ChainID(consumer1): ChainState{

--- a/tests/e2e/steps_multi_consumer_downtime.go
+++ b/tests/e2e/steps_multi_consumer_downtime.go
@@ -7,31 +7,31 @@ package main
 func stepsMultiConsumerDowntimeFromConsumer(consumer1, consumer2 string) []Step {
 	return []Step{
 		{
-			action: downtimeSlashAction{
-				chain:     chainID(consumer1),
-				validator: validatorID("bob"),
+			Action: downtimeSlashAction{
+				Chain:     ChainID(consumer1),
+				Validator: ValidatorID("bob"),
 			},
-			state: State{
+			State: State{
 				// validator should be slashed on consumer, powers not affected on either chain yet
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
 			},
@@ -39,32 +39,32 @@ func stepsMultiConsumerDowntimeFromConsumer(consumer1, consumer2 string) []Step 
 		{
 			// Downtime jailing and corresponding voting power change are processed by provider
 			// Validator powers are unchanged on consumer chains
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer1),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer1),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   0,
-						validatorID("carol"): 501,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
 			},
@@ -73,149 +73,149 @@ func stepsMultiConsumerDowntimeFromConsumer(consumer1, consumer2 string) []Step 
 			// A block is incremented each action, hence why VSC is committed on provider,
 			// and can now be relayed as packet to consumer
 			// consumer1 will now see the validator power changes - consumer2 will not (had not been relayed)
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer1),
-				port:    "provider",
-				channel: 0, // consumer1 chan
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer1),
+				Port:    "provider",
+				Channel: 0, // consumer1 chan
 			},
-			state: State{
+			State: State{
 				// change propagated to consumer1
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
 						// VSC now seen on consumer1
-						validatorID("bob"):   0,
-						validatorID("carol"): 501,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
 						// VSC has not arrived to on consumer2
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
 			},
 		},
 		{
 			// both consumer1 and consumer will now see the validator power changes
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer2),
-				port:    "provider",
-				channel: 1, // consumer2 chan
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer2),
+				Port:    "provider",
+				Channel: 1, // consumer2 chan
 			},
-			state: State{
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   0, // both consumers see the change
-						validatorID("carol"): 501,
+			State: State{
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   0, // both consumers see the change
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   0, // both consumers see the change
-						validatorID("carol"): 501,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   0, // both consumers see the change
+						ValidatorID("carol"): 501,
 					},
 				},
 			},
 		},
 		{
-			action: unjailValidatorAction{
-				provider:  chainID("provi"),
-				validator: validatorID("bob"),
+			Action: unjailValidatorAction{
+				Provider:  ChainID("provi"),
+				Validator: ValidatorID("bob"),
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
 						// bob's stake should not be slashed since slash comes from consumer1
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
 				// change is not visible on consumer1
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   0,
-						validatorID("carol"): 501,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 501,
 					},
 				},
 				// change is not visible on consumer2
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   0,
-						validatorID("carol"): 501,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 501,
 					},
 				},
 			},
 		},
 		{
 			// relay to consumer 1
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer1),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer1),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500, // change has arrived to consumer1 (no slashing)
-						validatorID("carol"): 501,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500, // change has arrived to consumer1 (no slashing)
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   0, // change has not arrived to consumer2
-						validatorID("carol"): 501,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   0, // change has not arrived to consumer2
+						ValidatorID("carol"): 501,
 					},
 				},
 			},
 		},
 		{
 			// relay to consumer2
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer2),
-				port:    "provider",
-				channel: 1, // consumer2 chan
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer2),
+				Port:    "provider",
+				Channel: 1, // consumer2 chan
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500, // change has arrived to consumer1 (no slashing)
-						validatorID("carol"): 501,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500, // change has arrived to consumer1 (no slashing)
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500, // change has arrived to consumer2 (no slashing)
-						validatorID("carol"): 501,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500, // change has arrived to consumer2 (no slashing)
+						ValidatorID("carol"): 501,
 					},
 				},
 			},
@@ -229,190 +229,190 @@ func stepsMultiConsumerDowntimeFromProvider(consumer1, consumer2 string) []Step 
 	return []Step{
 		// Now we test provider initiated downtime/slashing
 		{
-			action: downtimeSlashAction{
-				chain:     chainID("provi"),
-				validator: validatorID("carol"),
+			Action: downtimeSlashAction{
+				Chain:     ChainID("provi"),
+				Validator: ValidatorID("carol"),
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// Non faulty validators still maintain just above 2/3 power here
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer1),
-				port:    "provider",
-				channel: 0, // consumer 1 channel
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer1),
+				Port:    "provider",
+				Channel: 0, // consumer 1 channel
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// Non faulty validators still maintain just above 2/3 power here
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
 				// powers now changed
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
 				// not relayed yet - powers unchanged
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 501,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 501,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer2),
-				port:    "provider",
-				channel: 1, // consumer2 channel
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer2),
+				Port:    "provider",
+				Channel: 1, // consumer2 channel
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// Non faulty validators still maintain just above 2/3 power here
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
 				// powers now changed
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
 			},
 		},
 		{
-			action: unjailValidatorAction{
-				provider:  chainID("provi"),
-				validator: validatorID("carol"),
+			Action: unjailValidatorAction{
+				Provider:  ChainID("provi"),
+				Validator: ValidatorID("carol"),
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 495, // slashed because infraction was committed on provider
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 495, // slashed because infraction was committed on provider
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer1),
-				port:    "provider",
-				channel: 0, // consumer1 channel
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer1),
+				Port:    "provider",
+				Channel: 0, // consumer1 channel
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 495,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 495,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 495,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 495,
 					},
 				},
 				// not relayed yet
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumer2),
-				port:    "provider",
-				channel: 1, // consumer2 channel
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumer2),
+				Port:    "provider",
+				Channel: 1, // consumer2 channel
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 495,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 495,
 					},
 				},
-				chainID(consumer1): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 495,
+				ChainID(consumer1): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 495,
 					},
 				},
-				chainID(consumer2): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 495,
+				ChainID(consumer2): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 495,
 					},
 				},
 			},

--- a/tests/e2e/steps_reward_denom.go
+++ b/tests/e2e/steps_reward_denom.go
@@ -3,22 +3,22 @@ package main
 func stepsRewardDenomConsumer(consumerName string) []Step {
 	return []Step{
 		{
-			action: registerRepresentativeAction{
-				chain:           chainID(consumerName),
-				representatives: []validatorID{validatorID("alice"), validatorID("bob")},
-				stakes:          []uint{100000000, 40000000},
+			Action: registerRepresentativeAction{
+				Chain:           ChainID(consumerName),
+				Representatives: []ValidatorID{ValidatorID("alice"), ValidatorID("bob")},
+				Stakes:          []uint{100000000, 40000000},
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					RepresentativePowers: &map[validatorID]uint{
-						validatorID("alice"): 100000000,
-						validatorID("bob"):   40000000,
+			State: State{
+				ChainID(consumerName): ChainState{
+					RepresentativePowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 100000000,
+						ValidatorID("bob"):   40000000,
 					},
 					Rewards: &Rewards{
-						IsRewarded: map[validatorID]bool{
-							validatorID("alice"): true,
-							validatorID("bob"):   true,
-							validatorID("carol"): false,
+						IsRewarded: map[ValidatorID]bool{
+							ValidatorID("alice"): true,
+							ValidatorID("bob"):   true,
+							ValidatorID("carol"): false,
 						},
 						IsIncrementalReward: true,
 						IsNativeDenom:       true,
@@ -27,31 +27,31 @@ func stepsRewardDenomConsumer(consumerName string) []Step {
 			},
 		},
 		{
-			action: delegateTokensAction{
-				chain:  chainID(consumerName),
-				from:   validatorID("carol"),
-				to:     validatorID("alice"),
-				amount: 500000,
+			Action: delegateTokensAction{
+				Chain:  ChainID(consumerName),
+				From:   ValidatorID("carol"),
+				To:     ValidatorID("alice"),
+				Amount: 500000,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
+			State: State{
+				ChainID(consumerName): ChainState{
 					// Check that delegators on gov-consumer chain can change representative powers
-					RepresentativePowers: &map[validatorID]uint{
-						validatorID("alice"): 100500000,
-						validatorID("bob"):   40000000,
+					RepresentativePowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 100500000,
+						ValidatorID("bob"):   40000000,
 					},
 					// Check that delegating on gov-consumer does not change validator powers
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 					// Check that tokens are minted and distributed to representatives and their delegators
 					Rewards: &Rewards{
-						IsRewarded: map[validatorID]bool{
-							validatorID("alice"): true,
-							validatorID("bob"):   true,
-							validatorID("carol"): true,
+						IsRewarded: map[ValidatorID]bool{
+							ValidatorID("alice"): true,
+							ValidatorID("bob"):   true,
+							ValidatorID("carol"): true,
 						},
 						IsIncrementalReward: true,
 						IsNativeDenom:       true,
@@ -61,19 +61,19 @@ func stepsRewardDenomConsumer(consumerName string) []Step {
 		},
 		{
 			// whitelisted legacy proposal can only handle ibctransfer.SendEnabled/ReceiveEnabled
-			action: submitParamChangeLegacyProposalAction{
-				chain:    chainID(consumerName),
-				from:     validatorID("alice"),
-				deposit:  10000001,
-				subspace: "transfer",
-				key:      "SendEnabled",
-				value:    true,
+			Action: submitParamChangeLegacyProposalAction{
+				Chain:    ChainID(consumerName),
+				From:     ValidatorID("alice"),
+				Deposit:  10000001,
+				Subspace: "transfer",
+				Key:      "SendEnabled",
+				Value:    true,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValBalances: &map[validatorID]uint{
-						validatorID("alice"): 9889999998,
-						validatorID("bob"):   9960000001,
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("alice"): 9889999998,
+						ValidatorID("bob"):   9960000001,
 					},
 					Proposals: &map[uint]Proposal{
 						1: ParamsProposal{
@@ -89,17 +89,17 @@ func stepsRewardDenomConsumer(consumerName string) []Step {
 		},
 		{
 			// Have accounts vote on something on the gov-consumer chain
-			action: voteGovProposalAction{
-				chain:      chainID(consumerName),
-				from:       []validatorID{validatorID("alice"), validatorID("bob")},
-				vote:       []string{"yes", "no"},
-				propNumber: 1,
+			Action: voteGovProposalAction{
+				Chain:      ChainID(consumerName),
+				From:       []ValidatorID{ValidatorID("alice"), ValidatorID("bob")},
+				Vote:       []string{"yes", "no"},
+				PropNumber: 1,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValBalances: &map[validatorID]uint{
-						validatorID("alice"): 9889999998,
-						validatorID("bob"):   9960000001,
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("alice"): 9889999998,
+						ValidatorID("bob"):   9960000001,
 					},
 					// Check that the parameter is changed on gov-consumer chain
 					Params: &([]Param{{Subspace: "transfer", Key: "SendEnabled", Value: "true"}}),
@@ -107,20 +107,20 @@ func stepsRewardDenomConsumer(consumerName string) []Step {
 			},
 		},
 		{
-			action: relayRewardPacketsToProviderAction{
-				consumerChain: chainID(consumerName),
-				providerChain: chainID("provi"),
-				port:          "transfer",
-				channel:       1,
+			Action: relayRewardPacketsToProviderAction{
+				ConsumerChain: ChainID(consumerName),
+				ProviderChain: ChainID("provi"),
+				Port:          "transfer",
+				Channel:       1,
 			},
-			state: State{
-				chainID("provi"): ChainState{
+			State: State{
+				ChainID("provi"): ChainState{
 					// Check that tokens are not distributed before the denom has been registered
 					Rewards: &Rewards{
-						IsRewarded: map[validatorID]bool{
-							validatorID("alice"): false,
-							validatorID("bob"):   false,
-							validatorID("carol"): false,
+						IsRewarded: map[ValidatorID]bool{
+							ValidatorID("alice"): false,
+							ValidatorID("bob"):   false,
+							ValidatorID("carol"): false,
 						},
 						IsIncrementalReward: false,
 						IsNativeDenom:       false,
@@ -131,47 +131,47 @@ func stepsRewardDenomConsumer(consumerName string) []Step {
 			},
 		},
 		{
-			action: submitChangeRewardDenomsProposalAction{
-				denom:   "ibc/3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9",
-				deposit: 10000001,
-				from:    validatorID("bob"),
+			Action: submitChangeRewardDenomsProposalAction{
+				Denom:   "ibc/3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9",
+				Deposit: 10000001,
+				From:    ValidatorID("bob"),
 			},
-			state: State{
-				chainID("provi"): ChainState{
+			State: State{
+				ChainID("provi"): ChainState{
 					// Denom not yet registered, gov prop needs to pass first
 					RegisteredConsumerRewardDenoms: &[]string{},
 				},
 			},
 		},
 		{
-			action: voteGovProposalAction{
-				chain:      chainID("provi"),
-				from:       []validatorID{validatorID("alice"), validatorID("bob"), validatorID("carol")},
-				vote:       []string{"yes", "yes", "yes"},
-				propNumber: 2,
+			Action: voteGovProposalAction{
+				Chain:      ChainID("provi"),
+				From:       []ValidatorID{ValidatorID("alice"), ValidatorID("bob"), ValidatorID("carol")},
+				Vote:       []string{"yes", "yes", "yes"},
+				PropNumber: 2,
 			},
-			state: State{
-				chainID("provi"): ChainState{
+			State: State{
+				ChainID("provi"): ChainState{
 					// Check that the denom is registered on provider chain
 					RegisteredConsumerRewardDenoms: &[]string{"ibc/3C3D7B3BE4ECC85A0E5B52A3AEC3B7DFC2AA9CA47C37821E57020D6807043BE9"},
 				},
 			},
 		},
 		{
-			action: relayRewardPacketsToProviderAction{
-				consumerChain: chainID(consumerName),
-				providerChain: chainID("provi"),
-				port:          "transfer",
-				channel:       1,
+			Action: relayRewardPacketsToProviderAction{
+				ConsumerChain: ChainID(consumerName),
+				ProviderChain: ChainID("provi"),
+				Port:          "transfer",
+				Channel:       1,
 			},
-			state: State{
-				chainID("provi"): ChainState{
+			State: State{
+				ChainID("provi"): ChainState{
 					// Check that tokens are not minted and sent to provider chain and distributed to validators and their delegators on provider chain
 					Rewards: &Rewards{
-						IsRewarded: map[validatorID]bool{
-							validatorID("alice"): false,
-							validatorID("bob"):   false,
-							validatorID("carol"): false,
+						IsRewarded: map[ValidatorID]bool{
+							ValidatorID("alice"): false,
+							ValidatorID("bob"):   false,
+							ValidatorID("carol"): false,
 						},
 						IsIncrementalReward: false,
 						IsNativeDenom:       false,
@@ -180,113 +180,113 @@ func stepsRewardDenomConsumer(consumerName string) []Step {
 			},
 		},
 		{
-			action: downtimeSlashAction{
-				chain:     chainID(consumerName),
-				validator: validatorID("bob"),
+			Action: downtimeSlashAction{
+				Chain:     ChainID(consumerName),
+				Validator: ValidatorID("bob"),
 			},
-			state: State{
+			State: State{
 				// validator should be slashed on consumer, powers not affected on either chain yet
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
 						// Downtime jailing and corresponding voting power change are processed by provider
-						validatorID("bob"):   0,
-						validatorID("carol"): 500,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
-		// A block is incremented each action, hence why VSC is committed on provider,
+		// A block is incremented each Action, hence why VSC is committed on provider,
 		// and can now be relayed as packet to consumer
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
 						// VSC now seen on consumer
-						validatorID("bob"):   0,
-						validatorID("carol"): 500,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: unjailValidatorAction{
-				provider:  chainID("provi"),
-				validator: validatorID("bob"),
+			Action: unjailValidatorAction{
+				Provider:  ChainID("provi"),
+				Validator: ValidatorID("bob"),
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   0,
-						validatorID("carol"): 500,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 					// Check that slashing on the gov-consumer chain does not result in slashing for the representatives or their delegators
-					RepresentativePowers: &map[validatorID]uint{
-						validatorID("alice"): 100500000,
-						validatorID("bob"):   40000000,
+					RepresentativePowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 100500000,
+						ValidatorID("bob"):   40000000,
 					},
 				},
 			},

--- a/tests/e2e/steps_sovereign_changeover.go
+++ b/tests/e2e/steps_sovereign_changeover.go
@@ -10,24 +10,24 @@ import clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 func stepsSovereignTransferChan() []Step {
 	return []Step{
 		{
-			action: createIbcClientsAction{
-				chainA: chainID("sover"),
-				chainB: chainID("provi"),
+			Action: createIbcClientsAction{
+				ChainA: ChainID("sover"),
+				ChainB: ChainID("provi"),
 			},
-			state: State{},
+			State: State{},
 		},
 		{
 			// this will create channel-0 connection end on both chain
-			action: addIbcChannelAction{
-				chainA:      chainID("sover"),
-				chainB:      chainID("provi"),
-				connectionA: 0,
-				portA:       "transfer",
-				portB:       "transfer",
-				order:       "unordered",
-				version:     "ics20-1",
+			Action: addIbcChannelAction{
+				ChainA:      ChainID("sover"),
+				ChainB:      ChainID("provi"),
+				ConnectionA: 0,
+				PortA:       "transfer",
+				PortB:       "transfer",
+				Order:       "unordered",
+				Version:     "ics20-1",
 			},
-			state: State{},
+			State: State{},
 		},
 	}
 }
@@ -36,29 +36,29 @@ func stepsSovereignTransferChan() []Step {
 func stepsChangeoverToConsumer(consumerName string) []Step {
 	s := []Step{
 		{
-			action: submitConsumerAdditionProposalAction{
-				preCCV:        true,
-				chain:         chainID("provi"),
-				from:          validatorID("alice"),
-				deposit:       10000001,
-				consumerChain: chainID(consumerName),
+			Action: submitConsumerAdditionProposalAction{
+				PreCCV:        true,
+				Chain:         ChainID("provi"),
+				From:          ValidatorID("alice"),
+				Deposit:       10000001,
+				ConsumerChain: ChainID(consumerName),
 				// chain-0 is the transfer channelID that gets created in stepsSovereignTransferChan
 				// the consumer chain will use this channel to send rewards to the provider chain
 				// there is no need to create a new channel for rewards distribution
-				distributionChannel: "channel-0",
-				spawnTime:           0,
-				initialHeight:       clienttypes.Height{RevisionNumber: 0, RevisionHeight: 111}, // 1 block after upgrade !important
+				DistributionChannel: "channel-0",
+				SpawnTime:           0,
+				InitialHeight:       clienttypes.Height{RevisionNumber: 0, RevisionHeight: 111}, // 1 block after upgrade !important
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValBalances: &map[validatorID]uint{
-						validatorID("alice"): 9489999999,
-						validatorID("bob"):   9500000000,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("alice"): 9489999999,
+						ValidatorID("bob"):   9500000000,
 					},
 					Proposals: &map[uint]Proposal{
 						1: ConsumerAdditionProposal{
 							Deposit:       10000001,
-							Chain:         chainID(consumerName),
+							Chain:         ChainID(consumerName),
 							SpawnTime:     0,
 							InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 111},
 							Status:        "PROPOSAL_STATUS_VOTING_PERIOD",
@@ -68,78 +68,78 @@ func stepsChangeoverToConsumer(consumerName string) []Step {
 			},
 		},
 		{
-			action: voteGovProposalAction{
-				chain:      chainID("provi"),
-				from:       []validatorID{validatorID("alice"), validatorID("bob"), validatorID("carol")},
-				vote:       []string{"yes", "yes", "yes"},
-				propNumber: 1,
+			Action: voteGovProposalAction{
+				Chain:      ChainID("provi"),
+				From:       []ValidatorID{ValidatorID("alice"), ValidatorID("bob"), ValidatorID("carol")},
+				Vote:       []string{"yes", "yes", "yes"},
+				PropNumber: 1,
 			},
-			state: State{
-				chainID("provi"): ChainState{
+			State: State{
+				ChainID("provi"): ChainState{
 					Proposals: &map[uint]Proposal{
 						1: ConsumerAdditionProposal{
 							Deposit:       10000001,
-							Chain:         chainID(consumerName),
+							Chain:         ChainID(consumerName),
 							SpawnTime:     0,
 							InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 111},
 							Status:        "PROPOSAL_STATUS_PASSED",
 						},
 					},
-					ValBalances: &map[validatorID]uint{
-						validatorID("alice"): 9500000000,
-						validatorID("bob"):   9500000000,
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("alice"): 9500000000,
+						ValidatorID("bob"):   9500000000,
 					},
 				},
 			},
 		},
 		{
-			action: ChangeoverChainAction{
-				sovereignChain: chainID(consumerName),
-				providerChain:  chainID("provi"),
-				validators: []StartChainValidator{
-					{id: validatorID("alice"), stake: 500000000, allocation: 10000000000},
-					{id: validatorID("bob"), stake: 500000000, allocation: 10000000000},
-					{id: validatorID("carol"), stake: 500000000, allocation: 10000000000},
+			Action: ChangeoverChainAction{
+				SovereignChain: ChainID(consumerName),
+				ProviderChain:  ChainID("provi"),
+				Validators: []StartChainValidator{
+					{Id: ValidatorID("alice"), Stake: 500000000, Allocation: 10000000000},
+					{Id: ValidatorID("bob"), Stake: 500000000, Allocation: 10000000000},
+					{Id: ValidatorID("carol"), Stake: 500000000, Allocation: 10000000000},
 				},
-				genesisChanges: ".app_state.ccvconsumer.params.soft_opt_out_threshold = \"0.05\"",
+				GenesisChanges: ".app_state.ccvconsumer.params.soft_opt_out_threshold = \"0.05\"",
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 500,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 500,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// uses val powers from consumer
-						validatorID("alice"): 500,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+						ValidatorID("alice"): 500,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: addIbcConnectionAction{
-				chainA:  chainID(consumerName),
-				chainB:  chainID("provi"),
-				clientA: 1,
-				clientB: 1,
+			Action: addIbcConnectionAction{
+				ChainA:  ChainID(consumerName),
+				ChainB:  ChainID("provi"),
+				ClientA: 1,
+				ClientB: 1,
 			},
-			state: State{},
+			State: State{},
 		},
 		{
-			action: addIbcChannelAction{
-				chainA:      chainID(consumerName),
-				chainB:      chainID("provi"),
-				connectionA: 1,
-				portA:       "consumer",
-				portB:       "provider",
-				order:       "ordered",
+			Action: addIbcChannelAction{
+				ChainA:      ChainID(consumerName),
+				ChainB:      ChainID("provi"),
+				ConnectionA: 1,
+				PortA:       "consumer",
+				PortB:       "provider",
+				Order:       "ordered",
 			},
-			state: State{},
+			State: State{},
 		},
 	}
 
@@ -154,33 +154,33 @@ func stepsChangeoverToConsumer(consumerName string) []Step {
 func stepRunSovereignChain() []Step {
 	return []Step{
 		{
-			action: StartSovereignChainAction{
-				chain: chainID("sover"),
-				validators: []StartChainValidator{
-					{id: validatorID("alice"), stake: 500000000, allocation: 10000000000},
+			Action: StartSovereignChainAction{
+				Chain: ChainID("sover"),
+				Validators: []StartChainValidator{
+					{Id: ValidatorID("alice"), Stake: 500000000, Allocation: 10000000000},
 				},
 			},
-			state: State{
-				chainID("sover"): ChainState{
-					ValBalances: &map[validatorID]uint{
-						validatorID("alice"): 9500000000,
+			State: State{
+				ChainID("sover"): ChainState{
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("alice"): 9500000000,
 					},
 				},
 			},
 		},
 		{
-			action: delegateTokensAction{
-				chain:  chainID("sover"),
-				from:   validatorID("alice"),
-				to:     validatorID("alice"),
-				amount: 11000000,
+			Action: delegateTokensAction{
+				Chain:  ChainID("sover"),
+				From:   ValidatorID("alice"),
+				To:     ValidatorID("alice"),
+				Amount: 11000000,
 			},
-			state: State{
-				chainID("sover"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   0, // does not exist on pre-ccv sover
-						validatorID("carol"): 0, // does not exist on pre-ccv sover
+			State: State{
+				ChainID("sover"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   0, // does not exist on pre-ccv sover
+						ValidatorID("carol"): 0, // does not exist on pre-ccv sover
 					},
 				},
 			},
@@ -192,14 +192,14 @@ func stepRunSovereignChain() []Step {
 func stepsUpgradeChain() []Step {
 	return []Step{
 		{
-			action: LegacyUpgradeProposalAction{
-				chainID:       chainID("sover"),
-				upgradeTitle:  "sovereign-changeover",
-				proposer:      validatorID("alice"),
-				upgradeHeight: 110,
+			Action: LegacyUpgradeProposalAction{
+				ChainID:       ChainID("sover"),
+				UpgradeTitle:  "sovereign-changeover",
+				Proposer:      ValidatorID("alice"),
+				UpgradeHeight: 110,
 			},
-			state: State{
-				chainID("sover"): ChainState{
+			State: State{
+				ChainID("sover"): ChainState{
 					Proposals: &map[uint]Proposal{
 						1: UpgradeProposal{
 							Title:         "sovereign-changeover",
@@ -213,14 +213,14 @@ func stepsUpgradeChain() []Step {
 			},
 		},
 		{
-			action: voteGovProposalAction{
-				chain:      chainID("sover"),
-				from:       []validatorID{validatorID("alice")},
-				vote:       []string{"yes"},
-				propNumber: 1,
+			Action: voteGovProposalAction{
+				Chain:      ChainID("sover"),
+				From:       []ValidatorID{ValidatorID("alice")},
+				Vote:       []string{"yes"},
+				PropNumber: 1,
 			},
-			state: State{
-				chainID("sover"): ChainState{
+			State: State{
+				ChainID("sover"): ChainState{
 					Proposals: &map[uint]Proposal{
 						1: UpgradeProposal{
 							Deposit:       10000000,
@@ -234,11 +234,11 @@ func stepsUpgradeChain() []Step {
 			},
 		},
 		{
-			action: waitUntilBlockAction{
-				chain: chainID("sover"),
-				block: 110,
+			Action: waitUntilBlockAction{
+				Chain: ChainID("sover"),
+				Block: 110,
 			},
-			state: State{},
+			State: State{},
 		},
 	}
 }
@@ -249,116 +249,116 @@ func stepsUpgradeChain() []Step {
 func stepsPostChangeoverDelegate(consumerName string) []Step {
 	return []Step{
 		{
-			action: SendTokensAction{
-				chain:  chainID(consumerName),
-				from:   validatorID("alice"),
-				to:     validatorID("bob"),
-				amount: 100,
+			Action: SendTokensAction{
+				Chain:  ChainID(consumerName),
+				From:   ValidatorID("alice"),
+				To:     ValidatorID("bob"),
+				Amount: 100,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
+			State: State{
+				ChainID(consumerName): ChainState{
 					// Tx should not go through, ICS channel is not setup until first VSC packet has been relayed to consumer
-					ValBalances: &map[validatorID]uint{
-						validatorID("bob"): 0,
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("bob"): 0,
 					},
 				},
 			},
 		},
 		{
-			action: delegateTokensAction{
-				chain:  chainID("provi"),
-				from:   validatorID("alice"),
-				to:     validatorID("alice"),
-				amount: 11000000,
+			Action: delegateTokensAction{
+				Chain:  ChainID("provi"),
+				From:   ValidatorID("alice"),
+				To:     ValidatorID("alice"),
+				Amount: 11000000,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 500,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
-					},
-				},
-			},
-		},
-		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 1,
-			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 500,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: SendTokensAction{
-				chain:  chainID(consumerName),
-				from:   validatorID("alice"),
-				to:     validatorID("bob"),
-				amount: 100,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 1,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
+					},
+				},
+			},
+		},
+		{
+			Action: SendTokensAction{
+				Chain:  ChainID(consumerName),
+				From:   ValidatorID("alice"),
+				To:     ValidatorID("bob"),
+				Amount: 100,
+			},
+			State: State{
+				ChainID(consumerName): ChainState{
 					// Tx should go through, ICS channel is setup
-					ValBalances: &map[validatorID]uint{
-						validatorID("bob"): 100,
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("bob"): 100,
 					},
 				},
 			},
 		},
 		{
-			action: unbondTokensAction{
-				chain:      chainID("provi"),
-				unbondFrom: validatorID("alice"),
-				sender:     validatorID("alice"),
-				amount:     1000000,
+			Action: unbondTokensAction{
+				Chain:      ChainID("provi"),
+				UnbondFrom: ValidatorID("alice"),
+				Sender:     ValidatorID("alice"),
+				Amount:     1000000,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 510,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 510,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// Voting power on consumer should not be affected yet
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 1,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 1,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 510,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+			State: State{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 510,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
 			},

--- a/tests/e2e/steps_start_chains.go
+++ b/tests/e2e/steps_start_chains.go
@@ -7,20 +7,20 @@ import (
 func stepStartProviderChain() []Step {
 	return []Step{
 		{
-			action: StartChainAction{
-				chain: chainID("provi"),
-				validators: []StartChainValidator{
-					{id: validatorID("bob"), stake: 500000000, allocation: 10000000000},
-					{id: validatorID("alice"), stake: 500000000, allocation: 10000000000},
-					{id: validatorID("carol"), stake: 500000000, allocation: 10000000000},
+			Action: StartChainAction{
+				Chain: ChainID("provi"),
+				Validators: []StartChainValidator{
+					{Id: ValidatorID("bob"), Stake: 500000000, Allocation: 10000000000},
+					{Id: ValidatorID("alice"), Stake: 500000000, Allocation: 10000000000},
+					{Id: ValidatorID("carol"), Stake: 500000000, Allocation: 10000000000},
 				},
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValBalances: &map[validatorID]uint{
-						validatorID("alice"): 9500000000,
-						validatorID("bob"):   9500000000,
-						validatorID("carol"): 9500000000,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("alice"): 9500000000,
+						ValidatorID("bob"):   9500000000,
+						ValidatorID("carol"): 9500000000,
 					},
 				},
 			},
@@ -31,24 +31,24 @@ func stepStartProviderChain() []Step {
 func stepsStartConsumerChain(consumerName string, proposalIndex, chainIndex uint, setupTransferChans bool) []Step {
 	s := []Step{
 		{
-			action: submitConsumerAdditionProposalAction{
-				chain:         chainID("provi"),
-				from:          validatorID("alice"),
-				deposit:       10000001,
-				consumerChain: chainID(consumerName),
-				spawnTime:     0,
-				initialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+			Action: submitConsumerAdditionProposalAction{
+				Chain:         ChainID("provi"),
+				From:          ValidatorID("alice"),
+				Deposit:       10000001,
+				ConsumerChain: ChainID(consumerName),
+				SpawnTime:     0,
+				InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValBalances: &map[validatorID]uint{
-						validatorID("alice"): 9489999999,
-						validatorID("bob"):   9500000000,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("alice"): 9489999999,
+						ValidatorID("bob"):   9500000000,
 					},
 					Proposals: &map[uint]Proposal{
 						proposalIndex: ConsumerAdditionProposal{
 							Deposit:       10000001,
-							Chain:         chainID(consumerName),
+							Chain:         ChainID(consumerName),
 							SpawnTime:     0,
 							InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
 							Status:        "PROPOSAL_STATUS_VOTING_PERIOD",
@@ -60,155 +60,155 @@ func stepsStartConsumerChain(consumerName string, proposalIndex, chainIndex uint
 		// add a consumer key before the chain starts
 		// the key will be present in consumer genesis initial_val_set
 		{
-			action: assignConsumerPubKeyAction{
-				chain:          chainID(consumerName),
-				validator:      validatorID("carol"),
-				consumerPubkey: `{"@type":"/cosmos.crypto.ed25519.PubKey","key":"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is="}`,
+			Action: assignConsumerPubKeyAction{
+				Chain:          ChainID(consumerName),
+				Validator:      ValidatorID("carol"),
+				ConsumerPubkey: `{"@type":"/cosmos.crypto.ed25519.PubKey","key":"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is="}`,
 				// consumer chain has not started
 				// we don't need to reconfigure the node
 				// since it will start with consumer key
-				reconfigureNode: false,
+				ReconfigureNode: false,
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					AssignedKeys: &map[validatorID]string{
-						validatorID("carol"): "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk",
+			State: State{
+				ChainID(consumerName): ChainState{
+					AssignedKeys: &map[ValidatorID]string{
+						ValidatorID("carol"): "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk",
 					},
-					ProviderKeys: &map[validatorID]string{
-						validatorID("carol"): "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6",
+					ProviderKeys: &map[ValidatorID]string{
+						ValidatorID("carol"): "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6",
 					},
 				},
 			},
 		},
 		{
 			// op should fail - key already assigned by the same validator
-			action: assignConsumerPubKeyAction{
-				chain:           chainID(consumerName),
-				validator:       validatorID("carol"),
-				consumerPubkey:  `{"@type":"/cosmos.crypto.ed25519.PubKey","key":"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is="}`,
-				reconfigureNode: false,
-				expectError:     true,
-				expectedError:   "a validator has assigned the consumer key already: consumer key is already in use by a validator",
+			Action: assignConsumerPubKeyAction{
+				Chain:           ChainID(consumerName),
+				Validator:       ValidatorID("carol"),
+				ConsumerPubkey:  `{"@type":"/cosmos.crypto.ed25519.PubKey","key":"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is="}`,
+				ReconfigureNode: false,
+				ExpectError:     true,
+				ExpectedError:   "a validator has assigned the consumer key already: consumer key is already in use by a validator",
 			},
-			state: State{},
+			State: State{},
 		},
 		{
 			// op should fail - key already assigned by another validator
-			action: assignConsumerPubKeyAction{
-				chain:     chainID(consumerName),
-				validator: validatorID("bob"),
+			Action: assignConsumerPubKeyAction{
+				Chain:     ChainID(consumerName),
+				Validator: ValidatorID("bob"),
 				// same pub key as carol
-				consumerPubkey:  `{"@type":"/cosmos.crypto.ed25519.PubKey","key":"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is="}`,
-				reconfigureNode: false,
-				expectError:     true,
-				expectedError:   "a validator has assigned the consumer key already: consumer key is already in use by a validator",
+				ConsumerPubkey:  `{"@type":"/cosmos.crypto.ed25519.PubKey","key":"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is="}`,
+				ReconfigureNode: false,
+				ExpectError:     true,
+				ExpectedError:   "a validator has assigned the consumer key already: consumer key is already in use by a validator",
 			},
-			state: State{
-				chainID(consumerName): ChainState{
-					AssignedKeys: &map[validatorID]string{
-						validatorID("carol"): "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk",
-						validatorID("bob"):   "",
+			State: State{
+				ChainID(consumerName): ChainState{
+					AssignedKeys: &map[ValidatorID]string{
+						ValidatorID("carol"): "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk",
+						ValidatorID("bob"):   "",
 					},
-					ProviderKeys: &map[validatorID]string{
-						validatorID("carol"): "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6",
+					ProviderKeys: &map[ValidatorID]string{
+						ValidatorID("carol"): "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6",
 					},
 				},
 			},
 		},
 		{
-			action: voteGovProposalAction{
-				chain:      chainID("provi"),
-				from:       []validatorID{validatorID("alice"), validatorID("bob"), validatorID("carol")},
-				vote:       []string{"yes", "yes", "yes"},
-				propNumber: proposalIndex,
+			Action: voteGovProposalAction{
+				Chain:      ChainID("provi"),
+				From:       []ValidatorID{ValidatorID("alice"), ValidatorID("bob"), ValidatorID("carol")},
+				Vote:       []string{"yes", "yes", "yes"},
+				PropNumber: proposalIndex,
 			},
-			state: State{
-				chainID("provi"): ChainState{
+			State: State{
+				ChainID("provi"): ChainState{
 					Proposals: &map[uint]Proposal{
 						proposalIndex: ConsumerAdditionProposal{
 							Deposit:       10000001,
-							Chain:         chainID(consumerName),
+							Chain:         ChainID(consumerName),
 							SpawnTime:     0,
 							InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
 							Status:        "PROPOSAL_STATUS_PASSED",
 						},
 					},
-					ValBalances: &map[validatorID]uint{
-						validatorID("alice"): 9500000000,
-						validatorID("bob"):   9500000000,
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("alice"): 9500000000,
+						ValidatorID("bob"):   9500000000,
 					},
 				},
 			},
 		},
 		{
-			action: startConsumerChainAction{
-				consumerChain: chainID(consumerName),
-				providerChain: chainID("provi"),
-				validators: []StartChainValidator{
-					{id: validatorID("bob"), stake: 500000000, allocation: 10000000000},
-					{id: validatorID("alice"), stake: 500000000, allocation: 10000000000},
-					{id: validatorID("carol"), stake: 500000000, allocation: 10000000000},
+			Action: startConsumerChainAction{
+				ConsumerChain: ChainID(consumerName),
+				ProviderChain: ChainID("provi"),
+				Validators: []StartChainValidator{
+					{Id: ValidatorID("bob"), Stake: 500000000, Allocation: 10000000000},
+					{Id: ValidatorID("alice"), Stake: 500000000, Allocation: 10000000000},
+					{Id: ValidatorID("carol"), Stake: 500000000, Allocation: 10000000000},
 				},
 				// For consumers that're launching with the provider being on an earlier version
 				// of ICS before the soft opt-out threshold was introduced, we need to set the
 				// soft opt-out threshold to 0.05 in the consumer genesis to ensure that the
 				// consumer binary doesn't panic. Sdk requires that all params are set to valid
 				// values from the genesis file.
-				genesisChanges: ".app_state.ccvconsumer.params.soft_opt_out_threshold = \"0.05\"",
+				GenesisChanges: ".app_state.ccvconsumer.params.soft_opt_out_threshold = \"0.05\"",
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValBalances: &map[validatorID]uint{
-						validatorID("alice"): 9500000000,
-						validatorID("bob"):   9500000000,
-						validatorID("carol"): 9500000000,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("alice"): 9500000000,
+						ValidatorID("bob"):   9500000000,
+						ValidatorID("carol"): 9500000000,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValBalances: &map[validatorID]uint{
-						validatorID("alice"): 10000000000,
-						validatorID("bob"):   10000000000,
-						validatorID("carol"): 10000000000,
+				ChainID(consumerName): ChainState{
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("alice"): 10000000000,
+						ValidatorID("bob"):   10000000000,
+						ValidatorID("carol"): 10000000000,
 					},
 				},
 			},
 		},
 		{
-			action: addIbcConnectionAction{
-				chainA:  chainID(consumerName),
-				chainB:  chainID("provi"),
-				clientA: 0,
-				clientB: chainIndex,
+			Action: addIbcConnectionAction{
+				ChainA:  ChainID(consumerName),
+				ChainB:  ChainID("provi"),
+				ClientA: 0,
+				ClientB: chainIndex,
 			},
-			state: State{},
+			State: State{},
 		},
 		{
-			action: addIbcChannelAction{
-				chainA:      chainID(consumerName),
-				chainB:      chainID("provi"),
-				connectionA: 0,
-				portA:       "consumer", // TODO: check port mapping
-				portB:       "provider",
-				order:       "ordered",
+			Action: addIbcChannelAction{
+				ChainA:      ChainID(consumerName),
+				ChainB:      ChainID("provi"),
+				ConnectionA: 0,
+				PortA:       "consumer", // TODO: check port mapping
+				PortB:       "provider",
+				Order:       "ordered",
 			},
-			state: State{},
+			State: State{},
 		},
 	}
 
 	// currently only used in democracy tests
 	if setupTransferChans {
 		s = append(s, Step{
-			action: transferChannelCompleteAction{
-				chainA:      chainID(consumerName),
-				chainB:      chainID("provi"),
-				connectionA: 0,
-				portA:       "transfer",
-				portB:       "transfer",
-				order:       "unordered",
-				channelA:    1,
-				channelB:    1,
+			Action: transferChannelCompleteAction{
+				ChainA:      ChainID(consumerName),
+				ChainB:      ChainID("provi"),
+				ConnectionA: 0,
+				PortA:       "transfer",
+				PortB:       "transfer",
+				Order:       "unordered",
+				ChannelA:    1,
+				ChannelB:    1,
 			},
-			state: State{},
+			State: State{},
 		})
 	}
 	return s
@@ -228,75 +228,75 @@ func stepsStartChains(consumerNames []string, setupTransferChans bool) []Step {
 func stepsAssignConsumerKeyOnStartedChain(consumerName, validator string) []Step {
 	return []Step{
 		{
-			action: assignConsumerPubKeyAction{
-				chain:     chainID(consumerName),
-				validator: validatorID("bob"),
+			Action: assignConsumerPubKeyAction{
+				Chain:     ChainID(consumerName),
+				Validator: ValidatorID("bob"),
 				// reconfigure the node -> validator was using provider key
 				// until this point -> key matches config.consumerValPubKey for "bob"
-				consumerPubkey:  `{"@type":"/cosmos.crypto.ed25519.PubKey","key":"QlG+iYe6AyYpvY1z9RNJKCVlH14Q/qSz4EjGdGCru3o="}`,
-				reconfigureNode: true,
+				ConsumerPubkey:  `{"@type":"/cosmos.crypto.ed25519.PubKey","key":"QlG+iYe6AyYpvY1z9RNJKCVlH14Q/qSz4EjGdGCru3o="}`,
+				ReconfigureNode: true,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// this happens after some delegations
 						// so that the chain does not halt if 1/3 of power is offline
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// this happens after some delegations
 						// so that the chain does not halt if 1/3 of power is offline
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
-					AssignedKeys: &map[validatorID]string{
-						validatorID("bob"):   "cosmosvalcons1uuec3cjxajv5te08p220usrjhkfhg9wyvqn0tm",
-						validatorID("carol"): "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk",
+					AssignedKeys: &map[ValidatorID]string{
+						ValidatorID("bob"):   "cosmosvalcons1uuec3cjxajv5te08p220usrjhkfhg9wyvqn0tm",
+						ValidatorID("carol"): "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk",
 					},
-					ProviderKeys: &map[validatorID]string{
-						validatorID("bob"):   "cosmosvalcons1nx7n5uh0ztxsynn4sje6eyq2ud6rc6klc96w39",
-						validatorID("carol"): "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6",
+					ProviderKeys: &map[ValidatorID]string{
+						ValidatorID("bob"):   "cosmosvalcons1nx7n5uh0ztxsynn4sje6eyq2ud6rc6klc96w39",
+						ValidatorID("carol"): "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6",
 					},
 				},
 			},
 		},
 		{
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// this happens after some delegations
 						// so that the chain does not halt if 1/3 of power is offline
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
 						// this happens after some delegations
 						// so that the chain does not halt if 1/3 of power is offline
-						validatorID("alice"): 511,
-						validatorID("bob"):   500,
-						validatorID("carol"): 500,
+						ValidatorID("alice"): 511,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 500,
 					},
-					AssignedKeys: &map[validatorID]string{
-						validatorID("bob"):   "cosmosvalcons1uuec3cjxajv5te08p220usrjhkfhg9wyvqn0tm",
-						validatorID("carol"): "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk",
+					AssignedKeys: &map[ValidatorID]string{
+						ValidatorID("bob"):   "cosmosvalcons1uuec3cjxajv5te08p220usrjhkfhg9wyvqn0tm",
+						ValidatorID("carol"): "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk",
 					},
-					ProviderKeys: &map[validatorID]string{
-						validatorID("bob"):   "cosmosvalcons1nx7n5uh0ztxsynn4sje6eyq2ud6rc6klc96w39",
-						validatorID("carol"): "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6",
+					ProviderKeys: &map[ValidatorID]string{
+						ValidatorID("bob"):   "cosmosvalcons1nx7n5uh0ztxsynn4sje6eyq2ud6rc6klc96w39",
+						ValidatorID("carol"): "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6",
 					},
 				},
 			},

--- a/tests/e2e/steps_stop_chain.go
+++ b/tests/e2e/steps_stop_chain.go
@@ -6,8 +6,8 @@ import "time"
 func stepsStartRelayer() []Step {
 	return []Step{
 		{
-			action: startRelayerAction{},
-			state:  State{},
+			Action: startRelayerAction{},
+			State:  State{},
 		},
 	}
 }
@@ -16,51 +16,51 @@ func stepsStartRelayer() []Step {
 func stepsStopChain(consumerName string, propNumber uint) []Step {
 	s := []Step{
 		{
-			action: submitConsumerRemovalProposalAction{
-				chain:          chainID("provi"),
-				from:           validatorID("bob"),
-				deposit:        10000001,
-				consumerChain:  chainID(consumerName),
-				stopTimeOffset: 0 * time.Millisecond,
+			Action: submitConsumerRemovalProposalAction{
+				Chain:          ChainID("provi"),
+				From:           ValidatorID("bob"),
+				Deposit:        10000001,
+				ConsumerChain:  ChainID(consumerName),
+				StopTimeOffset: 0 * time.Millisecond,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValBalances: &map[validatorID]uint{
-						validatorID("bob"): 9489999999,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("bob"): 9489999999,
 					},
 					Proposals: &map[uint]Proposal{
 						propNumber: ConsumerRemovalProposal{
 							Deposit:  10000001,
-							Chain:    chainID(consumerName),
+							Chain:    ChainID(consumerName),
 							StopTime: 0,
 							Status:   "PROPOSAL_STATUS_VOTING_PERIOD",
 						},
 					},
-					ConsumerChains: &map[chainID]bool{"consu": true}, // consumer chain not yet removed
+					ConsumerChains: &map[ChainID]bool{"consu": true}, // consumer chain not yet removed
 				},
 			},
 		},
 		{
-			action: voteGovProposalAction{
-				chain:      chainID("provi"),
-				from:       []validatorID{validatorID("alice"), validatorID("bob"), validatorID("carol")},
-				vote:       []string{"yes", "yes", "yes"},
-				propNumber: propNumber,
+			Action: voteGovProposalAction{
+				Chain:      ChainID("provi"),
+				From:       []ValidatorID{ValidatorID("alice"), ValidatorID("bob"), ValidatorID("carol")},
+				Vote:       []string{"yes", "yes", "yes"},
+				PropNumber: propNumber,
 			},
-			state: State{
-				chainID("provi"): ChainState{
+			State: State{
+				ChainID("provi"): ChainState{
 					Proposals: &map[uint]Proposal{
 						propNumber: ConsumerRemovalProposal{
 							Deposit:  10000001,
-							Chain:    chainID(consumerName),
+							Chain:    ChainID(consumerName),
 							StopTime: 0,
 							Status:   "PROPOSAL_STATUS_PASSED",
 						},
 					},
-					ValBalances: &map[validatorID]uint{
-						validatorID("bob"): 9500000000,
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("bob"): 9500000000,
 					},
-					ConsumerChains: &map[chainID]bool{}, // Consumer chain is now removed
+					ConsumerChains: &map[ChainID]bool{}, // Consumer chain is now removed
 				},
 			},
 		},
@@ -74,51 +74,51 @@ func stepsStopChain(consumerName string, propNumber uint) []Step {
 func stepsConsumerRemovalPropNotPassing(consumerName string, propNumber uint) []Step {
 	s := []Step{
 		{
-			action: submitConsumerRemovalProposalAction{
-				chain:          chainID("provi"),
-				from:           validatorID("bob"),
-				deposit:        10000001,
-				consumerChain:  chainID(consumerName),
-				stopTimeOffset: 0 * time.Millisecond,
+			Action: submitConsumerRemovalProposalAction{
+				Chain:          ChainID("provi"),
+				From:           ValidatorID("bob"),
+				Deposit:        10000001,
+				ConsumerChain:  ChainID(consumerName),
+				StopTimeOffset: 0 * time.Millisecond,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValBalances: &map[validatorID]uint{
-						validatorID("bob"): 9489999999,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("bob"): 9489999999,
 					},
 					Proposals: &map[uint]Proposal{
 						propNumber: ConsumerRemovalProposal{
 							Deposit:  10000001,
-							Chain:    chainID(consumerName),
+							Chain:    ChainID(consumerName),
 							StopTime: 0,
 							Status:   "PROPOSAL_STATUS_VOTING_PERIOD",
 						},
 					},
-					ConsumerChains: &map[chainID]bool{"consu": true}, // consumer chain not removed
+					ConsumerChains: &map[ChainID]bool{"consu": true}, // consumer chain not removed
 				},
 			},
 		},
 		{
-			action: voteGovProposalAction{
-				chain:      chainID("provi"),
-				from:       []validatorID{validatorID("alice"), validatorID("bob"), validatorID("carol")},
-				vote:       []string{"no", "no", "no"},
-				propNumber: propNumber,
+			Action: voteGovProposalAction{
+				Chain:      ChainID("provi"),
+				From:       []ValidatorID{ValidatorID("alice"), ValidatorID("bob"), ValidatorID("carol")},
+				Vote:       []string{"no", "no", "no"},
+				PropNumber: propNumber,
 			},
-			state: State{
-				chainID("provi"): ChainState{
+			State: State{
+				ChainID("provi"): ChainState{
 					Proposals: &map[uint]Proposal{
 						propNumber: ConsumerRemovalProposal{
 							Deposit:  10000001,
-							Chain:    chainID(consumerName),
+							Chain:    ChainID(consumerName),
 							StopTime: 0,
 							Status:   "PROPOSAL_STATUS_REJECTED",
 						},
 					},
-					ValBalances: &map[validatorID]uint{
-						validatorID("bob"): 9500000000,
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("bob"): 9500000000,
 					},
-					ConsumerChains: &map[chainID]bool{"consu": true}, // consumer chain not removed
+					ConsumerChains: &map[ChainID]bool{"consu": true}, // consumer chain not removed
 				},
 			},
 		},

--- a/tests/e2e/steps_submit_equivocation_proposal.go
+++ b/tests/e2e/steps_submit_equivocation_proposal.go
@@ -7,35 +7,35 @@ func stepsRejectEquivocationProposal(consumerName string, propNumber uint) []Ste
 	return []Step{
 		{
 			// bob submits a proposal to slash himself
-			action: submitEquivocationProposalAction{
-				chain:     chainID("consu"),
-				from:      validatorID("bob"),
-				deposit:   10000001,
-				height:    10,
-				time:      time.Now(),
-				power:     500,
-				validator: validatorID("bob"),
+			Action: submitEquivocationProposalAction{
+				Chain:     ChainID("consu"),
+				From:      ValidatorID("bob"),
+				Deposit:   10000001,
+				Height:    10,
+				Time:      time.Now(),
+				Power:     500,
+				Validator: ValidatorID("bob"),
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 495,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 495,
 					},
-					ValBalances: &map[validatorID]uint{
-						validatorID("bob"): 9500000000,
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("bob"): 9500000000,
 					},
 					Proposals: &map[uint]Proposal{
 						// proposal does not exist
 						propNumber: TextProposal{},
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 495,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 495,
 					},
 				},
 			},
@@ -48,24 +48,24 @@ func stepsSubmitEquivocationProposal(consumerName string, propNumber uint) []Ste
 	s := []Step{
 		{
 			// bob submits a proposal to slash himself
-			action: submitEquivocationProposalAction{
-				chain:     chainID("consu"),
-				from:      validatorID("bob"),
-				deposit:   10000001,
-				height:    10,
-				time:      time.Now(), // not sure what time in equivocations means
-				power:     500,
-				validator: validatorID("bob"),
+			Action: submitEquivocationProposalAction{
+				Chain:     ChainID("consu"),
+				From:      ValidatorID("bob"),
+				Deposit:   10000001,
+				Height:    10,
+				Time:      time.Now(), // not sure what time in equivocations means
+				Power:     500,
+				Validator: ValidatorID("bob"),
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
-					ValBalances: &map[validatorID]uint{
-						validatorID("bob"): 9489999999,
+					ValBalances: &map[ValidatorID]uint{
+						ValidatorID("bob"): 9489999999,
 					},
 					Proposals: &map[uint]Proposal{
 						propNumber: EquivocationProposal{
@@ -77,28 +77,28 @@ func stepsSubmitEquivocationProposal(consumerName string, propNumber uint) []Ste
 						},
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500,
-						validatorID("carol"): 0,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500,
+						ValidatorID("carol"): 0,
 					},
 				},
 			},
 		},
 		{
-			action: voteGovProposalAction{
-				chain:      chainID("provi"),
-				from:       []validatorID{validatorID("alice"), validatorID("bob"), validatorID("carol")},
-				vote:       []string{"yes", "yes", "yes"},
-				propNumber: propNumber,
+			Action: voteGovProposalAction{
+				Chain:      ChainID("provi"),
+				From:       []ValidatorID{ValidatorID("alice"), ValidatorID("bob"), ValidatorID("carol")},
+				Vote:       []string{"yes", "yes", "yes"},
+				PropNumber: propNumber,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   0, // bob is tombstoned after proposal passes
-						validatorID("carol"): 0,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   0, // bob is tombstoned after proposal passes
+						ValidatorID("carol"): 0,
 					},
 					Proposals: &map[uint]Proposal{
 						propNumber: EquivocationProposal{
@@ -110,36 +110,36 @@ func stepsSubmitEquivocationProposal(consumerName string, propNumber uint) []Ste
 						},
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   500, // slash not reflected in consumer chain
-						validatorID("carol"): 0,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   500, // slash not reflected in consumer chain
+						ValidatorID("carol"): 0,
 					},
 				},
 			},
 		},
 		{
 			// relay power change to consumer1
-			action: relayPacketsAction{
-				chainA:  chainID("provi"),
-				chainB:  chainID(consumerName),
-				port:    "provider",
-				channel: 0,
+			Action: relayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID(consumerName),
+				Port:    "provider",
+				Channel: 0,
 			},
-			state: State{
-				chainID("provi"): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   0,
-						validatorID("carol"): 0,
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 0,
 					},
 				},
-				chainID(consumerName): ChainState{
-					ValPowers: &map[validatorID]uint{
-						validatorID("alice"): 509,
-						validatorID("bob"):   0, // slash relayed to consumer chain
-						validatorID("carol"): 0,
+				ChainID(consumerName): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 509,
+						ValidatorID("bob"):   0, // slash relayed to consumer chain
+						ValidatorID("carol"): 0,
 					},
 				},
 			},


### PR DESCRIPTION
## Description

Closes: Part of #1265 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

This PR makes the fields of the relevant structs used in traces exported.
This is necessary preparation for the json format, since JSON marshal/unmarshal has problems with unexported fields, see https://stackoverflow.com/questions/11126793/json-and-dealing-with-unexported-fields.

To review this, please check that the only changes this PR makes are setting the fields of structs and types used in the e2e tests to public. In particular, the fields of all actions need to be exported.
There are also two small refactors that I have marked with comments.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
