### PR TITLE
chore: Fix definition of breaking in production template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/production.md
+++ b/.github/PULL_REQUEST_TEMPLATE/production.md
@@ -19,7 +19,7 @@ please add links to any relevant follow up issues.*
 I have...
 
 * [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
-* [ ] Added `!` to the type prefix if state-machine breaking change (i.e., requires coordinated upgrade)
+* [ ] Added `!` to the type prefix if the change is library breaking, state-machine breaking, or node API breaking (see more info [here](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes
 * [ ] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
 * [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
 * [ ] Provided a link to the relevant issue or specification
@@ -40,7 +40,7 @@ your handle next to the items reviewed if you only reviewed selected items.*
 I have...
 
 * [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
-* [ ] confirmed `!` in the type prefix if API or client breaking change
+* [ ] confirmed `!` in the type prefix if the change is library breaking, state-machine breaking, or node API breaking
 * [ ] confirmed this PR does not introduce changes requiring state migrations, OR confirmed migration code has been added to consumer and/or provider modules
 * [ ] confirmed all author checklist items have been addressed
 * [ ] reviewed state machine logic

--- a/.github/PULL_REQUEST_TEMPLATE/production.md
+++ b/.github/PULL_REQUEST_TEMPLATE/production.md
@@ -19,7 +19,7 @@ please add links to any relevant follow up issues.*
 I have...
 
 * [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
-* [ ] Added `!` to the type prefix if the change is state-machine breaking and therefore requires a coordinated upgrade (see further [here](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes)
+* [ ] Added `!` to the type prefix if the change is [state-machine breaking](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes)
 * [ ] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
 * [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
 * [ ] Provided a link to the relevant issue or specification

--- a/.github/PULL_REQUEST_TEMPLATE/production.md
+++ b/.github/PULL_REQUEST_TEMPLATE/production.md
@@ -19,7 +19,7 @@ please add links to any relevant follow up issues.*
 I have...
 
 * [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
-* [ ] Added `!` to the type prefix if the change is library breaking, state-machine breaking, or node API breaking (see more info [here](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes
+* [ ] Added `!` to the type prefix if the change is state-machine breaking and therefore requires a coordinated upgrade (see further [here](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes)
 * [ ] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
 * [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
 * [ ] Provided a link to the relevant issue or specification
@@ -40,7 +40,7 @@ your handle next to the items reviewed if you only reviewed selected items.*
 I have...
 
 * [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
-* [ ] confirmed `!` in the type prefix if the change is library breaking, state-machine breaking, or node API breaking
+* [ ] confirmed `!` the type prefix if the change is state-machine breaking
 * [ ] confirmed this PR does not introduce changes requiring state migrations, OR confirmed migration code has been added to consumer and/or provider modules
 * [ ] confirmed all author checklist items have been addressed
 * [ ] reviewed state machine logic


### PR DESCRIPTION
## Description

Closes: N/A

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

The PR template is inconsistently using client breaking, state breaking, library breaking.
This unifies it with the updated definitions from the RELEASE document

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
