### PR TITLE
fix!: Fix opt-in assignment

### DIFF
--- a/.changelog/unreleased/api-breaking/provider/1732-assigning-already-assigned-key-fix.md
+++ b/.changelog/unreleased/api-breaking/provider/1732-assigning-already-assigned-key-fix.md
@@ -1,0 +1,2 @@
+- Assigning a key that is already assigned by the same validator will now be a no-op instead of throwing an error.
+  ([\#1732](https://github.com/cosmos/interchain-security/pull/1732))

--- a/.changelog/unreleased/state-breaking/provider/1732-assigning-already-assigned-key-fix.md
+++ b/.changelog/unreleased/state-breaking/provider/1732-assigning-already-assigned-key-fix.md
@@ -1,0 +1,2 @@
+- Assigning a key that is already assigned by the same validator will now be a no-op instead of throwing an error.
+  ([\#1732](https://github.com/cosmos/interchain-security/pull/1732))

--- a/tests/e2e/main.go
+++ b/tests/e2e/main.go
@@ -430,13 +430,13 @@ TEST RESULTS
 		}
 	}
 	if len(passedTests) > 0 {
-		report += fmt.Sprintln("\n\nPASSED TESTS:\n")
+		report += fmt.Sprintln("\n\nPASSED TESTS:")
 		for _, t := range passedTests {
 			report += t.Report()
 		}
 	}
 	if len(remainingTests) > 0 {
-		report += fmt.Sprintln("\n\nREMAINING TESTS:\n")
+		report += fmt.Sprintln("\n\nREMAINING TESTS:")
 		for _, t := range remainingTests {
 			report += t.Report()
 		}

--- a/tests/e2e/steps_compatibility.go
+++ b/tests/e2e/steps_compatibility.go
@@ -86,18 +86,6 @@ func compstepsStartConsumerChain(consumerName string, proposalIndex, chainIndex 
 			},
 		},
 		{
-			// op should fail - key already assigned by the same validator
-			Action: AssignConsumerPubKeyAction{
-				Chain:           ChainID(consumerName),
-				Validator:       ValidatorID("carol"),
-				ConsumerPubkey:  getDefaultValidators()[ValidatorID("carol")].ConsumerValPubKey,
-				ReconfigureNode: false,
-				ExpectError:     true,
-				ExpectedError:   "a validator has assigned the consumer key already: consumer key is already in use by a validator",
-			},
-			State: State{},
-		},
-		{
 			// op should fail - key already assigned by another validator
 			Action: AssignConsumerPubKeyAction{
 				Chain:     ChainID(consumerName),

--- a/tests/e2e/steps_start_chains.go
+++ b/tests/e2e/steps_start_chains.go
@@ -82,16 +82,24 @@ func stepsStartConsumerChain(consumerName string, proposalIndex, chainIndex uint
 			},
 		},
 		{
-			// op should fail - key already assigned by the same validator
+			// op should be a noop - key already assigned, but by the same validator
 			Action: AssignConsumerPubKeyAction{
 				Chain:           ChainID(consumerName),
 				Validator:       ValidatorID("carol"),
 				ConsumerPubkey:  getDefaultValidators()[ValidatorID("carol")].ConsumerValPubKey,
 				ReconfigureNode: false,
-				ExpectError:     true,
-				ExpectedError:   "a validator has assigned the consumer key already: consumer key is already in use by a validator",
+				ExpectError:     false,
 			},
-			State: State{},
+			State: State{
+				ChainID(consumerName): ChainState{
+					AssignedKeys: &map[ValidatorID]string{
+						ValidatorID("carol"): getDefaultValidators()[ValidatorID("carol")].ConsumerValconsAddressOnProvider,
+					},
+					ProviderKeys: &map[ValidatorID]string{
+						ValidatorID("carol"): getDefaultValidators()[ValidatorID("carol")].ValconsAddress,
+					},
+				},
+			},
 		},
 		{
 			// op should fail - key already assigned by another validator

--- a/tests/e2e/tracehandler_testdata/consumer-double-sign.json
+++ b/tests/e2e/tracehandler_testdata/consumer-double-sign.json
@@ -134,10 +134,30 @@
       "Validator": "carol",
       "ConsumerPubkey": "{\"@type\":\"/cosmos.crypto.ed25519.PubKey\",\"key\":\"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is=\"}",
       "ReconfigureNode": false,
-      "ExpectError": true,
-      "ExpectedError": "a validator has assigned the consumer key already: consumer key is already in use by a validator"
+      "ExpectError": false,
+      "ExpectedError": ""
     },
-    "State": {}
+    "State": {
+      "consu": {
+        "ValBalances": null,
+        "ProposedConsumerChains": null,
+        "ValPowers": null,
+        "StakedTokens": null,
+        "Params": null,
+        "Rewards": null,
+        "ConsumerChains": null,
+        "AssignedKeys": {
+          "carol": "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk"
+        },
+        "ProviderKeys": {
+          "carol": "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6"
+        },
+        "ConsumerPendingPacketQueueSize": null,
+        "RegisteredConsumerRewardDenoms": null,
+        "ClientsFrozenHeights": null,
+        "Proposals": null
+      }
+    }
   },
   {
     "ActionType": "main.AssignConsumerPubKeyAction",

--- a/tests/e2e/tracehandler_testdata/democracy.json
+++ b/tests/e2e/tracehandler_testdata/democracy.json
@@ -134,10 +134,30 @@
       "Validator": "carol",
       "ConsumerPubkey": "{\"@type\":\"/cosmos.crypto.ed25519.PubKey\",\"key\":\"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is=\"}",
       "ReconfigureNode": false,
-      "ExpectError": true,
-      "ExpectedError": "a validator has assigned the consumer key already: consumer key is already in use by a validator"
+      "ExpectError": false,
+      "ExpectedError": ""
     },
-    "State": {}
+    "State": {
+      "democ": {
+        "ValBalances": null,
+        "ProposedConsumerChains": null,
+        "ValPowers": null,
+        "StakedTokens": null,
+        "Params": null,
+        "Rewards": null,
+        "ConsumerChains": null,
+        "AssignedKeys": {
+          "carol": "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk"
+        },
+        "ProviderKeys": {
+          "carol": "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6"
+        },
+        "ConsumerPendingPacketQueueSize": null,
+        "RegisteredConsumerRewardDenoms": null,
+        "ClientsFrozenHeights": null,
+        "Proposals": null
+      }
+    }
   },
   {
     "ActionType": "main.AssignConsumerPubKeyAction",

--- a/tests/e2e/tracehandler_testdata/democracyRewardsSteps.json
+++ b/tests/e2e/tracehandler_testdata/democracyRewardsSteps.json
@@ -134,10 +134,30 @@
       "Validator": "carol",
       "ConsumerPubkey": "{\"@type\":\"/cosmos.crypto.ed25519.PubKey\",\"key\":\"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is=\"}",
       "ReconfigureNode": false,
-      "ExpectError": true,
-      "ExpectedError": "a validator has assigned the consumer key already: consumer key is already in use by a validator"
+      "ExpectError": false,
+      "ExpectedError": ""
     },
-    "State": {}
+    "State": {
+      "democ": {
+        "ValBalances": null,
+        "ProposedConsumerChains": null,
+        "ValPowers": null,
+        "StakedTokens": null,
+        "Params": null,
+        "Rewards": null,
+        "ConsumerChains": null,
+        "AssignedKeys": {
+          "carol": "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk"
+        },
+        "ProviderKeys": {
+          "carol": "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6"
+        },
+        "ConsumerPendingPacketQueueSize": null,
+        "RegisteredConsumerRewardDenoms": null,
+        "ClientsFrozenHeights": null,
+        "Proposals": null
+      }
+    }
   },
   {
     "ActionType": "main.AssignConsumerPubKeyAction",

--- a/tests/e2e/tracehandler_testdata/happyPath.json
+++ b/tests/e2e/tracehandler_testdata/happyPath.json
@@ -134,10 +134,30 @@
       "Validator": "carol",
       "ConsumerPubkey": "{\"@type\":\"/cosmos.crypto.ed25519.PubKey\",\"key\":\"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is=\"}",
       "ReconfigureNode": false,
-      "ExpectError": true,
-      "ExpectedError": "a validator has assigned the consumer key already: consumer key is already in use by a validator"
+      "ExpectError": false,
+      "ExpectedError": ""
     },
