### PR TITLE
docs: tiny ADR fix 

### DIFF
--- a/docs/docs/adrs/adr-015-partial-set-security.md
+++ b/docs/docs/adrs/adr-015-partial-set-security.md
@@ -56,18 +56,18 @@ In a future version of PSS, we intend to introduce a `ConsumerModificationPropos
 We augment the provider module’s state to keep track of the `top_N` value for each consumer chain. The key to store this information would be:
 
 ```
-topNFractionBytePrefix | len(chainID) | chainID
+topNBytePrefix | len(chainID) | chainID
 ```
 To create the above key, we can use [`ChainIdWithLenKey`](https://github.com/cosmos/interchain-security/blob/v4.0.0/x/ccv/provider/types/keys.go#L418).
 
 Then in the [keeper](https://github.com/cosmos/interchain-security/blob/v4.0.0/x/ccv/provider/keeper/keeper.go) we introduce methods as follows:
 ```golang
-func (k Keeper) SetTopNFraction(ctx sdk.Context, chainID string, topNFraction string)
+func (k Keeper) SetTopN(ctx sdk.Context, chainID string, topN uint32)
 func (k Keeper) IsTopN(ctx sdk.Context, chainID string) bool
 func (k Keeper) IsOptIn(ctx sdk.Context, chainID string) bool
 
 // returns the N if Top N chain, otherwise an error
-func (k Keeper) GetTopNFraction(ctx sdk.Context, chainID string) (Dec, error)
+func (k Keeper) GetTopN(ctx sdk.Context, chainID string) (uint32, error)
 ```
 
 We also extend the `interchain-security-pd query provider list-consumer-chains` query to return information on whether a consumer chain is an Opt In or a Top N chain and with what N.


### PR DESCRIPTION
## Description

Remove the word "fraction" from the ADR because `top_N` is a `uint32` and hence corresponds directly to a percentage.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct `docs:` prefix in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)
- [ ] Checked that the documentation website can be built and deployed successfully (run `make build-docs`)

