### PR TITLE
fix: Fix Dockerfile.gaia not pulling the latest version

### DIFF
--- a/Dockerfile.gaia
+++ b/Dockerfile.gaia
@@ -29,7 +29,7 @@ RUN if [ -n "${GAIA_TAG}" ]; \
     then git checkout "${GAIA_TAG}"; \
     # if GAIA_TAG is not set, build the latest tagged version
     else \
-    git checkout $(git tag | tail -1); \
+    git checkout $(git tag | sort -Vr | head -n1); \
     fi 
 
 # Also replace sdk version in the go.mod if specified


### PR DESCRIPTION
<!--
The production pull request template is for types feat, fix, or refactor.
-->

## Description

Closes: N/A

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Dockerfile.gaia is not pulling the latest version, contrary to what it claims in the comment.
The current line sorts by lexicographic order, i.e.

```
 $ git tag
stargate-6
stargate-6-a
stargate-6-b
v0.0.0
v0.0.1-rc0
v1.0.0
v1.0.0-rc1
v1.0.0-rc2
v1.0.0-rc3
v10.0.0
v10.0.0-rc0
v10.0.1
v10.0.2
v11.0.0
v11.0.0-rc0
v12.0.0
v12.0.0-rc0
v13.0.0
v13.0.0-rc0
v13.0.1
v2.0.0
v2.0.0-rc1
v2.0.1
v2.0.10
v2.0.11
v2.0.12
v2.0.13
v2.0.14
v2.0.15
v2.0.2
v2.0.3
v2.0.4
v2.0.5
v2.0.6
v2.0.7
v2.0.8
v2.0.9
v3.0.0
v3.0.1
v4.0.0
v4.0.1
v4.0.2
v4.0.3
v4.0.4
v4.0.5
v4.0.6
v4.1.0
v4.1.1
v4.1.2
v4.2.0
v4.2.1
v5.0.0
v5.0.1
v5.0.2
v5.0.3
v5.0.4
v5.0.5
v5.0.6
v5.0.7
v5.0.8
v6.0.0
v6.0.0-rc1
v6.0.0-rc2
v6.0.0-rc3
v6.0.1
v6.0.2
v6.0.3
v6.0.4
v7.0.0
v7.0.0-rc0
v7.0.1
v7.0.2
v7.0.3
v7.1.0
v7.1.1
v8.0.0
v8.0.0-rc
v8.0.0-rc1
v8.0.0-rc2
v8.0.0-rc3
v8.0.0-rc4
v8.0.0-rc5
v8.0.1
v9.0.0
v9.0.0-rc0
v9.0.0-rc1
v9.0.0-rc2
v9.0.0-rc3
v9.0.0-rc4
v9.0.0-rc5
v9.0.0-rc6
v9.0.0-rc7
v9.0.1
v9.0.1-rc0
v9.0.2
v9.0.2-rc0
v9.0.3
v9.0.3-rc0
v9.1.0
v9.1.1
```

Thus, this tries to build v9.1.1.

The adjusted sorting actually sorts correctly (though it is reversed in order now, which is why we take head instead of tail).
```
% git tag | sort -Vr           
v13.0.1
v13.0.0-rc0
v13.0.0
v12.0.0-rc0
v12.0.0
v11.0.0-rc0
v11.0.0
v10.0.2
v10.0.1
v10.0.0-rc0
v10.0.0
v9.1.1
v9.1.0
v9.0.3-rc0
v9.0.3
v9.0.2-rc0
v9.0.2
v9.0.1-rc0
v9.0.1
v9.0.0-rc7
v9.0.0-rc6
v9.0.0-rc5
v9.0.0-rc4
v9.0.0-rc3
v9.0.0-rc2
v9.0.0-rc1
v9.0.0-rc0
v9.0.0
v8.0.1
v8.0.0-rc5
v8.0.0-rc4
v8.0.0-rc3
v8.0.0-rc2
v8.0.0-rc1
v8.0.0-rc
v8.0.0
v7.1.1
v7.1.0
v7.0.3
v7.0.2
v7.0.1
v7.0.0-rc0
v7.0.0
v6.0.4
v6.0.3
v6.0.2
v6.0.1
v6.0.0-rc3
v6.0.0-rc2
v6.0.0-rc1
v6.0.0
v5.0.8
v5.0.7
v5.0.6
v5.0.5
v5.0.4
v5.0.3
v5.0.2
v5.0.1
v5.0.0
v4.2.1
v4.2.0
v4.1.2
v4.1.1
v4.1.0
v4.0.6
v4.0.5
v4.0.4
v4.0.3
v4.0.2
v4.0.1
v4.0.0
v3.0.1
v3.0.0
v2.0.15
v2.0.14
v2.0.13
v2.0.12
v2.0.11
v2.0.10
v2.0.9
v2.0.8
v2.0.7
v2.0.6
v2.0.5
v2.0.4
v2.0.3
v2.0.2
v2.0.1
v2.0.0-rc1
v2.0.0
v1.0.0-rc3
v1.0.0-rc2
v1.0.0-rc1
v1.0.0
v0.0.1-rc0
v0.0.0
stargate-6-b
stargate-6-a
stargate-6
stargate-4
stargate-3
stargate-2
stargate-1a
stargate-1
list
goz-phase-3
goz-phase-2
goz-phase-1
cosmoshub-test-stargate-e
cosmoshub-test-stargate-2
cosmoshub-test-stargate
```

Neither the new nor the old version handle the random tags flying around very well,
so I think the change shouldn't make anything worse in that (and we avoid problems with this by keeping our tags neat in the future).
---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
* [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed this PR does not introduce changes requiring state migrations, OR confirmed migration code has been added to consumer and/or provider modules
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