-    "State": {}
+    "State": {
+      "consu": {
+        "ValBalances": null,
+        "ProposedConsumerChains": null,
+        "ValPowers": null,
+        "StakedTokens": null,
+        "Params": null,
+        "Rewards": null,
+        "ConsumerChains": null,
+        "AssignedKeys": {
+          "carol": "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk"
+        },
+        "ProviderKeys": {
+          "carol": "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6"
+        },
+        "ConsumerPendingPacketQueueSize": null,
+        "RegisteredConsumerRewardDenoms": null,
+        "ClientsFrozenHeights": null,
+        "Proposals": null
+      }
+    }
   },
   {
     "ActionType": "main.AssignConsumerPubKeyAction",

--- a/tests/e2e/tracehandler_testdata/multipleConsumers.json
+++ b/tests/e2e/tracehandler_testdata/multipleConsumers.json
@@ -134,10 +134,30 @@
       "Validator": "carol",
       "ConsumerPubkey": "{\"@type\":\"/cosmos.crypto.ed25519.PubKey\",\"key\":\"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is=\"}",
       "ReconfigureNode": false,
-      "ExpectError": true,
-      "ExpectedError": "a validator has assigned the consumer key already: consumer key is already in use by a validator"
+      "ExpectError": false,
+      "ExpectedError": ""
     },
