### PR TITLE
test: Add driver for PSS

### DIFF
--- a/tests/mbt/driver/core.go
+++ b/tests/mbt/driver/core.go
@@ -375,20 +375,12 @@ func (s *Driver) setTime(chain ChainId, newTime time.Time) {
 	testChain.App.BeginBlock(abcitypes.RequestBeginBlock{Header: testChain.CurrentHeader})
 }
 
-<<<<<<< HEAD
-func (s *Driver) AssignKey(chain ChainId, valIndex int64, value crypto.PublicKey) error {
-=======
 func (s *Driver) AssignKey(chain ChainId, valIndex int64, key crypto.PublicKey) error {
->>>>>>> feat/partial-set-security
 	stakingVal, found := s.stakingValidator(valIndex)
 	if !found {
 		return fmt.Errorf("validator with id %v not found on provider", valIndex)
 	}
-<<<<<<< HEAD
-	return s.providerKeeper().AssignConsumerKey(s.providerCtx(), string(chain), stakingVal, value)
-=======
 	return s.providerKeeper().AssignConsumerKey(s.providerCtx(), string(chain), stakingVal, key)
->>>>>>> feat/partial-set-security
 }
 
 // DeliverPacketToConsumer delivers a packet from the provider to the given consumer recipient.

--- a/tests/mbt/driver/core.go
+++ b/tests/mbt/driver/core.go
@@ -383,6 +383,34 @@ func (s *Driver) AssignKey(chain ChainId, valIndex int64, key crypto.PublicKey) 
 	return s.providerKeeper().AssignConsumerKey(s.providerCtx(), string(chain), stakingVal, key)
 }
 
+// Opts the given validator into the given consumer chain on the provider.
+func (s *Driver) OptIn(chain ChainId, valIndex int64) error {
+	stakingVal, found := s.stakingValidator(valIndex)
+	if !found {
+		return fmt.Errorf("validator with id %v not found on provider", valIndex)
+	}
+	consPubKey, err := stakingVal.ConsPubKey()
+	if err != nil {
+		return err
+	}
+	consAddr := sdk.GetConsAddress(consPubKey)
+	return s.providerKeeper().HandleOptIn(s.providerCtx(), string(chain), providertypes.NewProviderConsAddress(consAddr), nil)
+}
+
+// Opts the given validator out of the given consumer chain on the provider.
+func (s *Driver) OptOut(chain ChainId, valIndex int64) error {
+	stakingVal, found := s.stakingValidator(valIndex)
+	if !found {
+		return fmt.Errorf("validator with id %v not found on provider", valIndex)
+	}
+	consPubKey, err := stakingVal.ConsPubKey()
+	if err != nil {
+		return err
+	}
+	consAddr := sdk.GetConsAddress(consPubKey)
+	return s.providerKeeper().HandleOptOut(s.providerCtx(), string(chain), providertypes.NewProviderConsAddress(consAddr))
+}
+
 // DeliverPacketToConsumer delivers a packet from the provider to the given consumer recipient.
 // It updates the client before delivering the packet.
 // Since the channel is ordered, the packet that is delivered is the first packet in the outbox.

--- a/tests/mbt/driver/generate_more_traces.sh
+++ b/tests/mbt/driver/generate_more_traces.sh
@@ -11,3 +11,4 @@ go run ./... -modelPath=../model/ccv_sync.qnt -init initSync -step stepSync -inv
 echo "Generating long synced traces without invariants"
 go run ./... -modelPath=../model/ccv_sync.qnt -init initSync -step stepSync -traceFolder traces/sync_noinv -numTraces 20 -numSteps 500 -numSamples 1
 go run ./... -modelPath=../model/ccv_boundeddrift.qnt --step stepBoundedDriftKeyAssignment --traceFolder traces/bound_key -numTraces 20 -numSteps 100 -numSamples 20
+go run ./... -modelPath=../model/ccv_boundeddrift.qnt --step stepBoundedDriftKeyAndPSS --traceFolder traces/bound_pss -numTraces 20 -numSteps 100 -numSamples 20

--- a/tests/mbt/driver/generate_more_traces.sh
+++ b/tests/mbt/driver/generate_more_traces.sh
@@ -10,3 +10,4 @@ echo "Generating synced traces with maturations"
 go run ./... -modelPath=../model/ccv_sync.qnt -init initSync -step stepSync -invariant CanReceiveMaturations -traceFolder traces/sync_mat -numTraces 20 -numSteps 300 -numSamples 20
 echo "Generating long synced traces without invariants"
 go run ./... -modelPath=../model/ccv_sync.qnt -init initSync -step stepSync -traceFolder traces/sync_noinv -numTraces 20 -numSteps 500 -numSamples 1
