### PR TITLE
fix: in mbt, do not set outstandingDowntime for double-sign slashes

### DIFF
--- a/tests/mbt/model/ccv.qnt
+++ b/tests/mbt/model/ccv.qnt
@@ -877,8 +877,8 @@ module ccv {
             })
             val newConsumerState = 
                 commitPacketOnConsumer(consumerState, packet)
-                // add the consumer address to the list of outstanding slashes
-                .with("outstandingDowntime", consumerState.outstandingDowntime.union(Set(consumerNode)))
+                // add the consumer address to the list of outstanding downtime if the packet is a downtime slash
+                .with("outstandingDowntime", if (downtime) consumerState.outstandingDowntime.add(consumerNode) else consumerState.outstandingDowntime)
             Ok(currentState.with("consumerStates", currentState.consumerStates.set(consumer, newConsumerState)))
         }
     }

--- a/tests/mbt/model/ccv_test.qnt
+++ b/tests/mbt/model/ccv_test.qnt
@@ -320,4 +320,61 @@ module ccv_test {
         )
         res._2 == "Cannot start and stop a consumer at the same time"
     }
+
+    // ===== Tests for Slashing =====
+    // create  a base state for the slashing tests.
+    // set consumer "receiver" to running and set a validator set with two validators as current
+    // and historical validator set on provider and consumer.
+    // Also, make it so the consumer state has received a vsc packet from the provider.
+    pure val validatorSet = Map(
+        "validator" -> 5,
+        "validator2" -> 5
+    )
+    pure val vscPacket = {
+        id: 0,
+        validatorSet: validatorSet,
+        sendingTime: 0,
+        timeoutTime: 1,
+        downtimeSlashAcks: List()
+    }
+    pure val SlashingTestState = 
+        GetEmptyProtocolState.with(
+            "providerState", GetEmptyProtocolState.providerState.with(
+                "chainState", GetEmptyProtocolState.providerState.chainState.with(
+                    "currentValidatorPowers", validatorSet
+                ).with(
+                    "votingPowerHistory", List(validatorSet)
+                )
+            ).with(
+                "consumerStatus", Map(
+                    "receiver" -> RUNNING
+                )
+            )
+        ).with(
+            "consumerStates", GetEmptyProtocolState.consumerStates.put(
+                "receiver", GetEmptyConsumerState.with(
+                    "chainState", GetEmptyProtocolState.providerState.chainState.with(
+                        "currentValidatorPowers", validatorSet
+                    ).with(
+                        "votingPowerHistory", List(validatorSet)
+                    )
+                ).with(
+                    "receivedVscPackets", List(vscPacket)
+                )
+            )
+        )
+
+    // ensure that sending a slash request for a double-sign infraction does not put outstandingDowntime in the state
+    run DoubleSignSlashRequestNoOutstandingDowntimeTest =
+    {
+        val result = SlashingTestState.sendSlashRequest(
+            "receiver",
+            "validator",
+            0,
+            false
+        )
+        not(result.hasError()) and
+        // should not have outstanding downtime, since the slash is for double-signing
+        result.newState.consumerStates.get("receiver").outstandingDowntime.size() == 0
+    }
 }


### PR DESCRIPTION
## Description

Closes: MBT test failure in https://github.com/cosmos/interchain-security/actions/runs/8472508023/job/23214757156?pr=1740
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

The issue occurred if there was first a double-sign slash request and then a downtime slash request for the same node.
In the model, I mistakenly always put outstandingDowntime for the node to true, so the downtime slash request was not sent.

This PR fixes this and adds a test for the issue.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [x] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
