### PR TITLE
ci: GH workflow for publishing docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,103 @@
+name: DockerPublish
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  release:
+    types: [published]
+  push:
+    branches: [ "main", "release/v4.0.x", "release/v3.3.x", "release/v3.2.x", "release/v3.1.x", "release/v3.0.x"]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*', 'v*.*.*-lsm' ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@6e04d228eb30da1757ee4e1dd75a0ec73a653e06 #v3.1.1
+        with:
+          cosign-release: 'v2.1.1'
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta # reference for later steps
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{github.ref == 'refs/heads/main'}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern={{version}},value=${{ inputs.tags }},enable=${{ inputs.tags != '' }}
+          flavor: |
+            latest=false
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          file: ./Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,8 @@ on:
     branches: [ "main", "release/v4.0.x", "release/v3.3.x", "release/v3.2.x", "release/v3.1.x", "release/v3.0.x"]
     # Publish semver tags as releases.
     tags: [ 'v*.*.*', 'v*.*.*-lsm' ]
+  pull_request:
+    branches: [ "main", "release/v4.0.x", "release/v3.3.x", "release/v3.2.x", "release/v3.1.x", "release/v3.0.x"]
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -67,7 +69,7 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{github.ref == 'refs/heads/main'}}
             type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern={{version}},value=${{ inputs.tags }},enable=${{ inputs.tags != '' }}
+            type=semver,pattern=v{{version}},value=${{ inputs.tags }},enable=${{ inputs.tags != '' }}
           flavor: |
             latest=false
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,9 @@
-name: DockerPublish
+name: Docker Publish
 
+# Build and publish docker images of ICS on ghcr.io/cosmos/interchain-security
+#
+# Note: publishing will only be done outside pull-requests
+#
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support
@@ -34,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
@@ -44,16 +48,18 @@ jobs:
         with:
           cosign-release: 'v2.1.1'
 
-      # Workaround: https://github.com/docker/build-push-action/issues/461
-      - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
 
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -63,7 +69,7 @@ jobs:
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta # reference for later steps
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -77,7 +83,7 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 #v5.0.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -76,6 +76,7 @@ jobs:
             type=raw,value=latest,enable=${{github.ref == 'refs/heads/main'}}
             type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{version}},value=${{ inputs.tags }},enable=${{ inputs.tags != '' }}
+            type=match,pattern=v\d+.\d+.\d+-lsm,group=0
           flavor: |
             latest=false
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,14 +10,12 @@ name: Docker Publish
 # documentation.
 
 on:
-  release:
-    types: [published]
   push:
-    branches: [ "main", "release/v4.0.x", "release/v3.3.x", "release/v3.2.x", "release/v3.1.x", "release/v3.0.x"]
-    # Publish semver tags as releases.
-    tags: [ 'v*.*.*', 'v*.*.*-lsm' ]
-  pull_request:
-    branches: [ "main", "release/v4.0.x", "release/v3.3.x", "release/v3.2.x", "release/v3.1.x", "release/v3.0.x"]
+    branches:
+      - main
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+" # Push events matching tag versions as v3.0.0
+      - "v[0-9]+.[0-9]+.[0-9]+-lsm" # Push events matching '-lsm' postfix tags
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -74,12 +72,10 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=raw,value=latest,enable=${{github.ref == 'refs/heads/main'}}
-            type=semver,pattern=v{{major}}.{{minor}}
             type=semver,pattern=v{{version}},value=${{ inputs.tags }},enable=${{ inputs.tags != '' }}
-            type=match,pattern=v\d+.\d+.\d+-lsm,group=0
+            type=match,pattern=v\d+.\d+.\d+(-lsm)?,group=0
           flavor: |
             latest=false
-
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image


### PR DESCRIPTION
## Description

Closes: #1592 
GH workflow to publish ICS docker images

Workflow is triggerd to build
- `interchain-security:latest` image when a commit is pushed to 'main' branch
- `interchain-security:vX.Y.Z` when a tag with pattern vX.Y.Z is pushed 
- `interchain-security:vX.Y.Z-lsm` when a tag with pattern vX.Y.Z-lsm is pushed 

for all other commits/tags no docker image workflow  will be triggered

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
