### PR TITLE
docs: reject ADR 012

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/production.md
+++ b/.github/PULL_REQUEST_TEMPLATE/production.md
@@ -30,7 +30,7 @@ I have...
 * [ ] Updated the relevant documentation or specification
 * [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
 * [ ] Confirmed all CI checks have passed
-* [ ] If this PR is library API breaking, bump the go.mod version string of the repo, and follow through on a new major release for both the consumer and provider
+* [ ] If this PR is library API breaking, bump the go.mod version string of the repo, and follow through on a new major release
 
 ### Reviewers Checklist
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,9 +247,9 @@ ICS adheres to the [trunk based development branching model](https://trunkbasedd
 
 ICS follows [semantic versioning](https://semver.org), but with the following deviations (similar to [IBC-Go](https://github.com/cosmos/ibc-go/blob/main/RELEASES.md)):
 
-- A library API breaking change to EITHER the provider or consumer module will result in an increase of the MAJOR version number for BOTH modules (X.y.z-provider AND X.y.z-consumer).
-- A state breaking change (change requiring coordinated upgrade and/or state migration) will result in an increase of the MINOR version number for the AFFECTED module(s) (x.Y.z-provider AND/OR x.Y.z-consumer).
-- Any other changes (including node API breaking changes) will result in an increase of the PATCH version number for the AFFECTED module(s) (x.y.Z-provider AND/OR x.y.Z-consumer).
+- A library API breaking change will result in an increase of the MAJOR version number (X.y.z | x > 0). 
+- A state breaking change (change requiring coordinated upgrade and/or state migration for the consumer, the provider, or both) will result in an increase of the MINOR version number (x.Y.z | x > 0).
+- Any other changes (including node API breaking changes) will result in an increase of the PATCH version number (x.y.Z | x > 0).
 
 ### Backwards Compatibility
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,15 +1,17 @@
 <!--
   A release notes template that should be adapted for every release
-    - release: <v*.*.*>-<consumer/provider>
-    - release branch: release/<v*.*.x>-<consumer/provider>
+    - release: <v*.*.*>
+    - release branch: <v*.x>
+    - the last release: <v-last> 
+    - the last release branch: <v-last.x>
 -->
 
-# Replicated Security <v*.*.*>-<consumer/provider>  Release Notes
+# Replicated Security <v*.*.*>  Release Notes
 
 <!--
   Please indicate whether this release is relevant to consumers or providers.
 -->
-## Note this release is ONLY relevant to <consumers/providers>
+❗ ***Note this release is ONLY relevant to <consumers/providers>***
 
 ## 📝 Changelog
 

--- a/docs/docs/adrs/adr-012-separate-releasing.md
+++ b/docs/docs/adrs/adr-012-separate-releasing.md
@@ -8,10 +8,11 @@ title: Separate Releasing
 
 * {8/18/22}: Initial draft of idea in [#801](https://github.com/cosmos/interchain-security/issues/801)
 * {8/22/22}: Put idea in this ADR
+* {11/10/22}: Reject this ADR
 
 ## Status
 
-Accepted
+Rejected
 
 ## Context
 
@@ -63,7 +64,7 @@ We upgrade `main` to use a new version of SDK. This is a major version bump, tri
 
 ### Negative
 
-* Slightly more complexity.
+* ~~Slightly more complexity.~~Considerably more complex to manage the ICS library. 
 * This solution does not allow having provider and consumer on separate versions of e.g. the Cosmos SDK
 
 ### Neutral


### PR DESCRIPTION
## Description

Closes: NA

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Reverting the changes introduced by `ADR 012: Separate Releasing` in order to simplify the release process. The changelog will be updated in a different PR. 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct `docs:` prefix in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)
- [ ] Checked that the documentation website can be built and deployed successfully (run `make build-docs`)

