### PR TITLE
refactor: RepresentativePowers to StakedTokens

### DIFF
--- a/tests/e2e/state.go
+++ b/tests/e2e/state.go
@@ -20,7 +20,7 @@ type ChainState struct {
 	ValBalances                    *map[ValidatorID]uint
 	Proposals                      *map[uint]Proposal
 	ValPowers                      *map[ValidatorID]uint
-	RepresentativePowers           *map[ValidatorID]uint
+	StakedTokens                   *map[ValidatorID]uint
 	Params                         *[]Param
 	Rewards                        *Rewards
 	ConsumerChains                 *map[ChainID]bool
@@ -138,9 +138,9 @@ func (tr TestConfig) getChainState(chain ChainID, modelState ChainState) ChainSt
 		chainState.ValPowers = &powers
 	}
 
-	if modelState.RepresentativePowers != nil {
-		representPowers := tr.getRepresentativePowers(chain, *modelState.RepresentativePowers)
-		chainState.RepresentativePowers = &representPowers
+	if modelState.StakedTokens != nil {
+		representPowers := tr.getStakedTokens(chain, *modelState.StakedTokens)
+		chainState.StakedTokens = &representPowers
 	}
 
 	if modelState.Params != nil {
@@ -282,10 +282,10 @@ func (tr TestConfig) getValPowers(chain ChainID, modelState map[ValidatorID]uint
 	return actualState
 }
 
-func (tr TestConfig) getRepresentativePowers(chain ChainID, modelState map[ValidatorID]uint) map[ValidatorID]uint {
+func (tr TestConfig) getStakedTokens(chain ChainID, modelState map[ValidatorID]uint) map[ValidatorID]uint {
 	actualState := map[ValidatorID]uint{}
 	for k := range modelState {
-		actualState[k] = tr.getRepresentativePower(chain, k)
+		actualState[k] = tr.getValStakedTokens(chain, k)
 	}
 
 	return actualState
@@ -547,7 +547,7 @@ func (tr TestConfig) getValPower(chain ChainID, validator ValidatorID) uint {
 	return 0
 }
 
-func (tr TestConfig) getRepresentativePower(chain ChainID, validator ValidatorID) uint {
+func (tr TestConfig) getValStakedTokens(chain ChainID, validator ValidatorID) uint {
 	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
 	bz, err := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[chain].BinaryName,
 

--- a/tests/e2e/state_rapid_test.go
+++ b/tests/e2e/state_rapid_test.go
@@ -39,7 +39,7 @@ func GetChainStateGen() *rapid.Generator[ChainState] {
 			valBalances := GetValBalancesGen().Draw(t, "ValBalances")
 			proposals := GetProposalsGen().Draw(t, "Proposals")
 			valPowers := GetValPowersGen().Draw(t, "ValPowers")
-			representativePowers := GetRepresentativePowersGen().Draw(t, "RepresentativePowers")
+			stakedTokens := GetStakedTokensGen().Draw(t, "StakedTokens")
 			params := GetParamsGen().Draw(t, "Params")
 			rewards := GetRewardsGen().Draw(t, "Rewards")
 			consumerChains := GetConsumerChainsGen().Draw(t, "ConsumerChains")
@@ -53,7 +53,7 @@ func GetChainStateGen() *rapid.Generator[ChainState] {
 				ValBalances:                    &valBalances,
 				Proposals:                      &proposals,
 				ValPowers:                      &valPowers,
-				RepresentativePowers:           &representativePowers,
+				StakedTokens:                   &stakedTokens,
 				Params:                         &params,
 				Rewards:                        &rewards,
 				ConsumerChains:                 &consumerChains,
@@ -127,12 +127,12 @@ func GetParamGen() *rapid.Generator[Param] {
 	})
 }
 
-func GetRepresentativePowersGen() *rapid.Generator[map[ValidatorID]uint] {
+func GetStakedTokensGen() *rapid.Generator[map[ValidatorID]uint] {
 	return rapid.Custom(func(t *rapid.T) map[ValidatorID]uint {
 		return rapid.MapOf(
 			GetValidatorIDGen(),
 			rapid.Uint(),
-		).Draw(t, "RepresentativePowers")
+		).Draw(t, "StakedTokens")
 	})
 }
 

--- a/tests/e2e/steps_democracy.go
+++ b/tests/e2e/steps_democracy.go
@@ -12,7 +12,7 @@ func stepsDemocracy(consumerName string) []Step {
 			},
 			State: State{
 				ChainID(consumerName): ChainState{
-					RepresentativePowers: &map[ValidatorID]uint{
+					StakedTokens: &map[ValidatorID]uint{
 						ValidatorID("alice"): 100000000,
 						ValidatorID("bob"):   40000000,
 					},
@@ -38,7 +38,7 @@ func stepsDemocracy(consumerName string) []Step {
 			State: State{
 				ChainID(consumerName): ChainState{
 					// Check that delegators on gov-consumer chain can change representative powers
-					RepresentativePowers: &map[ValidatorID]uint{
+					StakedTokens: &map[ValidatorID]uint{
 						ValidatorID("alice"): 100500000,
 						ValidatorID("bob"):   40000000,
 					},
@@ -286,7 +286,7 @@ func stepsDemocracy(consumerName string) []Step {
 						ValidatorID("carol"): 500,
 					},
 					// Check that slashing on the gov-consumer chain does not result in slashing for the representatives or their delegators
-					RepresentativePowers: &map[ValidatorID]uint{
+					StakedTokens: &map[ValidatorID]uint{
 						ValidatorID("alice"): 100500000,
 						ValidatorID("bob"):   40000000,
 					},

--- a/tests/e2e/steps_reward_denom.go
+++ b/tests/e2e/steps_reward_denom.go
@@ -10,7 +10,7 @@ func stepsRewardDenomConsumer(consumerName string) []Step {
 			},
 			State: State{
 				ChainID(consumerName): ChainState{
-					RepresentativePowers: &map[ValidatorID]uint{
+					StakedTokens: &map[ValidatorID]uint{
 						ValidatorID("alice"): 100000000,
 						ValidatorID("bob"):   40000000,
 					},
@@ -36,7 +36,7 @@ func stepsRewardDenomConsumer(consumerName string) []Step {
 			State: State{
 				ChainID(consumerName): ChainState{
 					// Check that delegators on gov-consumer chain can change representative powers
-					RepresentativePowers: &map[ValidatorID]uint{
+					StakedTokens: &map[ValidatorID]uint{
 						ValidatorID("alice"): 100500000,
 						ValidatorID("bob"):   40000000,
 					},
@@ -284,7 +284,7 @@ func stepsRewardDenomConsumer(consumerName string) []Step {
 						ValidatorID("carol"): 500,
 					},
 					// Check that slashing on the gov-consumer chain does not result in slashing for the representatives or their delegators
-					RepresentativePowers: &map[ValidatorID]uint{
+					StakedTokens: &map[ValidatorID]uint{
 						ValidatorID("alice"): 100500000,
 						ValidatorID("bob"):   40000000,
 					},

--- a/tests/e2e/tracehandler_testdata/changeover.json
+++ b/tests/e2e/tracehandler_testdata/changeover.json
@@ -18,7 +18,7 @@
           "alice": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -47,7 +47,7 @@
           "bob": 0,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -92,7 +92,7 @@
           "carol": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -138,7 +138,7 @@
       "sover": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -179,7 +179,7 @@
       "sover": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -233,7 +233,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -282,7 +282,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -340,7 +340,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -358,7 +358,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -408,7 +408,7 @@
           "bob": 0
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -437,7 +437,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -455,7 +455,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -484,7 +484,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -511,7 +511,7 @@
           "bob": 100
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -540,7 +540,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -558,7 +558,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -587,7 +587,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,

--- a/tests/e2e/tracehandler_testdata/democracy.json
+++ b/tests/e2e/tracehandler_testdata/democracy.json
@@ -1,3 +1,4 @@
+
 [
   {
     "ActionType": "main.StartChainAction",
@@ -31,7 +32,7 @@
           "carol": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -65,7 +66,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -105,7 +106,7 @@
       "democ": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -148,7 +149,7 @@
       "democ": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -189,7 +190,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -247,7 +248,7 @@
           "carol": 10000000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -265,7 +266,7 @@
           "carol": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -331,7 +332,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -349,7 +350,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -377,7 +378,7 @@
           "bob": 10000000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -406,7 +407,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -434,7 +435,7 @@
           "bob": 10000000001
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -464,7 +465,7 @@
       "democ": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": {
+        "StakedTokens": {
           "alice": 100000000,
           "bob": 40000000
         },
@@ -504,7 +505,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": {
+        "StakedTokens": {
           "alice": 100500000,
           "bob": 40000000
         },
@@ -545,7 +546,7 @@
           "bob": 9960000001
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -590,7 +591,7 @@
           "bob": 9960000001
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": [
           {
             "Subspace": "transfer",
@@ -621,7 +622,7 @@
       "provi": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": {
           "IsRewarded": {
@@ -653,7 +654,7 @@
       "provi": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -686,7 +687,7 @@
       "provi": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -713,7 +714,7 @@
       "provi": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": {
           "IsRewarded": {
@@ -748,7 +749,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -766,7 +767,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -795,7 +796,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -813,7 +814,7 @@
           "bob": 0,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -842,7 +843,7 @@
           "bob": 0,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -869,7 +870,7 @@
           "bob": 0,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -887,7 +888,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -916,7 +917,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": {
+        "StakedTokens": {
           "alice": 100500000,
           "bob": 40000000
         },

--- a/tests/e2e/tracehandler_testdata/democracyRewardsSteps.json
+++ b/tests/e2e/tracehandler_testdata/democracyRewardsSteps.json
@@ -31,7 +31,7 @@
           "carol": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -65,7 +65,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -105,7 +105,7 @@
       "democ": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -148,7 +148,7 @@
       "democ": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -189,7 +189,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -247,7 +247,7 @@
           "carol": 10000000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -265,7 +265,7 @@
           "carol": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -331,7 +331,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -349,7 +349,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -377,7 +377,7 @@
           "bob": 10000000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -406,7 +406,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -434,7 +434,7 @@
           "bob": 10000000001
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -464,7 +464,7 @@
       "democ": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": {
+        "StakedTokens": {
           "alice": 100000000,
           "bob": 40000000
         },
@@ -504,7 +504,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": {
+        "StakedTokens": {
           "alice": 100500000,
           "bob": 40000000
         },
@@ -545,7 +545,7 @@
           "bob": 9960000001
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -590,7 +590,7 @@
           "bob": 9960000001
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": [
           {
             "Subspace": "transfer",
@@ -621,7 +621,7 @@
       "provi": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": {
           "IsRewarded": {
@@ -653,7 +653,7 @@
       "provi": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -686,7 +686,7 @@
       "provi": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -713,7 +713,7 @@
       "provi": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": {
           "IsRewarded": {
@@ -748,7 +748,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -766,7 +766,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -795,7 +795,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -813,7 +813,7 @@
           "bob": 0,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -842,7 +842,7 @@
           "bob": 0,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -869,7 +869,7 @@
           "bob": 0,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -887,7 +887,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -916,7 +916,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": {
+        "StakedTokens": {
           "alice": 100500000,
           "bob": 40000000
         },

--- a/tests/e2e/tracehandler_testdata/happyPath.json
+++ b/tests/e2e/tracehandler_testdata/happyPath.json
@@ -31,7 +31,7 @@
           "carol": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -65,7 +65,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -105,7 +105,7 @@
       "consu": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -148,7 +148,7 @@
       "consu": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -189,7 +189,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -247,7 +247,7 @@
           "carol": 10000000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -265,7 +265,7 @@
           "carol": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -317,7 +317,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -335,7 +335,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -363,7 +363,7 @@
           "bob": 10000000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -392,7 +392,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -420,7 +420,7 @@
           "bob": 10000000001
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -451,7 +451,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -475,7 +475,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -504,7 +504,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -528,7 +528,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -557,7 +557,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -575,7 +575,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -604,7 +604,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -633,7 +633,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -651,7 +651,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -680,7 +680,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -709,7 +709,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -727,7 +727,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -756,7 +756,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -786,7 +786,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -804,7 +804,7 @@
           "bob": 500,
           "carol": 950
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -833,7 +833,7 @@
           "bob": 500,
           "carol": 950
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -860,7 +860,7 @@
           "bob": 500,
           "carol": 950
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -878,7 +878,7 @@
           "bob": 500,
           "carol": 950
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -907,7 +907,7 @@
           "bob": 500,
           "carol": 950
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -925,7 +925,7 @@
           "bob": 500,
           "carol": 950
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -955,7 +955,7 @@
           "bob": 500,
           "carol": 950
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -973,7 +973,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1002,7 +1002,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1029,7 +1029,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1047,7 +1047,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1076,7 +1076,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1094,7 +1094,7 @@
           "bob": 0,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1123,7 +1123,7 @@
           "bob": 0,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1150,7 +1150,7 @@
           "bob": 0,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1168,7 +1168,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1197,7 +1197,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1224,7 +1224,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1242,7 +1242,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1271,7 +1271,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1298,7 +1298,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1316,7 +1316,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1345,7 +1345,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1377,7 +1377,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1397,7 +1397,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1434,7 +1434,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1452,7 +1452,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1481,7 +1481,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1499,7 +1499,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1526,7 +1526,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1544,7 +1544,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1573,7 +1573,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1591,7 +1591,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1620,7 +1620,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1638,7 +1638,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1670,7 +1670,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1690,7 +1690,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1738,7 +1738,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1756,7 +1756,7 @@
           "bob": 0,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1796,7 +1796,7 @@
           "bob": 0,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1814,7 +1814,7 @@
           "bob": 0,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1847,7 +1847,7 @@
           "bob": 9489999999
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": {
@@ -1894,7 +1894,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": {
@@ -1934,7 +1934,7 @@
           "bob": 9489999999
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": {
@@ -1981,7 +1981,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": {},

--- a/tests/e2e/tracehandler_testdata/multipleConsumers.json
+++ b/tests/e2e/tracehandler_testdata/multipleConsumers.json
@@ -31,7 +31,7 @@
           "carol": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -65,7 +65,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -105,7 +105,7 @@
       "consu": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -148,7 +148,7 @@
       "consu": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -189,7 +189,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -247,7 +247,7 @@
           "carol": 10000000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -265,7 +265,7 @@
           "carol": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -322,7 +322,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -362,7 +362,7 @@
       "densu": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -405,7 +405,7 @@
       "densu": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -446,7 +446,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -504,7 +504,7 @@
           "carol": 10000000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -522,7 +522,7 @@
           "carol": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -574,7 +574,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -592,7 +592,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -610,7 +610,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -639,7 +639,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -657,7 +657,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -675,7 +675,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -704,7 +704,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -722,7 +722,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -740,7 +740,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -769,7 +769,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -787,7 +787,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -805,7 +805,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -834,7 +834,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -852,7 +852,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -870,7 +870,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -899,7 +899,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -917,7 +917,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -935,7 +935,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -965,7 +965,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -983,7 +983,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1001,7 +1001,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1030,7 +1030,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1048,7 +1048,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1066,7 +1066,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1095,7 +1095,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1113,7 +1113,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1131,7 +1131,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1158,7 +1158,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1176,7 +1176,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1194,7 +1194,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1223,7 +1223,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1241,7 +1241,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1259,7 +1259,7 @@
           "bob": 0,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1288,7 +1288,7 @@
           "bob": 0,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1306,7 +1306,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1335,7 +1335,7 @@
           "bob": 0,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1353,7 +1353,7 @@
           "bob": 0,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1380,7 +1380,7 @@
           "bob": 0,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1398,7 +1398,7 @@
           "bob": 0,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1416,7 +1416,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1445,7 +1445,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1463,7 +1463,7 @@
           "bob": 0,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1481,7 +1481,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1510,7 +1510,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1528,7 +1528,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1546,7 +1546,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1573,7 +1573,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1591,7 +1591,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1609,7 +1609,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1638,7 +1638,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1656,7 +1656,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1674,7 +1674,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1703,7 +1703,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1721,7 +1721,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1739,7 +1739,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1766,7 +1766,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1784,7 +1784,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1802,7 +1802,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1831,7 +1831,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1849,7 +1849,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1867,7 +1867,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1896,7 +1896,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1914,7 +1914,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1932,7 +1932,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1959,7 +1959,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1977,7 +1977,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1995,7 +1995,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2024,7 +2024,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2042,7 +2042,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2060,7 +2060,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2089,7 +2089,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2107,7 +2107,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2125,7 +2125,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2152,7 +2152,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2170,7 +2170,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2188,7 +2188,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2217,7 +2217,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2235,7 +2235,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2253,7 +2253,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2282,7 +2282,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2300,7 +2300,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2318,7 +2318,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2347,7 +2347,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -2365,7 +2365,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,

--- a/tests/e2e/tracehandler_testdata/shorthappy.json
+++ b/tests/e2e/tracehandler_testdata/shorthappy.json
@@ -31,7 +31,7 @@
           "carol": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -65,7 +65,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -105,7 +105,7 @@
       "consu": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -148,7 +148,7 @@
       "consu": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -189,7 +189,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -247,7 +247,7 @@
           "carol": 10000000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -265,7 +265,7 @@
           "carol": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -317,7 +317,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -335,7 +335,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -363,7 +363,7 @@
           "bob": 10000000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -392,7 +392,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -420,7 +420,7 @@
           "bob": 10000000001
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -449,7 +449,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -467,7 +467,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -496,7 +496,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -526,7 +526,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -544,7 +544,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -573,7 +573,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -600,7 +600,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -618,7 +618,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -647,7 +647,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -665,7 +665,7 @@
           "bob": 0,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -694,7 +694,7 @@
           "bob": 0,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -721,7 +721,7 @@
           "bob": 0,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -739,7 +739,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -768,7 +768,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -795,7 +795,7 @@
           "bob": 500,
           "carol": 501
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -813,7 +813,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -842,7 +842,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -869,7 +869,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -887,7 +887,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -916,7 +916,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -948,7 +948,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -968,7 +968,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1005,7 +1005,7 @@
           "bob": 500,
           "carol": 495
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1023,7 +1023,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1052,7 +1052,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1070,7 +1070,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1097,7 +1097,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1115,7 +1115,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1144,7 +1144,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1162,7 +1162,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1191,7 +1191,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1209,7 +1209,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1241,7 +1241,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1261,7 +1261,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1309,7 +1309,7 @@
           "bob": 500,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1327,7 +1327,7 @@
           "bob": 0,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1367,7 +1367,7 @@
           "bob": 0,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1385,7 +1385,7 @@
           "bob": 0,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -1418,7 +1418,7 @@
           "bob": 9489999999
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": {
@@ -1465,7 +1465,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": {
@@ -1505,7 +1505,7 @@
           "bob": 9489999999
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": {
@@ -1552,7 +1552,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": {},

--- a/tests/e2e/tracehandler_testdata/slashThrottle.json
+++ b/tests/e2e/tracehandler_testdata/slashThrottle.json
@@ -31,7 +31,7 @@
           "carol": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -65,7 +65,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -105,7 +105,7 @@
       "consu": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -148,7 +148,7 @@
       "consu": {
         "ValBalances": null,
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -189,7 +189,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -247,7 +247,7 @@
           "carol": 10000000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -265,7 +265,7 @@
           "carol": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -317,7 +317,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -335,7 +335,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -363,7 +363,7 @@
           "bob": 10000000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -392,7 +392,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -420,7 +420,7 @@
           "bob": 10000000001
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -447,7 +447,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -465,7 +465,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -494,7 +494,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -512,7 +512,7 @@
           "bob": 0,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -541,7 +541,7 @@
           "bob": 500,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -559,7 +559,7 @@
           "bob": 0,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -588,7 +588,7 @@
           "bob": 0,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -606,7 +606,7 @@
           "bob": 0,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -637,7 +637,7 @@
           "bob": 0,
           "carol": 500
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -655,7 +655,7 @@
           "bob": 0,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -686,7 +686,7 @@
           "bob": 0,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -704,7 +704,7 @@
           "bob": 0,
           "carol": 0
         },
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": null,
@@ -734,7 +734,7 @@
           "bob": 9489999999
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": {
@@ -781,7 +781,7 @@
           "bob": 9500000000
         },
         "ValPowers": null,
-        "RepresentativePowers": null,
+        "StakedTokens": null,
         "Params": null,
         "Rewards": null,
         "ConsumerChains": {},


### PR DESCRIPTION
## Description
This is a minor-refactor PR and hence no issue is created for it.

Based on @p-offtermatt [comment](https://github.com/cosmos/interchain-security/pull/1275#discussion_r1336804594
):
> Seems ok to me. Could rename it to something like StakedTokens instead of RepresentativePowers (looking at the code, I think that's what this actually is, right?)

We rename `RepresentativePowers` to `StakedTokens`. We can see that `StakedTokens` is a better name if we look at what `getRepresentativePower` is computing, which is just the number of tokens:

```
func (tr TestConfig) getRepresentativePower(chain ChainID, validator ValidatorID) uint {
	//#nosec G204 -- Bypass linter warning for spawning subprocess with cmd arguments.
	bz, err := exec.Command("docker", "exec", tr.containerConfig.InstanceName, tr.chainConfigs[chain].BinaryName,

		"query", "staking", "validator",
		tr.validatorConfigs[validator].ValoperAddress,
		`--node`, tr.getQueryNode(chain),
		`-o`, `json`,
	).CombinedOutput()
	if err != nil {
		log.Fatal(err, "\n", string(bz))
	}
	amount := gjson.Get(string(bz), `tokens`)
	return uint(amount.Uint())
}
```