### PR TITLE
test: upgrade packetSniffer to latest ABCIListener API 

### DIFF
--- a/tests/integration/common.go
+++ b/tests/integration/common.go
@@ -373,7 +373,7 @@ func checkRedelegationEntryCompletionTime(
 func getStakingUnbondingDelegationEntry(ctx sdk.Context, k testutil.TestStakingKeeper, id uint64) (stakingUnbondingOp stakingtypes.UnbondingDelegationEntry, found bool) {
 	stakingUbd, err := k.GetUnbondingDelegationByUnbondingID(ctx, id)
 	if err != nil {
-		panic(fmt.Sprintf("could not get unbonding delegation", err))
+		panic(fmt.Sprintf("could not get unbonding delegation: %v", err))
 	}
 
 	found = false


### PR DESCRIPTION
Relates: #1349

Also remove unused func ABCIToSDKEvents.

Please go the the `Preview` tab and select the appropriate sub-template:

* [Production code](?expand=1&template=production.md) - for types `fix`, `feat`, and `refactor`.
* [Docs](?expand=1&template=docs.md) - for documentation changes.
* [Others](?expand=1&template=others.md) - for changes that do not affect production code.