### PR TITLE
chore: fix GH workflow for compatiblity tests and docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,7 +12,8 @@ name: Docker Publish
 on:
   push:
     branches:
-      - main
+      - 'main'
+      - 'releases/**'
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+" # Push events matching tag versions as v3.0.0
       - "v[0-9]+.[0-9]+.[0-9]+-lsm" # Push events matching '-lsm' postfix tags

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   compatibility-test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 120
     steps:
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
## Description

Closes: #XXXX

fix GH workflow for docker images & nightly compatiblity tests
Issues:
- timeout for nightly comaptibility tests is too low. (local runs  ~ 1:10 h)
- no docker images were published for  relase/** branch
---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
