### PR TITLE
style: (tiny) rename variable to avoid shadowing

### DIFF
--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -215,11 +215,11 @@ func (k Keeper) QueueVSCPackets(ctx sdk.Context) {
 	// Get the validator updates from the staking module.
 	// Note: GetValidatorUpdates panics if the updates provided by the x/staking module
 	// of cosmos-sdk is invalid.
-	valUpdates := k.stakingKeeper.GetValidatorUpdates(ctx)
+	stakingValUpdates := k.stakingKeeper.GetValidatorUpdates(ctx)
 
 	for _, chain := range k.GetAllConsumerChains(ctx) {
 		// Apply the key assignment to the validator updates.
-		valUpdates := k.MustApplyKeyAssignmentToValUpdates(ctx, chain.ChainId, valUpdates)
+		valUpdates := k.MustApplyKeyAssignmentToValUpdates(ctx, chain.ChainId, stakingValUpdates)
 
 		// check whether there are changes in the validator set;
 		// note that this also entails unbonding operations


### PR DESCRIPTION
## Description

This is a tiny PR to avoid possible confusion when looking at the `QueueVSCPacket` code. We rename `valUpdates` returned from the staking module to `stakingValUpdates` so that the `valUpdates` variable in the `for` loop does not shadow the outside variable. See [50 Shades of Go](https://golang50shad.es/index.html#vars_shadow) for more on this.

Thanks @MSalopek pointing out the correctness of this!

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