+go run ./... -modelPath=../model/ccv_boundeddrift.qnt --step stepBoundedDriftKeyAssignment --traceFolder traces/bound_key -numTraces 20 -numSteps 100 -numSamples 20

--- a/tests/mbt/driver/generate_more_traces.sh
+++ b/tests/mbt/driver/generate_more_traces.sh
@@ -10,9 +10,5 @@ echo "Generating synced traces with maturations"
 go run ./... -modelPath=../model/ccv_sync.qnt -init initSync -step stepSync -invariant CanReceiveMaturations -traceFolder traces/sync_mat -numTraces 20 -numSteps 300 -numSamples 20
 echo "Generating long synced traces without invariants"
 go run ./... -modelPath=../model/ccv_sync.qnt -init initSync -step stepSync -traceFolder traces/sync_noinv -numTraces 20 -numSteps 500 -numSamples 1
-<<<<<<< HEAD
 go run ./... -modelPath=../model/ccv_boundeddrift.qnt --step stepBoundedDriftKeyAssignment --traceFolder traces/bound_key -numTraces 20 -numSteps 100 -numSamples 20
 go run ./... -modelPath=../model/ccv_boundeddrift.qnt --step stepBoundedDriftKeyAndPSS --traceFolder traces/bound_pss -numTraces 20 -numSteps 100 -numSamples 20
-=======
-go run ./... -modelPath=../model/ccv_boundeddrift.qnt --step stepBoundedDriftKeyAssignment --traceFolder traces/bound_key -numTraces 20 -numSteps 100 -numSamples 20
->>>>>>> feat/partial-set-security

--- a/tests/mbt/driver/generate_traces.sh
+++ b/tests/mbt/driver/generate_traces.sh
@@ -10,4 +10,4 @@ echo "Generating synced traces with maturations"
 go run ./... -modelPath=../model/ccv_sync.qnt -init initSync -step stepSync -invariant CanReceiveMaturations -traceFolder traces/sync_mat -numTraces 1 -numSteps 300 -numSamples 20
 echo "Generating long synced traces without invariants"
 go run ./... -modelPath=../model/ccv_sync.qnt -init initSync -step stepSync -traceFolder traces/sync_noinv -numTraces 1 -numSteps 500 -numSamples 1
-go run ./... -modelPath=../model/ccv_boundeddrift.qnt --step stepBoundedDriftKeyAssignment --traceFolder traces/bound_key -numTraces 1 -numSteps 100 -numSamples 20
+go run ./... -modelPath=../model/ccv_boundeddrift.qnt --step stepBoundedDriftKeyAndPSS --traceFolder traces/bound_pss -numTraces 1 -numSteps 100 -numSamples 20

--- a/tests/mbt/driver/generate_traces.sh
+++ b/tests/mbt/driver/generate_traces.sh
@@ -10,3 +10,4 @@ echo "Generating synced traces with maturations"
 go run ./... -modelPath=../model/ccv_sync.qnt -init initSync -step stepSync -invariant CanReceiveMaturations -traceFolder traces/sync_mat -numTraces 1 -numSteps 300 -numSamples 20
 echo "Generating long synced traces without invariants"
 go run ./... -modelPath=../model/ccv_sync.qnt -init initSync -step stepSync -traceFolder traces/sync_noinv -numTraces 1 -numSteps 500 -numSamples 1
+go run ./... -modelPath=../model/ccv_boundeddrift.qnt --step stepBoundedDriftKeyAssignment --traceFolder traces/bound_key -numTraces 1 -numSteps 100 -numSamples 20

