### PR TITLE
fix: missing transformation for field 'new_chain' in ccv consumer genesis

### DIFF
--- a/app/consumer/genesis.go
+++ b/app/consumer/genesis.go
@@ -64,6 +64,7 @@ func transform(jsonRaw []byte, ctx client.Context) (json.RawMessage, error) {
 			ConsensusState: oldConsumerGenesis.ProviderConsensusState,
 			InitialValSet:  oldConsumerGenesis.InitialValSet,
 		},
+		NewChain: oldConsumerGenesis.NewChain,
 	}
 
 	newJson, err := ctx.Codec.MarshalJSON(&newGenesis)

--- a/app/consumer/genesis_test.go
+++ b/app/consumer/genesis_test.go
@@ -3,6 +3,7 @@ package app_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -192,6 +193,10 @@ func TestConsumerGenesisTransformationV2(t *testing.T) {
 	_, err = cmd.ExecuteC()
 	require.NoError(t, err)
 
+	var oldConsumerGenesis map[string]interface{}
+	err = json.Unmarshal([]byte(consumerGenesisStates[version]), &oldConsumerGenesis)
+	require.NoError(t, err, "Error parsing old version of ccv genesis content for consumer")
+
 	consumerGenesis := consumerTypes.GenesisState{}
 
 	bz := output.Bytes()
@@ -212,4 +217,5 @@ func TestConsumerGenesisTransformationV2(t *testing.T) {
 	require.Empty(t, consumerGenesis.InitialValSet)
 	require.NotEmpty(t, consumerGenesis.Provider.InitialValSet)
 	require.Equal(t, consumerGenesis.Params.RetryDelayPeriod, ccvtypes.DefaultRetryDelayPeriod)
+	require.Equal(t, consumerGenesis.NewChain, oldConsumerGenesis["new_chain"])
 }


### PR DESCRIPTION
<!--
The production pull request template is for types feat, fix, or refactor.
-->

## Description

Closes: #1508 

Missing transformation of ccv consumer genesis value for `new_chain` ending up in default which was preventing client creation on consumer chane. Fix for the shortcomming transforms the missing value to the exported one from provider chain. 

Fix was tested using e2e tests running consumer version v3.3.0-rc0 with provider version v2.4.0-lsm

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] Added `!` to the type prefix if state-machine breaking change (i.e., requires coordinated upgrade)
* [x] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
* [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] Provided a link to the relevant issue or specification
* [ ] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/00-intro.md)
* [x] Included the necessary unit and integration [tests](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry to `CHANGELOG.md`
* [ ] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [x] Confirmed all CI checks have passed
* [ ] If this PR is library API breaking, bump the go.mod version string of the repo, and follow through on a new major release

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed this PR does not introduce changes requiring state migrations, OR confirmed migration code has been added to consumer and/or provider modules
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
