### PR TITLE
ci: fix publishing docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,7 +13,6 @@ on:
   push:
     branches:
       - 'main'
-      - 'release/**'
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+" # Push events matching tag versions as v3.0.0
       - "v[0-9]+.[0-9]+.[0-9]+-lsm" # Push events matching '-lsm' postfix tags
@@ -45,7 +44,7 @@ jobs:
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@e1523de7571e31dbe865fd2e80c5c7c23ae71eb4 #v3.4.0
         with:
-          cosign-release: 'v2.1.1'
+          cosign-release: 'v2.2.3'
 
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache


### PR DESCRIPTION
## Description

Closes: #XXXX

Image signing failed due to change of cosign changes [TUF Trust Root and client](https://blog.sigstore.dev/tuf-root-update/)

```
Error: signing [ghcr.io/cosmos/interchain-security:latest@sha256:56298a96ff435bdda4b3a490bc74c7f936934fe7348708635e0210a76c3b713a]: 
getting signer: getting key from Fulcio: 
getting CTFE public keys: updating local metadata and targets: error updating to TUF remote mirror: invalid key
```

Changing to client version >= v2.2.0 fixes signing error
Tested on fork

Also fixing: 
builds triggered on commits targeting release/** branches which were failing due to missing tag

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
