### PR TITLE
chore: fix dockerfile FROM statement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,6 +193,7 @@ jobs:
             **/Makefile
             Makefile
             Dockerfile
+            Dockerfile.gaia
       - name: e2e tests
         if: env.GIT_DIFF
         run: |
@@ -224,6 +225,7 @@ jobs:
             **/Makefile
             Makefile
             Dockerfile
+            Dockerfile.gaia
       - name: cometmock tests
         if: env.GIT_DIFF
         run: |
@@ -255,6 +257,7 @@ jobs:
             **/Makefile
             Makefile
             Dockerfile
+            Dockerfile.gaia
       - name: trace-e2e tests
         if: env.GIT_DIFF
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,6 +192,7 @@ jobs:
             **/go.sum
             **/Makefile
             Makefile
+            Dockerfile
       - name: e2e tests
         if: env.GIT_DIFF
         run: |
@@ -222,6 +223,7 @@ jobs:
             **/go.sum
             **/Makefile
             Makefile
+            Dockerfile
       - name: cometmock tests
         if: env.GIT_DIFF
         run: |
@@ -252,6 +254,7 @@ jobs:
             **/go.sum
             **/Makefile
             Makefile
+            Dockerfile
       - name: trace-e2e tests
         if: env.GIT_DIFF
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,8 +192,7 @@ jobs:
             **/go.sum
             **/Makefile
             Makefile
-            Dockerfile
-            Dockerfile.gaia
+            Dockerfile*
       - name: e2e tests
         if: env.GIT_DIFF
         run: |
@@ -224,8 +223,7 @@ jobs:
             **/go.sum
             **/Makefile
             Makefile
-            Dockerfile
-            Dockerfile.gaia
+            Dockerfile*
       - name: cometmock tests
         if: env.GIT_DIFF
         run: |
@@ -256,8 +254,7 @@ jobs:
             **/go.sum
             **/Makefile
             Makefile
-            Dockerfile
-            Dockerfile.gaia
+            Dockerfile*
       - name: trace-e2e tests
         if: env.GIT_DIFF
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN go mod tidy
 RUN make install
 
 # Get Hermes build
-FROM otacrew/hermes-ics:evidence-cmd AS hermes-builder
+FROM --platform=linux/amd64 otacrew/hermes-ics:evidence-cmd AS hermes-builder
 
 # Get CometMock
 FROM ghcr.io/informalsystems/cometmock:v0.37.x as cometmock-builder

--- a/Dockerfile.gaia
+++ b/Dockerfile.gaia
@@ -61,7 +61,7 @@ WORKDIR /interchain-security
 RUN make install
 
 # Get Hermes build
-FROM ghcr.io/informalsystems/hermes:1.4.1 AS hermes-builder
+FROM --platform=linux/amd64 ghcr.io/informalsystems/hermes:1.4.1 AS hermes-builder
 
 FROM --platform=linux/amd64 fedora:36
 RUN dnf update -y


### PR DESCRIPTION
**Problem**
Trying to run the e2e tests locally would give:
```
OCI runtime exec failed: exec failed: unable to start container process: exec /usr/local/bin/hermes: no such file or directory: unknown
exit status 1
make: *** [test-e2e-short] Error 1
```

**Solution**
Fixed by adding `--platform=linux/amd64` in the relevant `FROM` statement.
Also, added the `Dockerfile` in the test GitHub actions because a change there might lead to the tests failing.

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