-    "State": {}
+    "State": {
+      "consu": {
+        "ValBalances": null,
+        "ProposedConsumerChains": null,
+        "ValPowers": null,
+        "StakedTokens": null,
+        "Params": null,
+        "Rewards": null,
+        "ConsumerChains": null,
+        "AssignedKeys": {
+          "carol": "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk"
+        },
+        "ProviderKeys": {
+          "carol": "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6"
+        },
+        "ConsumerPendingPacketQueueSize": null,
+        "RegisteredConsumerRewardDenoms": null,
+        "ClientsFrozenHeights": null,
+        "Proposals": null
+      }
+    }
   },
   {
     "ActionType": "main.AssignConsumerPubKeyAction",
@@ -399,10 +419,30 @@
       "Validator": "carol",
       "ConsumerPubkey": "{\"@type\":\"/cosmos.crypto.ed25519.PubKey\",\"key\":\"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is=\"}",
       "ReconfigureNode": false,
-      "ExpectError": true,
-      "ExpectedError": "a validator has assigned the consumer key already: consumer key is already in use by a validator"
+      "ExpectError": false,
+      "ExpectedError": ""
     },
-    "State": {}
+    "State": {
+      "densu": {
+        "ValBalances": null,
+        "ProposedConsumerChains": null,
+        "ValPowers": null,
+        "StakedTokens": null,
+        "Params": null,
+        "Rewards": null,
+        "ConsumerChains": null,
+        "AssignedKeys": {
+          "carol": "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk"
+        },
+        "ProviderKeys": {
+          "carol": "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6"
+        },
+        "ConsumerPendingPacketQueueSize": null,
+        "RegisteredConsumerRewardDenoms": null,
+        "ClientsFrozenHeights": null,
+        "Proposals": null
+      }
+    }
   },
   {
     "ActionType": "main.AssignConsumerPubKeyAction",

--- a/tests/e2e/tracehandler_testdata/shorthappy.json
+++ b/tests/e2e/tracehandler_testdata/shorthappy.json
@@ -134,10 +134,30 @@
       "Validator": "carol",
       "ConsumerPubkey": "{\"@type\":\"/cosmos.crypto.ed25519.PubKey\",\"key\":\"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is=\"}",
       "ReconfigureNode": false,
-      "ExpectError": true,
-      "ExpectedError": "a validator has assigned the consumer key already: consumer key is already in use by a validator"
+      "ExpectError": false,
+      "ExpectedError": ""
     },
