### PR TITLE
chore: remove `-consumer` prefix from v3.2.x

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -72,7 +72,7 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    target-branch: "release/v3.2.x-consumer"
+    target-branch: "release/v3.2.x"
     # Only allow automated security-related dependency updates on release branches.
     open-pull-requests-limit: 0
     labels:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -50,11 +50,11 @@ pull_request_rules:
       backport:
         branches:
           - release/v3.1.x
-  - name: Backport patches to the release/v3.2.x-consumer branch
+  - name: Backport patches to the release/v3.2.x branch
     conditions:
       - base=main
-      - label=A:backport/v3.2.x-consumer
+      - label=A:backport/v3.2.x
     actions:
       backport:
         branches:
-          - release/v3.2.x-consumer
+          - release/v3.2.x


### PR DESCRIPTION
## Description

Closes: NA

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Update dependabot and mergify -- remove `-consumer` prefix from v3.2.x

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
