### PR TITLE
docs: added a ramification of opt out

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -29,8 +29,9 @@ Refer to the [upgrading guide](https://github.com/cosmos/interchain-security/blo
 <!-- Add any highlights of this release -->
 
 ## ❤️ Contributors
-
+<!-- markdown-link-check-disable -->
 * Informal Systems ([@informalinc](https://twitter.com/informalinc))
+<!-- markdown-link-check-enable -->
 
 This list is non-exhaustive and ordered alphabetically.  
 Thank you to everyone who contributed to this release!

--- a/docs/docs/adrs/adr-009-soft-opt-out.md
+++ b/docs/docs/adrs/adr-009-soft-opt-out.md
@@ -38,6 +38,7 @@ Then, whenever the `Slash()` interface is executed on the consumer, if the votin
 
 * The bottom `x%` is still part of the total voting power of the consumer chain. This means that if the soft opt-out threshold is set to `10%` for example, and every validator in the bottom `10%` opts out from validating the consumer, then a `24%` downtime of the remaining voting power would halt the chain. This may be especially problematic during consumer upgrades.
 * In nominal scenarios, consumers with soft opt out enabled will be constructing slash packets for small vals, which may be dropped. This is wasted computation, but necessary to keep implementation simple. Note that the sdk's [full downtime logic](https://github.com/cosmos/cosmos-sdk/blob/d3f09c222243bb3da3464969f0366330dcb977a8/x/slashing/keeper/infractions.go#L75) is always executed on the consumer, which can be computationally expensive and slow down certain blocks.
+* In a consumer chain, when a validator that has opted out becomes the proposer, there will naturally be no proposal made and validators would need to move to the next consensus round for the same height to reach a decision. As a result, we would need more time to finalize blocks on a consumer chain.
 
 ### Neutral
 


### PR DESCRIPTION
## Description
Added a ramification of [ADR 009](https://github.com/cosmos/interchain-security/blob/main/docs/docs/adrs/adr-009-soft-opt-out.md), namely that _soft opt-out_ would delay the decision of blocks on consumer chains.

Thanks to @sergio-mena for mentioning this!

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct `docs:` prefix in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)
- [ ] Checked that the documentation website can be built and deployed successfully (run `make build-docs`)

