### PR TITLE
test: Add backtransform functionality to genesis transform cli

### DIFF
--- a/app/consumer/genesis_test.go
+++ b/app/consumer/genesis_test.go
@@ -446,7 +446,7 @@ func transformConsumerGenesis(filePath string, version *string) ([]byte, error) 
 	cmd.SetOutput(result)
 	_, err = cmd.ExecuteC()
 	if err != nil {
-		return nil, fmt.Errorf("Error runnning transformation command: %v", err)
+		return nil, fmt.Errorf("Error running transformation command: %v", err)
 	}
 	return result.Bytes(), nil
 }

--- a/app/consumer/genesis_test.go
+++ b/app/consumer/genesis_test.go
@@ -3,7 +3,7 @@ package app_test
 import (
 	"bytes"
 	"context"
-	"encoding/json"
+	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -24,7 +24,7 @@ import (
 // Testdata mapping consumer genesis exports to a provider module version as
 // used by transformation function for consumer genesis content.
 var consumerGenesisStates map[string]string = map[string]string{
-	"v2": `
+	"v2.x": `
 	{
 		"params": {
 		  "enabled": true,
@@ -147,6 +147,259 @@ var consumerGenesisStates map[string]string = map[string]string{
 	  }
 
 	`,
+	"v3.3.x": `
+	{
+		"params": {
+		  "enabled": true,
+		  "blocks_per_distribution_transmission": "1000",
+		  "distribution_transmission_channel": "",
+		  "provider_fee_pool_addr_str": "",
+		  "ccv_timeout_period": "2419200s",
+		  "transfer_timeout_period": "3600s",
+		  "consumer_redistribution_fraction": "0.75",
+		  "historical_entries": "10000",
+		  "unbonding_period": "1209600s",
+		  "soft_opt_out_threshold": "0.05",
+		  "reward_denoms": [],
+		  "provider_reward_denoms": []
+		},
+		"provider": {
+		  "client_state": {
+			"chain_id": "provi",
+			"trust_level": {
+			  "numerator": "1",
+			  "denominator": "3"
+			},
+			"trusting_period": "1197504s",
+			"unbonding_period": "1814400s",
+			"max_clock_drift": "10s",
+			"frozen_height": {
+			  "revision_number": "0",
+			  "revision_height": "0"
+			},
+			"latest_height": {
+			  "revision_number": "0",
+			  "revision_height": "20"
+			},
+			"proof_specs": [
+			  {
+				"leaf_spec": {
+				  "hash": "SHA256",
+				  "prehash_key": "NO_HASH",
+				  "prehash_value": "SHA256",
+				  "length": "VAR_PROTO",
+				  "prefix": "AA=="
+				},
+				"inner_spec": {
+				  "child_order": [
+					0,
+					1
+				  ],
+				  "child_size": 33,
+				  "min_prefix_length": 4,
+				  "max_prefix_length": 12,
+				  "empty_child": null,
+				  "hash": "SHA256"
+				},
+				"max_depth": 0,
+				"min_depth": 0,
+				"prehash_key_before_comparison": false
+			  },
+			  {
+				"leaf_spec": {
+				  "hash": "SHA256",
+				  "prehash_key": "NO_HASH",
+				  "prehash_value": "SHA256",
+				  "length": "VAR_PROTO",
+				  "prefix": "AA=="
+				},
+				"inner_spec": {
+				  "child_order": [
+					0,
+					1
+				  ],
+				  "child_size": 32,
+				  "min_prefix_length": 1,
+				  "max_prefix_length": 1,
+				  "empty_child": null,
+				  "hash": "SHA256"
+				},
+				"max_depth": 0,
+				"min_depth": 0,
+				"prehash_key_before_comparison": false
+			  }
+			],
+			"upgrade_path": [
+			  "upgrade",
+			  "upgradedIBCState"
+			],
+			"allow_update_after_expiry": false,
+			"allow_update_after_misbehaviour": false
+		  },
+		  "consensus_state": {
+			"timestamp": "2023-12-15T09:25:46.098392003Z",
+			"root": {
+			  "hash": "0aoNOwWy67aQKs2r+FcDf2RxIq2UJtBb3g9ZWn0Gkas="
+			},
+			"next_validators_hash": "632730A03DEF630F77B61DF4092629007AE020B789713158FABCB104962FA54F"
+		  },
+		  "initial_val_set": [
+			{
+			  "pub_key": {
+				"ed25519": "RrclQz9bIhkIy/gfL485g3PYMeiIku4qeo495787X10="
+			  },
+			  "power": "500"
+			},
+			{
+			  "pub_key": {
+				"ed25519": "Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is="
+			  },
+			  "power": "500"
+			},
+			{
+			  "pub_key": {
+				"ed25519": "mAN6RXYxSM4MNGSIriYiS7pHuwAcOHDQAy9/wnlSzOI="
+			  },
+			  "power": "500"
+			}
+		  ]
+		},
+		"new_chain": true
+	  }
+	`,
+	"v4.x": `
+	{
+		"params": {
+		  "enabled": true,
+		  "blocks_per_distribution_transmission": "1000",
+		  "distribution_transmission_channel": "",
+		  "provider_fee_pool_addr_str": "",
+		  "ccv_timeout_period": "2419200s",
+		  "transfer_timeout_period": "3600s",
+		  "consumer_redistribution_fraction": "0.75",
+		  "historical_entries": "10000",
+		  "unbonding_period": "1209600s",
+		  "soft_opt_out_threshold": "0.05",
+		  "reward_denoms": [],
+		  "provider_reward_denoms": [],
+		  "retry_delay_period": "3600s"
+		},
+		"provider": {
+		  "client_state": {
+			"chain_id": "provi",
+			"trust_level": {
+			  "numerator": "1",
+			  "denominator": "3"
+			},
+			"trusting_period": "1197504s",
+			"unbonding_period": "1814400s",
+			"max_clock_drift": "10s",
+			"frozen_height": {
+			  "revision_number": "0",
+			  "revision_height": "0"
+			},
+			"latest_height": {
+			  "revision_number": "0",
+			  "revision_height": "20"
+			},
+			"proof_specs": [
+			  {
+				"leaf_spec": {
+				  "hash": "SHA256",
+				  "prehash_key": "NO_HASH",
+				  "prehash_value": "SHA256",
+				  "length": "VAR_PROTO",
+				  "prefix": "AA=="
+				},
+				"inner_spec": {
+				  "child_order": [
+					0,
+					1
+				  ],
+				  "child_size": 33,
+				  "min_prefix_length": 4,
+				  "max_prefix_length": 12,
+				  "empty_child": null,
+				  "hash": "SHA256"
+				},
+				"max_depth": 0,
+				"min_depth": 0,
+				"prehash_key_before_comparison": false
+			  },
+			  {
+				"leaf_spec": {
+				  "hash": "SHA256",
+				  "prehash_key": "NO_HASH",
+				  "prehash_value": "SHA256",
+				  "length": "VAR_PROTO",
+				  "prefix": "AA=="
+				},
+				"inner_spec": {
+				  "child_order": [
+					0,
+					1
+				  ],
+				  "child_size": 32,
+				  "min_prefix_length": 1,
+				  "max_prefix_length": 1,
+				  "empty_child": null,
+				  "hash": "SHA256"
+				},
+				"max_depth": 0,
+				"min_depth": 0,
+				"prehash_key_before_comparison": false
+			  }
+			],
+			"upgrade_path": [
+			  "upgrade",
+			  "upgradedIBCState"
+			],
+			"allow_update_after_expiry": false,
+			"allow_update_after_misbehaviour": false
+		  },
+		  "consensus_state": {
+			"timestamp": "2023-12-15T09:57:02.687079137Z",
+			"root": {
+			  "hash": "EH9YbrWC3Qojy8ycl5GhOdVEC1ifPIGUUItL70bTkHo="
+			},
+			"next_validators_hash": "632730A03DEF630F77B61DF4092629007AE020B789713158FABCB104962FA54F"
+		  },
+		  "initial_val_set": [
+			{
+			  "pub_key": {
+				"ed25519": "RrclQz9bIhkIy/gfL485g3PYMeiIku4qeo495787X10="
+			  },
+			  "power": "500"
+			},
+			{
+			  "pub_key": {
+				"ed25519": "Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is="
+			  },
+			  "power": "500"
+			},
+			{
+			  "pub_key": {
+				"ed25519": "mAN6RXYxSM4MNGSIriYiS7pHuwAcOHDQAy9/wnlSzOI="
+			  },
+			  "power": "500"
+			}
+		  ]
+		},
+		"new_chain": true
+	  }
+	`,
+}
+
+// creates ccv consumer genesis data content for a given version
+// as it was exported from a provider
+func createConsumerDataGenesisFile(t *testing.T, version string) string {
+	filePath := filepath.Join(t.TempDir(), fmt.Sprintf("ConsumerGenesis_%s.json", version))
+	err := os.WriteFile(
+		filePath,
+		[]byte(consumerGenesisStates[version]),
+		fs.FileMode(0o644))
+	require.NoError(t, err, "Error creating source genesis data for version %s", version)
+	return filePath
 }
 
 func getClientCtx() client.Context {
@@ -160,7 +413,8 @@ func getClientCtx() client.Context {
 		WithAccountRetriever(types.AccountRetriever{})
 }
 
-// Setup client context
+// getGenesisTransformCmd sets up client context and returns
+// genesis transformation command (UUT)
 func getGenesisTransformCmd() (*cobra.Command, error) {
 	cmd := app.GetConsumerGenesisTransformCmd()
 	clientCtx := getClientCtx()
@@ -170,52 +424,247 @@ func getGenesisTransformCmd() (*cobra.Command, error) {
 	return cmd, err
 }
 
+// transformConsumerGenesis transform json content in a given file and return
+// the consumer genesis transformation result or an error
+// - filePath    file with consumer genesis content in json format
+// - version     ICS version to which the data should be transformed to
+func transformConsumerGenesis(filePath string, version *string) ([]byte, error) {
+	cmd, err := getGenesisTransformCmd()
+	if err != nil {
+		return nil, fmt.Errorf("Error setting up transformation command: %s", err)
+	}
+
+	args := []string{}
+	if version != nil {
+		args = append(args, fmt.Sprintf("--to=%s", *version))
+	}
+	args = append(args, filePath)
+
+	cmd.SetArgs(args)
+
+	result := new(bytes.Buffer)
+	cmd.SetOutput(result)
+	_, err = cmd.ExecuteC()
+	if err != nil {
+		return nil, fmt.Errorf("Error runnning transformation command: %v", err)
+	}
+	return result.Bytes(), nil
+}
+
 // Check transformation of a version 2 ConsumerGenesis export to
 // consumer genesis json format used by current consumer implementation.
-func TestConsumerGenesisTransformationV2(t *testing.T) {
-	version := "v2"
-	filePath := filepath.Join(t.TempDir(), "oldConsumerGenesis.json")
+func TestConsumerGenesisTransformationFromV2ToCurrent(t *testing.T) {
+	version := "v2.x"
+	ctx := getClientCtx()
 
-	err := os.WriteFile(
-		filePath,
-		[]byte(consumerGenesisStates[version]),
-		fs.FileMode(0o644))
-	require.NoError(t, err)
-	defer os.Remove(filePath)
-
-	cmd, err := getGenesisTransformCmd()
-	require.NoError(t, err, "Error setting up transformation command: %s", err)
-	cmd.SetArgs([]string{filePath})
-
-	output := new(bytes.Buffer)
-	cmd.SetOutput(output)
-	require.NoError(t, err)
-	_, err = cmd.ExecuteC()
-	require.NoError(t, err)
-
-	var oldConsumerGenesis map[string]interface{}
-	err = json.Unmarshal([]byte(consumerGenesisStates[version]), &oldConsumerGenesis)
+	srcGenesis := consumerTypes.GenesisState{}
+	err := ctx.Codec.UnmarshalJSON([]byte(consumerGenesisStates[version]), &srcGenesis)
 	require.NoError(t, err, "Error parsing old version of ccv genesis content for consumer")
 
-	consumerGenesis := consumerTypes.GenesisState{}
-
-	bz := output.Bytes()
-	ctx := client.GetClientContextFromCmd(cmd)
-	err = ctx.Codec.UnmarshalJSON(bz, &consumerGenesis)
-	require.NoError(t, err, "Error unmarshalling transformed genesis state :%s", err)
+	filePath := createConsumerDataGenesisFile(t, version)
+	defer os.Remove(filePath)
+	resultGenesis := consumerTypes.GenesisState{}
+	result, err := transformConsumerGenesis(filePath, nil)
+	require.NoError(t, err)
+	err = ctx.Codec.UnmarshalJSON(result, &resultGenesis)
+	require.NoError(t, err)
 
 	// Some basic sanity checks on the content.
-	require.Nil(t, consumerGenesis.ProviderClientState)
-	require.NotNil(t, consumerGenesis.Provider.ClientState)
-	require.Equal(t, "cosmoshub-4", consumerGenesis.Provider.ClientState.ChainId)
+	require.NotNil(t, resultGenesis.Provider.ClientState)
+	require.Equal(t, "cosmoshub-4", resultGenesis.Provider.ClientState.ChainId)
 
-	require.Nil(t, consumerGenesis.ProviderConsensusState)
-	require.NotNil(t, consumerGenesis.Provider.ConsensusState)
-	require.Equal(t, time.Date(2023, time.May, 8, 11, 0, 1, 563901871, time.UTC),
-		consumerGenesis.Provider.ConsensusState.Timestamp)
+	require.Empty(t, resultGenesis.InitialValSet)
+	require.NotEmpty(t, resultGenesis.Provider.InitialValSet)
+	require.Equal(t, resultGenesis.Params.RetryDelayPeriod, ccvtypes.DefaultRetryDelayPeriod)
 
-	require.Empty(t, consumerGenesis.InitialValSet)
-	require.NotEmpty(t, consumerGenesis.Provider.InitialValSet)
-	require.Equal(t, consumerGenesis.Params.RetryDelayPeriod, ccvtypes.DefaultRetryDelayPeriod)
-	require.Equal(t, consumerGenesis.NewChain, oldConsumerGenesis["new_chain"])
+	// Check params: retry_delay_period prevents direct comparison
+	require.EqualValues(t, srcGenesis.Params.Enabled, resultGenesis.Params.Enabled)
+	require.EqualValues(t, srcGenesis.Params.BlocksPerDistributionTransmission, resultGenesis.Params.BlocksPerDistributionTransmission)
+	require.EqualValues(t, srcGenesis.Params.DistributionTransmissionChannel, resultGenesis.Params.DistributionTransmissionChannel)
+	require.EqualValues(t, srcGenesis.Params.ProviderFeePoolAddrStr, resultGenesis.Params.ProviderFeePoolAddrStr)
+	require.EqualValues(t, srcGenesis.Params.CcvTimeoutPeriod, resultGenesis.Params.CcvTimeoutPeriod)
+	require.EqualValues(t, srcGenesis.Params.TransferTimeoutPeriod, resultGenesis.Params.TransferTimeoutPeriod)
+	require.EqualValues(t, srcGenesis.Params.ConsumerRedistributionFraction, resultGenesis.Params.ConsumerRedistributionFraction)
+	require.EqualValues(t, srcGenesis.Params.HistoricalEntries, resultGenesis.Params.HistoricalEntries)
+	require.EqualValues(t, srcGenesis.Params.UnbondingPeriod, resultGenesis.Params.UnbondingPeriod)
+	require.EqualValues(t, srcGenesis.Params.SoftOptOutThreshold, resultGenesis.Params.SoftOptOutThreshold)
+	require.EqualValues(t, srcGenesis.Params.RewardDenoms, resultGenesis.Params.RewardDenoms)
+	require.EqualValues(t, srcGenesis.Params.ProviderRewardDenoms, resultGenesis.Params.ProviderRewardDenoms)
+
+	require.Equal(t, srcGenesis.ProviderClientState, resultGenesis.Provider.ClientState)
+	require.Nil(t, resultGenesis.ProviderClientState)
+
+	require.Equal(t, srcGenesis.Provider.ConsensusState, resultGenesis.ProviderConsensusState)
+	require.Nil(t, resultGenesis.ProviderConsensusState)
+
+	require.Equal(t, srcGenesis.NewChain, resultGenesis.NewChain)
+	require.Equal(t, "", resultGenesis.ProviderClientId)
+	require.Equal(t, "", resultGenesis.ProviderChannelId)
+	require.Equal(t, srcGenesis.InitialValSet, resultGenesis.Provider.InitialValSet)
+	require.Empty(t, resultGenesis.InitialValSet)
+
+}
+
+// Check transformation of provider v3.3.x implementation to consumer V2
+func TestConsumerGenesisTransformationV330ToV2(t *testing.T) {
+	version := "v3.3.x"
+	filePath := createConsumerDataGenesisFile(t, version)
+	defer os.Remove(filePath)
+
+	var srcGenesis consumerTypes.GenesisState
+	ctx := getClientCtx()
+	err := ctx.Codec.UnmarshalJSON([]byte(consumerGenesisStates[version]), &srcGenesis)
+	require.NoError(t, err)
+
+	targetVersion := "v2.x"
+	result, err := transformConsumerGenesis(filePath, &targetVersion)
+	require.NoError(t, err)
+
+	resultGenesis := consumerTypes.GenesisState{}
+	err = ctx.Codec.UnmarshalJSON(result, &resultGenesis)
+	require.NoError(t, err)
+
+	require.Equal(t, srcGenesis.Params, resultGenesis.Params)
+	require.Equal(t, srcGenesis.Provider.ClientState, resultGenesis.ProviderClientState)
+	require.Equal(t, srcGenesis.Provider.ConsensusState, resultGenesis.ProviderConsensusState)
+	require.Equal(t, srcGenesis.NewChain, resultGenesis.NewChain)
+	require.Equal(t, "", resultGenesis.ProviderClientId)
+	require.Equal(t, "", resultGenesis.ProviderChannelId)
+
+}
+
+// Check transformation of provider v3.3.x implementation to current consumer version
+func TestConsumerGenesisTransformationV330ToCurrent(t *testing.T) {
+	version := "v3.3.x"
+	filePath := createConsumerDataGenesisFile(t, version)
+	defer os.Remove(filePath)
+
+	var srcGenesis consumerTypes.GenesisState
+	ctx := getClientCtx()
+	err := ctx.Codec.UnmarshalJSON([]byte(consumerGenesisStates[version]), &srcGenesis)
+	require.NoError(t, err)
+
+	result, err := transformConsumerGenesis(filePath, nil)
+	require.NoError(t, err)
+
+	resultGenesis := consumerTypes.GenesisState{}
+	err = ctx.Codec.UnmarshalJSON(result, &resultGenesis)
+	require.NoError(t, err)
+
+	require.Equal(t, srcGenesis.Params.Enabled, resultGenesis.Params.Enabled)
+	require.Equal(t, srcGenesis.Params.BlocksPerDistributionTransmission, resultGenesis.Params.BlocksPerDistributionTransmission)
+	require.Equal(t, srcGenesis.Params.DistributionTransmissionChannel, resultGenesis.Params.DistributionTransmissionChannel)
+	require.Equal(t, srcGenesis.Params.ProviderFeePoolAddrStr, resultGenesis.Params.ProviderFeePoolAddrStr)
+	require.Equal(t, srcGenesis.Params.CcvTimeoutPeriod, resultGenesis.Params.CcvTimeoutPeriod)
+	require.Equal(t, srcGenesis.Params.TransferTimeoutPeriod, resultGenesis.Params.TransferTimeoutPeriod)
+	require.Equal(t, srcGenesis.Params.ConsumerRedistributionFraction, resultGenesis.Params.ConsumerRedistributionFraction)
+	require.Equal(t, srcGenesis.Params.HistoricalEntries, resultGenesis.Params.HistoricalEntries)
+	require.Equal(t, srcGenesis.Params.UnbondingPeriod, resultGenesis.Params.UnbondingPeriod)
+	require.Equal(t, srcGenesis.Params.SoftOptOutThreshold, resultGenesis.Params.SoftOptOutThreshold)
+	require.Equal(t, srcGenesis.Params.RewardDenoms, resultGenesis.Params.RewardDenoms)
+	require.Equal(t, srcGenesis.Params.ProviderRewardDenoms, resultGenesis.Params.ProviderRewardDenoms)
+
+	require.Equal(t, resultGenesis.Params.RetryDelayPeriod, ccvtypes.DefaultRetryDelayPeriod)
+
+	require.Equal(t, srcGenesis.Provider.ClientState, resultGenesis.Provider.ClientState)
+	require.Nil(t, resultGenesis.ProviderClientState)
+	require.Nil(t, resultGenesis.ProviderConsensusState)
+
+	require.Equal(t, srcGenesis.Provider.ConsensusState, resultGenesis.Provider.ConsensusState)
+	require.Equal(t, srcGenesis.NewChain, resultGenesis.NewChain)
+	require.Equal(t, "", resultGenesis.ProviderClientId)
+	require.Equal(t, "", resultGenesis.ProviderChannelId)
+}
+
+// Check transformation of provider v4.x implementation to consumer V2
+func TestConsumerGenesisTransformationV4ToV2(t *testing.T) {
+	version := "v4.x"
+	filePath := createConsumerDataGenesisFile(t, version)
+	defer os.Remove(filePath)
+
+	var srcGenesis consumerTypes.GenesisState
+	ctx := getClientCtx()
+	err := ctx.Codec.UnmarshalJSON([]byte(consumerGenesisStates[version]), &srcGenesis)
+	require.NoError(t, err)
+
+	targetVersion := "v2.x"
+	result, err := transformConsumerGenesis(filePath, &targetVersion)
+	require.NoError(t, err)
+
+	resultGenesis := consumerTypes.GenesisState{}
+	err = ctx.Codec.UnmarshalJSON(result, &resultGenesis)
+	require.NoError(t, err)
+
+	// Check params: retry_delay_period prevents direct comparison
+	require.EqualValues(t, srcGenesis.Params.Enabled, resultGenesis.Params.Enabled)
+	require.EqualValues(t, srcGenesis.Params.BlocksPerDistributionTransmission, resultGenesis.Params.BlocksPerDistributionTransmission)
+	require.EqualValues(t, srcGenesis.Params.DistributionTransmissionChannel, resultGenesis.Params.DistributionTransmissionChannel)
+	require.EqualValues(t, srcGenesis.Params.ProviderFeePoolAddrStr, resultGenesis.Params.ProviderFeePoolAddrStr)
+	require.EqualValues(t, srcGenesis.Params.CcvTimeoutPeriod, resultGenesis.Params.CcvTimeoutPeriod)
+	require.EqualValues(t, srcGenesis.Params.TransferTimeoutPeriod, resultGenesis.Params.TransferTimeoutPeriod)
+	require.EqualValues(t, srcGenesis.Params.ConsumerRedistributionFraction, resultGenesis.Params.ConsumerRedistributionFraction)
+	require.EqualValues(t, srcGenesis.Params.HistoricalEntries, resultGenesis.Params.HistoricalEntries)
+	require.EqualValues(t, srcGenesis.Params.UnbondingPeriod, resultGenesis.Params.UnbondingPeriod)
+	require.EqualValues(t, srcGenesis.Params.SoftOptOutThreshold, resultGenesis.Params.SoftOptOutThreshold)
+	require.EqualValues(t, srcGenesis.Params.RewardDenoms, resultGenesis.Params.RewardDenoms)
+	require.EqualValues(t, srcGenesis.Params.ProviderRewardDenoms, resultGenesis.Params.ProviderRewardDenoms)
+	require.Equal(t, resultGenesis.Params.RetryDelayPeriod, time.Duration(0))
+
+	require.Equal(t, srcGenesis.Provider.ClientState, resultGenesis.ProviderClientState)
+	require.Nil(t, resultGenesis.Provider.ClientState)
+	require.Equal(t, srcGenesis.Provider.ConsensusState, resultGenesis.ProviderConsensusState)
+	require.Nil(t, resultGenesis.Provider.ConsensusState)
+	require.Equal(t, "", resultGenesis.ProviderClientId)
+	require.Equal(t, "", resultGenesis.ProviderChannelId)
+
+	require.Equal(t, 0, len(resultGenesis.Provider.InitialValSet))
+	require.Equal(t, srcGenesis.Provider.InitialValSet, resultGenesis.InitialValSet)
+	require.Empty(t, resultGenesis.Provider.InitialValSet)
+
+	require.Equal(t, srcGenesis.NewChain, resultGenesis.NewChain)
+}
+
+// Check transformation of provider v3.3.x implementation to consumer V2
+func TestConsumerGenesisTransformationV4ToV33(t *testing.T) {
+	version := "v4.x"
+	filePath := createConsumerDataGenesisFile(t, version)
+	defer os.Remove(filePath)
+
+	var srcGenesis ccvtypes.ConsumerGenesisState
+	ctx := getClientCtx()
+	err := ctx.Codec.UnmarshalJSON([]byte(consumerGenesisStates[version]), &srcGenesis)
+	require.NoError(t, err)
+
+	targetVersion := "v3.3.x"
+	result, err := transformConsumerGenesis(filePath, &targetVersion)
+	require.NoError(t, err)
+	resultGenesis := consumerTypes.GenesisState{} //Only difference to v33 is no RetryDelayPeriod
+	err = ctx.Codec.UnmarshalJSON(result, &resultGenesis)
+	require.NoError(t, err)
+
+	// Check params: retry_delay_period prevents direct comparison
+	require.EqualValues(t, srcGenesis.Params.Enabled, resultGenesis.Params.Enabled)
+	require.EqualValues(t, srcGenesis.Params.BlocksPerDistributionTransmission, resultGenesis.Params.BlocksPerDistributionTransmission)
+	require.EqualValues(t, srcGenesis.Params.DistributionTransmissionChannel, resultGenesis.Params.DistributionTransmissionChannel)
+	require.EqualValues(t, srcGenesis.Params.ProviderFeePoolAddrStr, resultGenesis.Params.ProviderFeePoolAddrStr)
+	require.EqualValues(t, srcGenesis.Params.CcvTimeoutPeriod, resultGenesis.Params.CcvTimeoutPeriod)
+	require.EqualValues(t, srcGenesis.Params.TransferTimeoutPeriod, resultGenesis.Params.TransferTimeoutPeriod)
+	require.EqualValues(t, srcGenesis.Params.ConsumerRedistributionFraction, resultGenesis.Params.ConsumerRedistributionFraction)
+	require.EqualValues(t, srcGenesis.Params.HistoricalEntries, resultGenesis.Params.HistoricalEntries)
+	require.EqualValues(t, srcGenesis.Params.UnbondingPeriod, resultGenesis.Params.UnbondingPeriod)
+	require.EqualValues(t, srcGenesis.Params.SoftOptOutThreshold, resultGenesis.Params.SoftOptOutThreshold)
+	require.EqualValues(t, srcGenesis.Params.RewardDenoms, resultGenesis.Params.RewardDenoms)
+	require.EqualValues(t, srcGenesis.Params.ProviderRewardDenoms, resultGenesis.Params.ProviderRewardDenoms)
+
+	require.Equal(t, srcGenesis.Provider.ClientState, resultGenesis.Provider.ClientState)
+	require.Nil(t, resultGenesis.ProviderClientState)
+
+	require.Equal(t, srcGenesis.Provider.ConsensusState, resultGenesis.Provider.ConsensusState)
+	require.Nil(t, resultGenesis.ProviderConsensusState)
+
+	require.Equal(t, srcGenesis.NewChain, resultGenesis.NewChain)
+	require.Equal(t, "", resultGenesis.ProviderClientId)
+	require.Equal(t, "", resultGenesis.ProviderChannelId)
+	require.Equal(t, srcGenesis.Provider.InitialValSet, resultGenesis.Provider.InitialValSet)
+	require.Empty(t, resultGenesis.InitialValSet)
 }

--- a/docs/docs/consumer-development/consumer-genesis-transformation.md
+++ b/docs/docs/consumer-development/consumer-genesis-transformation.md
@@ -5,25 +5,36 @@ sidebar_position: 6
 # Consumer Genesis Transformation
 
 Preparing a consumer chain for onboarding requires some information explaining how to run your chain. This includes a genesis file with CCV data where the CCV data is exported from the provider chain and added to the consumers genesis file (for more details check the documentation on [Onboarding](./onboarding.md) and [Changeover](./changeover-procedure.md)).
-In case that the provider chain is running an older version of the InterChainSecurity (ICS) module than the consumer chain the exported CCV data might need to be transformed to the format supported by the ICS implementation run on the consumer chain. This is the case if the consumer chain runs version 4 of ICS or later and the provider is running version 3 or older of the ICS module.
+In case that the provider chain is running an older version of the InterChainSecurity (ICS) module than the consumer chain - or vice versa - the exported CCV data might need to be transformed to the format supported by the ICS implementation run on the consumer chain. This is the case if the consumer chain runs version 4 of ICS or later and the provider is running version 3 or older of the ICS module.
+
+Check the [compatibility notes](../../../RELEASES.md#backwards-compatibility) for known incompatibilities between provider and consumer versions and indications if a consumer genesis transformation is required.
 
 To transform such CCV data follow the instructions below
 
 ## 1. Prerequisite
-- Provider chain is running version 3 or older of the ICS provider module
-- Consumer is running version 4 or later of the ICS consumer module.
-- interchain-security-cd application complies to the version run on the consumer chain
+- used provider and consumer versions require transformation step as indicated in in the [compatibility notes](../../../RELEASES.md#backwards-compatibility)
+- interchain-security-cd application supports the versions used by the consumer and provider
 
 ## 2. Export the CCV data
-Export the CCV data from the provider chain as described in the [Onboarding](./onboarding.md) and [Changeover](./changeover-procedure.md)) your following.
+Export the CCV data from the provider chain as described in the [Onboarding](./onboarding.md) and [Changeover](./changeover-procedure.md) your following.
 As a result the CCV data will be stored in a file in JSON format.
 
 ## 3. Transform CCV data
-To transform the CCV data to the newer format run the following command.
-```
-interchain-security-cd genesis transform [genesis-file]
-```
-where 'genesis-file' is the path to the file containing the CCV data exported in [step 2](#2-export-the-ccv-data).
-As a result the CCV data in the new format will be written to standard output.
+To transform the CCV data
+- to the format supported by the current version of the consumer run the following command:
+    ```
+    interchain-security-cd genesis transform [genesis-file]
+    ```
+    where 'genesis-file' is the path to the file containing the CCV data exported in [step 2](#2-export-the-ccv-data).
+    As a result the CCV data in the new format will be written to standard output.
+- a specific target version of a consumer run the following command:
+    ```
+    interchain-security-cd genesis transform --to <target_version> [genesis-file]
+
+    ```
+    where `<target_version` is the ICS version the consumer chain is running.
+    Use `interchain-security-cd genesis transform --help` to get more details about supported target versions and more.
+
 
 Use the new CCV data as described in the procedure you're following.
+

--- a/docs/docs/validators/changeover-procedure.md
+++ b/docs/docs/validators/changeover-procedure.md
@@ -27,6 +27,10 @@ gaiad q provider consumer-genesis stride-1 -o json > ccv-state.json
 jq -s '.[0].app_state.ccvconsumer = .[1] | .[0]' genesis.json ccv-state.json > ccv.json
 ```
 
+Transformation of the exported consumer genesis state to the target version of the consumer might be needed in case the provider and consumer formats are incompatible.
+Refer to the compatibility notes [here](../../../RELEASES.md#backwards-compatibility) to check if data transformation is needed for your case.
+Instructions on how to transform the exported CCV genesis state (`ccv-state.json` in the example above) to the required target version can be found [here](../consumer-development/consumer-genesis-transformation.md)
+
 ### 2. `SoftwareUpgradeProposal` on the standalone/consumer chain
 
 This upgrade proposal will introduce ICS to the standalone chain, making it a consumer.
@@ -37,7 +41,7 @@ After `spawn_time`, make sure to assign a consumer key if you intend to use one.
 
 Instructions are available [here](../features/key-assignment.md)
 
-### 4. Perform the software ugprade on standalone chain
+### 4. Perform the software upgrade on standalone chain
 
 Please use instructions provided by the standalone chain team and make sure to reach out if you are facing issues.
 The upgrade preparation depends on your setup, so please make sure you prepare ahead of time.


### PR DESCRIPTION
## Description

Closes: #1512

Changes will allow to transform exported consumer genesis data from version v2.x, v3.x, v4.x to a specified target version 
v2.x, v3.x, v4.x . With that newer version of provider chain exports can be transformed for older consumer chains e.g. 2.x


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
