### PR TITLE
test: fix flacky democracy tests 

### DIFF
--- a/tests/e2e/actions.go
+++ b/tests/e2e/actions.go
@@ -1910,7 +1910,7 @@ func (tr TestConfig) registerRepresentative(
 			}
 
 			// wait for inclusion in a block -> '--broadcast-mode block' is deprecated
-			tr.waitBlocks(action.Chain, 1, 10*time.Second)
+			tr.waitBlocks(action.Chain, 2, 10*time.Second)
 		}(val, stake)
 	}
 


### PR DESCRIPTION
## Description
Democracy e2e tests occasionally fail when calling registerRepresentative fn, because after the representative account is registered, the test waits for 1 block, which is in some cases insufficient due to network congestion. This is now increased to 2 following the example of another tests. We can think about changing this logic to wait for the tx hash to be included in the blockchain and replace it everywhere where it makes sense; this will probably be the better replacement for the obsolete
 --broadcast-mode flag.

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] Added `!` to the type prefix if the change is [state-machine breaking](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes)
* [x] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
* [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] Provided a link to the relevant issue or specification
* [ ] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/00-intro.md)
* [ ] Included the necessary unit and integration [tests](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry to `CHANGELOG.md`
* [ ] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [ ] Confirmed all CI checks have passed
* [ ] If this PR is library API breaking, bump the go.mod version string of the repo, and follow through on a new major release

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` the type prefix if the change is state-machine breaking
* [ ] confirmed this PR does not introduce changes requiring state migrations, OR confirmed migration code has been added to consumer and/or provider modules
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
