### PR TITLE
ci: update provider versions on nigthly comatibility runs

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -34,7 +34,7 @@ jobs:
         # Run compatibility tests for different consumer (-cv) and provider (-pv) versions.
         # Combination of all provider versions with consumer versions are tested.
         # For new versions to be tested add/modify -pc/-cv parameters.
-        run: go run ./tests/e2e/... --tc compatibility -pv latest -pv v4.0.0 -pv v3.3.2-lsm -cv latest -cv v4.0.0 -cv v3.3.0
+        run: go run ./tests/e2e/... --tc compatibility -pv latest -pv v4.0.0 -pv v3.3.3-lsm -cv latest -cv v4.0.0 -cv v3.3.0
   happy-path-test:
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
## Description

Closes: #XXXX

replace provider image v3.3.2-lsm with v3.3.3-lsm to be checked on nightly compatibility tests

results from local run passed:

```
Summary:
- time elapsed: 1h3m6.548360583s
- 7/7 tests passed
- 0/7 tests failed
- 0/7 tests with misc status (check details)
```

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
