### PR TITLE
tests: refactor and enable ABCI event listeners (packetSniffer)

### DIFF
--- a/tests/integration/common.go
+++ b/tests/integration/common.go
@@ -373,7 +373,7 @@ func checkRedelegationEntryCompletionTime(
 func getStakingUnbondingDelegationEntry(ctx sdk.Context, k testutil.TestStakingKeeper, id uint64) (stakingUnbondingOp stakingtypes.UnbondingDelegationEntry, found bool) {
 	stakingUbd, err := k.GetUnbondingDelegationByUnbondingID(ctx, id)
 	if err != nil {
-		panic(fmt.Sprintf("could not get unbonding delegation", err))
+		panic(fmt.Sprintf("could not get unbonding delegation: %v", err))
 	}
 
 	found = false

--- a/tests/integration/setup.go
+++ b/tests/integration/setup.go
@@ -390,7 +390,6 @@ func newPacketSniffer() *packetSniffer {
 }
 
 func (ps *packetSniffer) ListenFinalizeBlock(ctx context.Context, req abci.RequestFinalizeBlock, res abci.ResponseFinalizeBlock) error {
-	// TODO: @MSalopek this was deprecated, figure out how to use it
 	packets := ParsePacketsFromEvents(res.GetEvents())
 	for _, packet := range packets {
 		ps.packets[getSentPacketKey(packet.Sequence, packet.SourceChannel)] = packet
@@ -408,25 +407,7 @@ func (*packetSniffer) ListenCommit(ctx context.Context, res abci.ResponseCommit,
 	return nil
 }
 
-// [legacy simibc method]
-// ABCIToSDKEvents converts a list of ABCI events to Cosmos SDK events.
-func ABCIToSDKEvents(abciEvents []abci.Event) sdk.Events {
-	var events sdk.Events
-	for _, evt := range abciEvents {
-		var attributes []sdk.Attribute
-		for _, attr := range evt.GetAttributes() {
-			attributes = append(attributes, sdk.NewAttribute(attr.Key, attr.Value))
-		}
-
-		events = events.AppendEvent(sdk.NewEvent(evt.GetType(), attributes...))
-	}
-
-	return events
-}
-
-// [legacy simibc method]
 // ParsePacketsFromEvents returns all packets found in events.
-// func ParsePacketsFromEvents(events []sdk.Event) (packets []channeltypes.Packet) {
 func ParsePacketsFromEvents(events []abci.Event) (packets []channeltypes.Packet) {
 	for i, ev := range events {
 		if ev.Type == channeltypes.EventTypeSendPacket {


### PR DESCRIPTION
This adds the missing parts in eneabling integration test packet sniffing.

Partial implementation of: #1349 

Thank you @tbruyelle!