### PR TITLE
fix: fixed QueryAllPairsValConAddrByConsumerChainID output formatting

### DIFF
--- a/proto/interchain_security/ccv/provider/v1/query.proto
+++ b/proto/interchain_security/ccv/provider/v1/query.proto
@@ -200,9 +200,9 @@ message QueryAllPairsValConAddrByConsumerChainIDResponse {
 
 message PairValConAddrProviderAndConsumer {
   // The consensus address of the validator on the provider chain
-  string provider_address = 1 [ (gogoproto.moretags) = "yaml:\"address\"" ];
+  string provider_address = 1 [ (gogoproto.moretags) = "yaml:\"provider_address\"" ];
   // The consensus address of the validator on the consumer chain
-  string consumer_address = 2 [ (gogoproto.moretags) = "yaml:\"address\"" ];
+  string consumer_address = 2 [ (gogoproto.moretags) = "yaml:\"consumer_address\"" ];
   tendermint.crypto.PublicKey consumer_key = 3;
 }
 

--- a/x/ccv/provider/keeper/grpc_query.go
+++ b/x/ccv/provider/keeper/grpc_query.go
@@ -203,8 +203,8 @@ func (k Keeper) QueryAllPairsValConAddrByConsumerChainID(goCtx context.Context, 
 			return nil, err
 		}
 		pairValConAddrs = append(pairValConAddrs, &types.PairValConAddrProviderAndConsumer{
-			ProviderAddress: string(data.ProviderAddr),
-			ConsumerAddress: string(consumerAddr),
+			ProviderAddress: sdk.ConsAddress(data.ProviderAddr).String(),
+			ConsumerAddress: consumerAddr.String(),
 			ConsumerKey:     data.ConsumerKey,
 		})
 	}

--- a/x/ccv/provider/keeper/grpc_query_test.go
+++ b/x/ccv/provider/keeper/grpc_query_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	cryptotestutil "github.com/cosmos/interchain-security/v4/testutil/crypto"
 	testkeeper "github.com/cosmos/interchain-security/v4/testutil/keeper"
 	"github.com/cosmos/interchain-security/v4/x/ccv/provider/types"
@@ -13,7 +14,10 @@ import (
 
 func TestQueryAllPairsValConAddrByConsumerChainID(t *testing.T) {
 	chainID := consumer
-	providerAddr := types.NewProviderConsAddress([]byte("providerAddr"))
+
+	providerConsAddress, err := sdktypes.ConsAddressFromBech32("cosmosvalcons1wpex7anfv3jhystyv3eq20r35a")
+	require.NoError(t, err)
+	providerAddr := types.NewProviderConsAddress(providerConsAddress)
 
 	consumerKey := cryptotestutil.NewCryptoIdentityFromIntSeed(1).TMProtoCryptoPublicKey()
 	consumerAddr, err := ccvtypes.TMCryptoPublicKeyToConsAddr(consumerKey)
@@ -47,8 +51,8 @@ func TestQueryAllPairsValConAddrByConsumerChainID(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedResult := types.PairValConAddrProviderAndConsumer{
-		ProviderAddress: "providerAddr",
-		ConsumerAddress: string(consumerAddr),
+		ProviderAddress: providerConsAddress.String(),
+		ConsumerAddress: consumerAddr.String(),
 		ConsumerKey:     &consumerKey,
 	}
 	require.Equal(t, &consumerKey, response.PairValConAddr[0].ConsumerKey)


### PR DESCRIPTION
<!--
The production pull request template is for types feat, fix, or refactor.
-->

## Description

Fixes the issue described here: https://github.com/cosmos/interchain-security/issues/1251#issuecomment-2016665369

Converts QueryAllPairsValConAddrByConsumerChainID output to consumer addresses, so instead of raw bytes in gRPC/REST response we now have this:
<img width="572" alt="image" src="https://github.com/cosmos/interchain-security/assets/83376337/a77ca110-93a5-4d90-9947-66784b81a8fd">

I patched my Gaia node with this: https://api.cosmos.quokkastake.io/interchain_security/ccv/provider/consumer_chain_id?chain_id=neutron-1, seems to work more correct, also tested it with gRPC and it also works.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] Added `!` to the type prefix if the change is [state-machine breaking](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes)
* [x] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
* [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] Provided a link to the relevant issue or specification
* [x] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/00-intro.md)
* [x] Included the necessary unit and integration [tests](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry to `CHANGELOG.md`
* [x] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] Updated the relevant documentation or specification
* [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [x] Confirmed all CI checks have passed
* [x] If this PR is library API breaking, bump the go.mod version string of the repo, and follow through on a new major release

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` the type prefix if the change is state-machine breaking
* [ ] confirmed this PR does not introduce changes requiring state migrations, OR confirmed migration code has been added to consumer and/or provider modules
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