--- a/tests/mbt/driver/mbt_test.go
+++ b/tests/mbt/driver/mbt_test.go
@@ -271,14 +271,17 @@ func RunItfTrace(t *testing.T, path string) {
 			driver.coordinator.CurrentTime = driver.runningTime("provider")
 			// start consumers
 			for _, consumer := range consumersToStart {
+				chainId := consumer.Value.(itf.MapExprType)["chain"].Value.(string)
+				topN := consumer.Value.(itf.MapExprType)["topN"].Value.(int64)
 				driver.setupConsumer(
-					consumer.Value.(string),
+					chainId,
 					modelParams,
 					driver.providerChain().Vals,
 					consumerSigners,
 					nodes,
 					valNames,
 					driver.providerChain(),
+					topN,
 				)
 			}
 

--- a/tests/mbt/driver/setup.go
+++ b/tests/mbt/driver/setup.go
@@ -363,6 +363,8 @@ func (s *Driver) ConfigureNewPath(consumerChain, providerChain *ibctesting.TestC
 	require.NoError(s.t, err, "Error setting consumer genesis on provider for chain %v", consumerChain.ChainID)
 
 	// set the top N percentage
+	// needs to be done before the provider queues the first vsc packet to the consumer
+	// TODO: might be able to move this into setupConsumer, need to test once more logic is here
 	s.providerKeeper().SetTopN(providerChain.GetContext(), consumerChain.ChainID, topN)
 
 	// Client ID is set in InitGenesis and we treat it as a black box. So

--- a/tests/mbt/driver/setup.go
+++ b/tests/mbt/driver/setup.go
@@ -310,7 +310,7 @@ func newChain(
 // Creates a path for cross-chain validation from the consumer to the provider and configures the channel config of the endpoints
 // as well as the clients.
 // this function stops when there is an initialized, ready-to-relay channel between the provider and consumer.
-func (s *Driver) ConfigureNewPath(consumerChain, providerChain *ibctesting.TestChain, params ModelParams) *ibctesting.Path {
+func (s *Driver) ConfigureNewPath(consumerChain, providerChain *ibctesting.TestChain, params ModelParams, topN uint32) *ibctesting.Path {
 	consumerChainId := ChainId(consumerChain.ChainID)
 
 	path := ibctesting.NewPath(consumerChain, providerChain)
@@ -361,6 +361,9 @@ func (s *Driver) ConfigureNewPath(consumerChain, providerChain *ibctesting.TestC
 		string(consumerChainId),
 		consumerGenesisForProvider)
 	require.NoError(s.t, err, "Error setting consumer genesis on provider for chain %v", consumerChain.ChainID)
+
+	// set the top N percentage
+	s.providerKeeper().SetTopN(providerChain.GetContext(), consumerChain.ChainID, topN)
 
 	// Client ID is set in InitGenesis and we treat it as a black box. So
 	// must query it to use it with the endpoint.
@@ -437,6 +440,8 @@ func (s *Driver) setupConsumer(
 ) {
 	s.t.Logf("Starting consumer %v", chain)
 
+	// TODO: reuse the partial set computation logic to compute the initial validator set
+	// for top N chains
 	initValUpdates := cmttypes.TM2PB.ValidatorUpdates(valSet)
 
 	// start consumer chains
@@ -444,7 +449,7 @@ func (s *Driver) setupConsumer(
 	consumerChain := newChain(s.t, params, s.coordinator, icstestingutils.ConsumerAppIniter(initValUpdates), chain, valSet, signers, nodes, valNames)
 	s.coordinator.Chains[chain] = consumerChain
 
-	path := s.ConfigureNewPath(consumerChain, providerChain, params)
+	path := s.ConfigureNewPath(consumerChain, providerChain, params, uint32(topN))
 	s.simibcs[ChainId(chain)] = simibc.MakeRelayedPath(s.t, path)
 }
 

--- a/tests/mbt/driver/setup.go
+++ b/tests/mbt/driver/setup.go
@@ -433,6 +433,7 @@ func (s *Driver) setupConsumer(
 	nodes []*cmttypes.Validator, // the list of nodes, even ones that have no voting power initially
 	valNames []string,
 	providerChain *ibctesting.TestChain,
+	topN int64,
 ) {
 	s.t.Logf("Starting consumer %v", chain)
 

--- a/tests/mbt/driver/stats.go
+++ b/tests/mbt/driver/stats.go
@@ -16,4 +16,6 @@ type Stats struct {
 	numTxs         int
 
 	totalBlockTimePassedPerTrace time.Duration
+
+	numKeyAssignments int
 }

--- a/tests/mbt/model/ccv_pss_model.qnt
+++ b/tests/mbt/model/ccv_pss_model.qnt
@@ -22,8 +22,7 @@ module ccv_pss_model {
                     ...emptyAction,
                     kind: "OptIn",
                     consumerChain: consumer,
-                    validator: validator,
-                    expectedError: res.error
+                    validator: validator
                 }
             ),
             params' = params,


### PR DESCRIPTION
## Description

Closes: #1631 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

* Handles new action types OptIn and OptOut
* Handles the new topN field when adding consumer chains

Some things I decided against doing:
* I think comparing the sets of opted in validators between model and system is probably unnecessary, because those will become the validator sets on the consumer chain anyways, so if there is an issue with who is opted in, this will be detected when the validator sets are eventually different.
* Starting the chain with an initial validator set different from the replicated security valset will come later, since I will want to reuse the function to compute the partial set from the keeper

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed (mbt test is expected to fail, since PSS behaviour is not yet completely implemented)

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