-    "State": {}
+    "State": {
+      "consu": {
+        "ValBalances": null,
+        "ProposedConsumerChains": null,
+        "ValPowers": null,
+        "StakedTokens": null,
+        "Params": null,
+        "Rewards": null,
+        "ConsumerChains": null,
+        "AssignedKeys": {
+          "carol": "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk"
+        },
+        "ProviderKeys": {
+          "carol": "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6"
+        },
+        "ConsumerPendingPacketQueueSize": null,
+        "RegisteredConsumerRewardDenoms": null,
+        "ClientsFrozenHeights": null,
+        "Proposals": null
+      }
+    }
   },
   {
     "ActionType": "main.AssignConsumerPubKeyAction",

--- a/tests/e2e/tracehandler_testdata/slashThrottle.json
+++ b/tests/e2e/tracehandler_testdata/slashThrottle.json
@@ -134,10 +134,30 @@
       "Validator": "carol",
       "ConsumerPubkey": "{\"@type\":\"/cosmos.crypto.ed25519.PubKey\",\"key\":\"Ui5Gf1+mtWUdH8u3xlmzdKID+F3PK0sfXZ73GZ6q6is=\"}",
       "ReconfigureNode": false,
-      "ExpectError": true,
-      "ExpectedError": "a validator has assigned the consumer key already: consumer key is already in use by a validator"
+      "ExpectError": false,
+      "ExpectedError": ""
     },
