### PR TITLE
test: Update outdated base image version of fedora to latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ADD . /interchain-security
 
 WORKDIR /interchain-security
 
-# Do not specify version here. It leads to odd replacement behavior 
+# Do not specify version here. It leads to odd replacement behavior
 RUN if [ -d "./cosmos-sdk" ]; then go mod edit -replace github.com/cosmos/cosmos-sdk=./cosmos-sdk; fi
 RUN go mod tidy
 
@@ -37,7 +37,7 @@ FROM ghcr.io/informalsystems/cometmock:v0.37.x as cometmock-builder
 # Get GoRelayer
 FROM ghcr.io/informalsystems/relayer-no-gas-sim:v2.3.0-rc4-no-gas-sim AS gorelayer-builder
 
-FROM --platform=linux/amd64 fedora:36
+FROM --platform=linux/amd64 fedora:39
 RUN dnf update -y
 RUN dnf install -y which iproute iputils procps-ng vim-minimal tmux net-tools htop jq
 USER root


### PR DESCRIPTION
## Description

Closes: #1448

e2e tets are using outdated version of fedora base image.
Image creation from non-cached version fails download.
This fix uses latest version (v39) of fedora base image for e2e images.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
