### PR TITLE
feat!: automatically opt in validators that vote Yes on consumer addition proposals

### DIFF
--- a/testutil/keeper/mocks.go
+++ b/testutil/keeper/mocks.go
@@ -473,18 +473,6 @@ func (mr *MockSlashingKeeperMockRecorder) GetValidatorSigningInfo(ctx, address i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValidatorSigningInfo", reflect.TypeOf((*MockSlashingKeeper)(nil).GetValidatorSigningInfo), ctx, address)
 }
 
-// SetValidatorSigningInfo mocks base method.
-func (m *MockSlashingKeeper) SetValidatorSigningInfo(ctx types0.Context, address types0.ConsAddress, info types3.ValidatorSigningInfo) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetValidatorSigningInfo", ctx, address, info)
-}
-
-// SetValidatorSigningInfo indicates an expected call of SetValidatorSigningInfo.
-func (mr *MockSlashingKeeperMockRecorder) SetValidatorSigningInfo(ctx, address interface{}, info interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetValidatorSigningInfo", reflect.TypeOf((*MockSlashingKeeper)(nil).SetValidatorSigningInfo), ctx, address, info)
-}
-
 // IsTombstoned mocks base method.
 func (m *MockSlashingKeeper) IsTombstoned(arg0 types0.Context, arg1 types0.ConsAddress) bool {
 	m.ctrl.T.Helper()
@@ -509,6 +497,18 @@ func (m *MockSlashingKeeper) JailUntil(arg0 types0.Context, arg1 types0.ConsAddr
 func (mr *MockSlashingKeeperMockRecorder) JailUntil(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JailUntil", reflect.TypeOf((*MockSlashingKeeper)(nil).JailUntil), arg0, arg1, arg2)
+}
+
+// SetValidatorSigningInfo mocks base method.
+func (m *MockSlashingKeeper) SetValidatorSigningInfo(ctx types0.Context, address types0.ConsAddress, info types3.ValidatorSigningInfo) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetValidatorSigningInfo", ctx, address, info)
+}
+
+// SetValidatorSigningInfo indicates an expected call of SetValidatorSigningInfo.
+func (mr *MockSlashingKeeperMockRecorder) SetValidatorSigningInfo(ctx, address, info interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetValidatorSigningInfo", reflect.TypeOf((*MockSlashingKeeper)(nil).SetValidatorSigningInfo), ctx, address, info)
 }
 
 // SlashFractionDoubleSign mocks base method.
@@ -1216,4 +1216,33 @@ func (m *MockGovKeeper) GetProposal(ctx types0.Context, proposalID uint64) (v1.P
 func (mr *MockGovKeeperMockRecorder) GetProposal(ctx, proposalID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProposal", reflect.TypeOf((*MockGovKeeper)(nil).GetProposal), ctx, proposalID)
+}
+
+// GetProposals mocks base method.
+func (m *MockGovKeeper) GetProposals(ctx types0.Context) v1.Proposals {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProposals", ctx)
+	ret0, _ := ret[0].(v1.Proposals)
+	return ret0
+}
+
+// GetProposals indicates an expected call of GetProposals.
+func (mr *MockGovKeeperMockRecorder) GetProposals(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProposals", reflect.TypeOf((*MockGovKeeper)(nil).GetProposals), ctx)
+}
+
+// GetVote mocks base method.
+func (m *MockGovKeeper) GetVote(ctx types0.Context, proposalID uint64, voterAddr types0.AccAddress) (v1.Vote, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVote", ctx, proposalID, voterAddr)
+	ret0, _ := ret[0].(v1.Vote)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetVote indicates an expected call of GetVote.
+func (mr *MockGovKeeperMockRecorder) GetVote(ctx, proposalID, voterAddr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVote", reflect.TypeOf((*MockGovKeeper)(nil).GetVote), ctx, proposalID, voterAddr)
 }

--- a/x/ccv/provider/keeper/hooks.go
+++ b/x/ccv/provider/keeper/hooks.go
@@ -217,6 +217,9 @@ func (h Hooks) AfterProposalVote(ctx sdk.Context, proposalID uint64, voterAddr s
 			return
 		}
 		if !weight.Equal(math.LegacyNewDec(1)) {
+			h.k.Logger(ctx).Error("single vote does not have a weight of 1",
+				"vote", vote,
+			)
 			return
 		}
 

--- a/x/ccv/provider/keeper/hooks.go
+++ b/x/ccv/provider/keeper/hooks.go
@@ -185,6 +185,10 @@ func (h Hooks) AfterProposalVote(ctx sdk.Context, proposalID uint64, voterAddr s
 
 	consAddr, err := validator.GetConsAddr()
 	if err != nil {
+		h.k.Logger(ctx).Error("could not extract validator's consensus address",
+			"error", err.Error(),
+			"validator acc addr", voterAddr,
+		)
 		return
 	}
 
@@ -195,6 +199,10 @@ func (h Hooks) AfterProposalVote(ctx sdk.Context, proposalID uint64, voterAddr s
 
 	vote, found := h.k.govKeeper.GetVote(ctx, proposalID, voterAddr)
 	if !found {
+		h.k.Logger(ctx).Error("could not find vote for validator",
+			"validator acc addr", voterAddr,
+			"proposalID", proposalID,
+		)
 		return
 	}
 
@@ -202,6 +210,10 @@ func (h Hooks) AfterProposalVote(ctx sdk.Context, proposalID uint64, voterAddr s
 		// only consider votes that vote YES with 100% weight
 		weight, err := sdk.NewDecFromStr(vote.Options[0].Weight)
 		if err != nil {
+			h.k.Logger(ctx).Error("could not extract decimal value from vote's weight",
+				"vote", vote,
+				"error", err.Error(),
+			)
 			return
 		}
 		if !weight.Equal(math.LegacyNewDec(1)) {

--- a/x/ccv/provider/keeper/hooks.go
+++ b/x/ccv/provider/keeper/hooks.go
@@ -223,7 +223,7 @@ func (h Hooks) AfterProposalVote(ctx sdk.Context, proposalID uint64, voterAddr s
 			return
 		}
 
-		// in case validator is already to-be-opted in, we just overwrite
+		// in the validator is already to-be-opted in, the `SetToBeOptedIn` is a no-op
 		h.k.SetToBeOptedIn(ctx, chainID, providertypes.NewProviderConsAddress(consAddr))
 	} else {
 		// if vote is not a YES vote with 100% weight, we delete the validator from to-be-opted in

--- a/x/ccv/provider/keeper/hooks.go
+++ b/x/ccv/provider/keeper/hooks.go
@@ -175,6 +175,8 @@ func (h Hooks) AfterProposalVotingPeriodEnded(ctx sdk.Context, proposalID uint64
 func (h Hooks) AfterProposalDeposit(ctx sdk.Context, proposalID uint64, depositorAddr sdk.AccAddress) {
 }
 
+// AfterProposalVote opts in validators that vote YES (with 100% weight) on a `ConsumerAdditionProposal`. If a
+// validator votes multiple times, only the last vote would be considered on whether the validator is opted in or not.
 func (h Hooks) AfterProposalVote(ctx sdk.Context, proposalID uint64, voterAddr sdk.AccAddress) {
 	validator, found := h.k.stakingKeeper.GetValidator(ctx, voterAddr.Bytes())
 	if !found {
@@ -186,7 +188,10 @@ func (h Hooks) AfterProposalVote(ctx sdk.Context, proposalID uint64, voterAddr s
 		return
 	}
 
-	chainID := h.k.GetProposedConsumerChain(ctx, proposalID)
+	chainID, found := h.k.GetProposedConsumerChain(ctx, proposalID)
+	if !found {
+		return
+	}
 
 	vote, found := h.k.govKeeper.GetVote(ctx, proposalID, voterAddr)
 	if !found {

--- a/x/ccv/provider/keeper/hooks_test.go
+++ b/x/ccv/provider/keeper/hooks_test.go
@@ -127,11 +127,13 @@ func TestAfterPropSubmissionAndVotingPeriodEnded(t *testing.T) {
 
 	k.Hooks().AfterProposalSubmission(ctx, prop.Id)
 	// verify that the proposal ID is created
-	require.NotEmpty(t, k.GetProposedConsumerChain(ctx, prop.Id))
+	_, found := k.GetProposedConsumerChain(ctx, prop.Id)
+	require.True(t, found)
 
 	k.Hooks().AfterProposalVotingPeriodEnded(ctx, prop.Id)
 	// verify that the proposal ID is deleted
-	require.Empty(t, k.GetProposedConsumerChain(ctx, prop.Id))
+	_, found = k.GetProposedConsumerChain(ctx, prop.Id)
+	require.False(t, found)
 }
 
 func TestGetConsumerAdditionLegacyPropFromProp(t *testing.T) {

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -186,9 +186,10 @@ func (k Keeper) SetProposedConsumerChain(ctx sdk.Context, chainID string, propos
 }
 
 // GetProposedConsumerChain returns the proposed chainID for the given consumerAddition proposal ID.
-func (k Keeper) GetProposedConsumerChain(ctx sdk.Context, proposalID uint64) string {
+func (k Keeper) GetProposedConsumerChain(ctx sdk.Context, proposalID uint64) (string, bool) {
 	store := ctx.KVStore(k.storeKey)
-	return string(store.Get(types.ProposedConsumerChainKey(proposalID)))
+	consumerChain := store.Get(types.ProposedConsumerChainKey(proposalID))
+	return string(consumerChain), consumerChain != nil
 }
 
 // DeleteProposedConsumerChainInStore deletes the consumer chainID from store

--- a/x/ccv/provider/keeper/keeper_test.go
+++ b/x/ccv/provider/keeper/keeper_test.go
@@ -552,7 +552,7 @@ func TestSetProposedConsumerChains(t *testing.T) {
 
 	for _, test := range tests {
 		providerKeeper.SetProposedConsumerChain(ctx, test.chainID, test.proposalID)
-		cID := providerKeeper.GetProposedConsumerChain(ctx, test.proposalID)
+		cID, _ := providerKeeper.GetProposedConsumerChain(ctx, test.proposalID)
 		require.Equal(t, cID, test.chainID)
 	}
 }
@@ -574,9 +574,9 @@ func TestDeleteProposedConsumerChainInStore(t *testing.T) {
 	for _, test := range tests {
 		providerKeeper.SetProposedConsumerChain(ctx, test.chainID, test.proposalID)
 		providerKeeper.DeleteProposedConsumerChainInStore(ctx, test.deleteProposalID)
-		cID := providerKeeper.GetProposedConsumerChain(ctx, test.proposalID)
+		cID, found := providerKeeper.GetProposedConsumerChain(ctx, test.proposalID)
 		if test.ok {
-			require.Equal(t, cID, "")
+			require.False(t, found)
 		} else {
 			require.Equal(t, cID, test.chainID)
 		}

--- a/x/ccv/types/expected_keepers.go
+++ b/x/ccv/types/expected_keepers.go
@@ -151,4 +151,6 @@ type ScopedKeeper interface {
 
 type GovKeeper interface {
 	GetProposal(ctx sdk.Context, proposalID uint64) (v1.Proposal, bool)
+	GetProposals(ctx sdk.Context) (proposals v1.Proposals)
+	GetVote(ctx sdk.Context, proposalID uint64, voterAddr sdk.AccAddress) (vote v1.Vote, found bool)
 }


### PR DESCRIPTION
## Description

(together with https://github.com/cosmos/interchain-security/pull/1620) closes: #1586

Overwrites the `AfterProposalVote` hook so that we can see whether a validator votes `Yes` on a `ConsumerAdditionProposal`. Validators that vote `Yes` are automatically opted in.

Note that we had to overwrite `AfterProposalVote` because the Tally method [deletes the votes](https://github.com/cosmos/cosmos-sdk/blob/v0.47.7/x/gov/keeper/tally.go#L71) after reading them. This also makes sense; There's no reason to keep the votes around after tallying them. Therefore, we wouldn't be able to extract any information on who voted Yes after a proposal has passed through [GetVotes](https://github.com/cosmos/cosmos-sdk/blob/v0.47.7/x/gov/keeper/vote.go#L59).


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] Added `!` to the type prefix if the change is [state-machine breaking](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes)
* [ ] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
* [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] Provided a link to the relevant issue or specification
* [ ] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/00-intro.md)
* [x] Included the necessary unit and integration [tests](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry to `CHANGELOG.md`
* [x] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [ ] Confirmed all CI checks have passed
* [ ] If this PR is library API breaking, bump the go.mod version string of the repo, and follow through on a new major release

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` the type prefix if the change is state-machine breaking
* [ ] confirmed this PR does not introduce changes requiring state migrations, OR confirmed migration code has been added to consumer and/or provider modules
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
