### PR TITLE
test: Quint model - Use `indices` instead of `range` to avoid problem with Apalache

### DIFF
--- a/tests/mbt/model/libraries/extraSpells.qnt
+++ b/tests/mbt/model/libraries/extraSpells.qnt
@@ -257,7 +257,7 @@ module extraSpells {
     /// Returns:
     /// - The index of the first element that satisfies the predicate function, or -1 if no such element exists.
     pure def firstIndex(__list: List[a], __f: a => bool): int = {
-        range(0, __list.length()).foldl(
+        __list.indices().fold(
             -1,
             (acc, i) => if (acc == -1 and __f(__list[i])) i else acc
         )


### PR DESCRIPTION
## Description

This is a simple fix for the model, so it works with Apalache (`quint verify`). Apalache doesn't support non-constant values in `range`, but in this case, we can simply use `indices` to achieve the same thing and avoid the issue. The behavior on simulation should stay the same, and this unblocks usage with Apalache.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [X] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [X] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [-] Provided a link to the relevant issue or specification
  - There are no issues related to this. I've been fixing some other issues on the quint repo related to this, and bumped into this problem myself.
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed
  - I need authorization for running them first

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
