### PR TITLE
feat!: only perform consumer additions for non-empty chains

### DIFF
--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -377,7 +377,7 @@ func (k Keeper) BeginBlockInit(ctx sdk.Context) {
 		if prop.Top_N == 0 && len(k.GetAllOptedIn(ctx, prop.ChainId)) == 0 {
 			// drop the proposal
 			ctx.Logger().Info("consumer client could not be created because no validator has"+
-				" opted in the Opt-In chain: %s", prop.ChainId)
+				" opted in for the Opt-In chain: %s", prop.ChainId)
 			continue
 		}
 


### PR DESCRIPTION
## Description
`ConsumerAdditionProposal`s for _opt-in_ chains that have no validator opted-in when they're initialized (i.e., when we create the consumer genesis) won't be able to start. This PR adds a check to drop proposals in those cases.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] Added `!` to the type prefix if the change is [state-machine breaking](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes)
* [ ] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
* [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] Provided a link to the relevant issue or specification
* [ ] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/00-intro.md)
* [ ] Included the necessary unit and integration [tests](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry to `CHANGELOG.md`
* [x] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [ ] Confirmed all CI checks have passed
* [ ] If this PR is library API breaking, bump the go.mod version string of the repo, and follow through on a new major release

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` the type prefix if the change is state-machine breaking
* [ ] confirmed this PR does not introduce changes requiring state migrations, OR confirmed migration code has been added to consumer and/or provider modules
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