-    "State": {}
+    "State": {
+      "consu": {
+        "ValBalances": null,
+        "ProposedConsumerChains": null,
+        "ValPowers": null,
+        "StakedTokens": null,
+        "Params": null,
+        "Rewards": null,
+        "ConsumerChains": null,
+        "AssignedKeys": {
+          "carol": "cosmosvalcons1kswr5sq599365kcjmhgufevfps9njf43e4lwdk"
+        },
+        "ProviderKeys": {
+          "carol": "cosmosvalcons1ezyrq65s3gshhx5585w6mpusq3xsj3ayzf4uv6"
+        },
+        "ConsumerPendingPacketQueueSize": null,
+        "RegisteredConsumerRewardDenoms": null,
+        "ClientsFrozenHeights": null,
+        "Proposals": null
+      }
+    }
   },
   {
     "ActionType": "main.AssignConsumerPubKeyAction",

--- a/tests/integration/key_assignment.go
+++ b/tests/integration/key_assignment.go
@@ -79,7 +79,7 @@ func (s *CCVTestSuite) TestKeyAssignment() {
 			}, false, 2,
 		},
 		{
-			"double same-key assignment in same block", func(pk *providerkeeper.Keeper) error {
+			"double same-key assignment in same block by different vals", func(pk *providerkeeper.Keeper) error {
 				// establish CCV channel
 				s.SetupCCVChannel(s.path)
 
@@ -90,8 +90,9 @@ func (s *CCVTestSuite) TestKeyAssignment() {
 					return err
 				}
 
-				// same key assignment
-				err = pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator, consumerKey)
+				// same key assignment, but different validator
+				validator2, _ := generateNewConsumerKey(s, 1)
+				err = pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator2, consumerKey)
 				if err != nil {
 					return err
 				}
@@ -99,6 +100,28 @@ func (s *CCVTestSuite) TestKeyAssignment() {
 
 				return nil
 			}, true, 2,
+		},
+		{
+			"double same-key assignment in same block by same val", func(pk *providerkeeper.Keeper) error {
+				// establish CCV channel
+				s.SetupCCVChannel(s.path)
+
+				// key assignment
+				validator, consumerKey := generateNewConsumerKey(s, 0)
+				err := pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator, consumerKey)
+				if err != nil {
+					return err
+				}
+
+				// same key assignment, but different validator
+				err = pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator, consumerKey)
+				if err != nil {
+					return err
+				}
+				s.nextEpoch()
+
+				return nil
+			}, false, 2,
 		},
 		{
 			"double key assignment in same block", func(pk *providerkeeper.Keeper) error {
@@ -124,7 +147,31 @@ func (s *CCVTestSuite) TestKeyAssignment() {
 			}, false, 2,
 		},
 		{
-			"double same-key assignment in different blocks", func(pk *providerkeeper.Keeper) error {
+			"double same-key assignment in different blocks by different vals", func(pk *providerkeeper.Keeper) error {
+				// establish CCV channel
+				s.SetupCCVChannel(s.path)
+
+				// key assignment
+				validator, consumerKey := generateNewConsumerKey(s, 0)
+				err := pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator, consumerKey)
+				if err != nil {
+					return err
+				}
+				s.nextEpoch()
+
+				// same key assignment
+				validator2, _ := generateNewConsumerKey(s, 1)
+				err = pk.AssignConsumerKey(s.providerCtx(), s.consumerChain.ChainID, validator2, consumerKey)
+				if err != nil {
+					return err
+				}
+				s.nextEpoch()
+
+				return nil
+			}, true, 2,
+		},
+		{
+			"double same-key assignment in different blocks by same val", func(pk *providerkeeper.Keeper) error {
 				// establish CCV channel
 				s.SetupCCVChannel(s.path)
 
@@ -144,7 +191,7 @@ func (s *CCVTestSuite) TestKeyAssignment() {
 				s.nextEpoch()
 
 				return nil
-			}, true, 2,
+			}, false, 2,
 		},
 		{
 			"double key assignment in different blocks", func(pk *providerkeeper.Keeper) error {

--- a/x/ccv/provider/handler_test.go
+++ b/x/ccv/provider/handler_test.go
@@ -36,7 +36,7 @@ func TestAssignConsensusKeyForConsumerChain(t *testing.T) {
 
 	// a different providerConsAddr, to simulate different validators having assigned keys
 	providerCryptoId2 := testcrypto.NewCryptoIdentityFromIntSeed(10)
-	providerConsAddr2 := providerCryptoId.ProviderConsAddress()
+	providerConsAddr2 := providerCryptoId2.ProviderConsAddress()
 
 	consumerCryptoId := testcrypto.NewCryptoIdentityFromIntSeed(1)
 	consumerConsAddr := consumerCryptoId.ConsumerConsAddress()
@@ -118,10 +118,11 @@ func TestAssignConsensusKeyForConsumerChain(t *testing.T) {
 				gomock.InOrder(
 					mocks.MockStakingKeeper.EXPECT().GetValidator(
 						ctx, providerCryptoId.SDKValOpAddress(),
-						// Return a valid validator, found!
-					).Return(providerCryptoId2.SDKStakingValidator(), true).Times(1),
+						// validator should not be missing
+					).Return(providerCryptoId.SDKStakingValidator(), true).Times(1),
 					mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(ctx,
 						consumerConsAddr.ToSdkConsAddr(),
+						// return false - no other validator uses the consumer key to validate *on the provider*
 					).Return(stakingtypes.Validator{}, false),
 				)
 			},

--- a/x/ccv/provider/handler_test.go
+++ b/x/ccv/provider/handler_test.go
@@ -34,6 +34,10 @@ func TestAssignConsensusKeyForConsumerChain(t *testing.T) {
 	providerCryptoId := testcrypto.NewCryptoIdentityFromIntSeed(0)
 	providerConsAddr := providerCryptoId.ProviderConsAddress()
 
+	// a different providerConsAddr, to simulate different validators having assigned keys
+	providerCryptoId2 := testcrypto.NewCryptoIdentityFromIntSeed(10)
+	providerConsAddr2 := providerCryptoId.ProviderConsAddress()
+
 	consumerCryptoId := testcrypto.NewCryptoIdentityFromIntSeed(1)
 	consumerConsAddr := consumerCryptoId.ConsumerConsAddress()
 	consumerKeyBz := base64.StdEncoding.EncodeToString(consumerCryptoId.ConsensusSDKPubKey().Bytes())
@@ -101,7 +105,31 @@ func TestAssignConsensusKeyForConsumerChain(t *testing.T) {
 			chainID:  "chainid",
 		},
 		{
-			name: "fail: consumer key in use",
+			name: "fail: consumer key in use by other validator",
+			setup: func(ctx sdk.Context,
+				k keeper.Keeper, mocks testkeeper.MockedKeepers,
+			) {
+				k.SetPendingConsumerAdditionProp(ctx, &providertypes.ConsumerAdditionProposal{
+					ChainId: "chainid",
+				})
+				// Use the consumer key already
+				k.SetValidatorByConsumerAddr(ctx, "chainid", consumerConsAddr, providerConsAddr2)
+
+				gomock.InOrder(
+					mocks.MockStakingKeeper.EXPECT().GetValidator(
+						ctx, providerCryptoId.SDKValOpAddress(),
+						// Return a valid validator, found!
+					).Return(providerCryptoId2.SDKStakingValidator(), true).Times(1),
+					mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(ctx,
+						consumerConsAddr.ToSdkConsAddr(),
+					).Return(stakingtypes.Validator{}, false),
+				)
+			},
+			expError: true,
+			chainID:  "chainid",
+		},
+		{
+			name: "success: consumer key in use, but by the same validator",
 			setup: func(ctx sdk.Context,
 				k keeper.Keeper, mocks testkeeper.MockedKeepers,
 			) {
@@ -121,7 +149,7 @@ func TestAssignConsensusKeyForConsumerChain(t *testing.T) {
 					).Return(stakingtypes.Validator{}, false),
 				)
 			},
-			expError: true,
+			expError: false,
 			chainID:  "chainid",
 		},
 	}

--- a/x/ccv/provider/handler_test.go
+++ b/x/ccv/provider/handler_test.go
@@ -112,7 +112,7 @@ func TestAssignConsensusKeyForConsumerChain(t *testing.T) {
 				k.SetPendingConsumerAdditionProp(ctx, &providertypes.ConsumerAdditionProposal{
 					ChainId: "chainid",
 				})
-				// Use the consumer key already
+				// Use the consumer key already used by some other validator
 				k.SetValidatorByConsumerAddr(ctx, "chainid", consumerConsAddr, providerConsAddr2)
 
 				gomock.InOrder(

--- a/x/ccv/provider/keeper/key_assignment.go
+++ b/x/ccv/provider/keeper/key_assignment.go
@@ -371,12 +371,19 @@ func (k Keeper) AssignConsumerKey(
 		}
 	}
 
-	if _, found := k.GetValidatorByConsumerAddr(ctx, chainID, consumerAddr); found {
+	if existingProviderAddr, found := k.GetValidatorByConsumerAddr(ctx, chainID, consumerAddr); found {
 		// consumer key is already in use
-		// prevent multiple validators from assigning the same key
-		return errorsmod.Wrapf(
-			types.ErrConsumerKeyInUse, "a validator has assigned the consumer key already",
-		)
+		if providerAddr.Address.Equals(existingProviderAddr.Address) {
+			// the validator itself is the one already using the consumer key,
+			// just do a noop
+			return nil
+		} else {
+			// the validators are different -> throw an error to
+			// prevent multiple validators from assigning the same key
+			return errorsmod.Wrapf(
+				types.ErrConsumerKeyInUse, "a validator has assigned the consumer key already",
+			)
+		}
 	}
 
 	// get the previous key assigned for this validator on this consumer chain

--- a/x/ccv/provider/keeper/key_assignment.go
+++ b/x/ccv/provider/keeper/key_assignment.go
@@ -376,6 +376,11 @@ func (k Keeper) AssignConsumerKey(
 		if providerAddr.Address.Equals(existingProviderAddr.Address) {
 			// the validator itself is the one already using the consumer key,
 			// just do a noop
+			k.Logger(ctx).Info("tried to assign a consumer key that is already assigned to the validator",
+				"consumer chainID", chainID,
+				"validator", providerAddr.String(),
+				"consumer consensus addr", consumerAddr.String(),
+			)
 			return nil
 		} else {
 			// the validators are different -> throw an error to


### PR DESCRIPTION
<!--
The production pull request template is for types feat, fix, or refactor.
-->

## Description

Closes: #1731 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

If a validator tries to assign the consumer key it already has assigned itself,
there previously was an error.

This changed the PR to do a noop instead.

This fixes the behaviour when opting in and specifying the consumer key that already is assigned by the validator, which previously wasn't possible.

I also got rid of two trailing newlines that produced warnings when regenerating the traces.

Note: MBT failure is currently expected

I didn't find any documentation that specifically talked about what happens when assigning the same key twice to the same validator, so I found nothing to update here specifically.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] Added `!` to the type prefix if the change is [state-machine breaking](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes)
* [x] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
* [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] Provided a link to the relevant issue or specification
* [ ] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/00-intro.md)
* [x] Included the necessary unit and integration [tests](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#testing)
* [x] Added a changelog entry to `CHANGELOG.md`
* [x] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [x] Confirmed all CI checks have passed
* [ ] If this PR is library API breaking, bump the go.mod version string of the repo, and follow through on a new major release

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` the type prefix if the change is state-machine breaking
* [ ] confirmed this PR does not introduce changes requiring state migrations, OR confirmed migration code has been added to consumer and/or provider modules
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
