### PR TITLE
fix!: introduce v4 provider migration code

### DIFF
--- a/x/ccv/provider/migrations/migrator.go
+++ b/x/ccv/provider/migrations/migrator.go
@@ -6,6 +6,7 @@ import (
 
 	providerkeeper "github.com/cosmos/interchain-security/v4/x/ccv/provider/keeper"
 	v3 "github.com/cosmos/interchain-security/v4/x/ccv/provider/migrations/v3"
+	v4 "github.com/cosmos/interchain-security/v4/x/ccv/provider/migrations/v4"
 )
 
 // Migrator is a struct for handling in-place store migrations.
@@ -29,6 +30,12 @@ func (m Migrator) Migrate1to2(ctx sdktypes.Context) error {
 
 // Migrate2to3 migrates x/ccvprovider state from consensus version 2 to 3.
 func (m Migrator) Migrate2to3(ctx sdktypes.Context) error {
-	v3.MigrateParams(ctx, m.paramSpace)
 	return v3.MigrateQueuedPackets(ctx, m.providerKeeper)
+}
+
+// Migrate3to4 migrates x/ccvprovider state from consensus version 3 to 4.
+// The migration consists of provider chain params additions.
+func (m Migrator) Migrate3to4(ctx sdktypes.Context) error {
+	v4.MigrateParams(ctx, m.paramSpace)
+	return nil
 }

--- a/x/ccv/provider/migrations/v3/migration_test.go
+++ b/x/ccv/provider/migrations/v3/migration_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	testutil "github.com/cosmos/interchain-security/v4/testutil/keeper"
-	providertypes "github.com/cosmos/interchain-security/v4/x/ccv/provider/types"
 )
 
 func TestMigrate2To3(t *testing.T) {
@@ -115,21 +114,4 @@ func TestMigrate2To3(t *testing.T) {
 		_, found := providerKeeper.GetVscSendTimestamp(ctx, "chain-3", data.ValsetUpdateId)
 		require.False(t, found)
 	}
-}
-
-func TestMigrateParams(t *testing.T) {
-	inMemParams := testutil.NewInMemKeeperParams(t)
-	_, ctx, ctrl, _ := testutil.GetProviderKeeperAndCtx(t, inMemParams)
-	defer ctrl.Finish()
-
-	// initially blocks per epoch param does not exist
-	require.False(t, inMemParams.ParamsSubspace.Has(ctx, providertypes.KeyBlocksPerEpoch))
-
-	MigrateParams(ctx, *inMemParams.ParamsSubspace)
-
-	// after migration, blocks per epoch param should exist and be equal to default
-	require.True(t, inMemParams.ParamsSubspace.Has(ctx, providertypes.KeyBlocksPerEpoch))
-	var blocksPerEpochParam int64
-	inMemParams.ParamsSubspace.Get(ctx, providertypes.KeyBlocksPerEpoch, &blocksPerEpochParam)
-	require.Equal(t, providertypes.DefaultBlocksPerEpoch, blocksPerEpochParam)
 }

--- a/x/ccv/provider/migrations/v3/migrations.go
+++ b/x/ccv/provider/migrations/v3/migrations.go
@@ -5,9 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	providerkeeper "github.com/cosmos/interchain-security/v4/x/ccv/provider/keeper"
-	providertypes "github.com/cosmos/interchain-security/v4/x/ccv/provider/types"
 )
 
 // MigrateQueuedPackets processes all queued packet data for all consumer chains that were stored
@@ -24,13 +22,4 @@ func MigrateQueuedPackets(ctx sdk.Context, k providerkeeper.Keeper) error {
 		k.LegacyDeleteThrottledPacketDataForConsumer(ctx, consumer.ChainId) //nolint:staticcheck //  SA1019: function used for migration
 	}
 	return nil
-}
-
-func MigrateParams(ctx sdk.Context, paramsSubspace paramtypes.Subspace) {
-	if paramsSubspace.HasKeyTable() {
-		paramsSubspace.Set(ctx, providertypes.KeyBlocksPerEpoch, providertypes.DefaultBlocksPerEpoch)
-	} else {
-		paramsSubspace.WithKeyTable(providertypes.ParamKeyTable())
-		paramsSubspace.Set(ctx, providertypes.KeyBlocksPerEpoch, providertypes.DefaultBlocksPerEpoch)
-	}
 }

--- a/x/ccv/provider/migrations/v4/migration_test.go
+++ b/x/ccv/provider/migrations/v4/migration_test.go
@@ -1,0 +1,27 @@
+package v4
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	testutil "github.com/cosmos/interchain-security/v4/testutil/keeper"
+	providertypes "github.com/cosmos/interchain-security/v4/x/ccv/provider/types"
+)
+
+func TestMigrateParams(t *testing.T) {
+	inMemParams := testutil.NewInMemKeeperParams(t)
+	_, ctx, ctrl, _ := testutil.GetProviderKeeperAndCtx(t, inMemParams)
+	defer ctrl.Finish()
+
+	// initially blocks per epoch param does not exist
+	require.False(t, inMemParams.ParamsSubspace.Has(ctx, providertypes.KeyBlocksPerEpoch))
+
+	MigrateParams(ctx, *inMemParams.ParamsSubspace)
+
+	// after migration, blocks per epoch param should exist and be equal to default
+	require.True(t, inMemParams.ParamsSubspace.Has(ctx, providertypes.KeyBlocksPerEpoch))
+	var blocksPerEpochParam int64
+	inMemParams.ParamsSubspace.Get(ctx, providertypes.KeyBlocksPerEpoch, &blocksPerEpochParam)
+	require.Equal(t, providertypes.DefaultBlocksPerEpoch, blocksPerEpochParam)
+}

--- a/x/ccv/provider/migrations/v4/migrations.go
+++ b/x/ccv/provider/migrations/v4/migrations.go
@@ -1,0 +1,18 @@
+package v4
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	providertypes "github.com/cosmos/interchain-security/v4/x/ccv/provider/types"
+)
+
+// MigrateParams adds missing provider chain params to the param store.
+func MigrateParams(ctx sdk.Context, paramsSubspace paramtypes.Subspace) {
+	if paramsSubspace.HasKeyTable() {
+		paramsSubspace.Set(ctx, providertypes.KeyBlocksPerEpoch, providertypes.DefaultBlocksPerEpoch)
+	} else {
+		paramsSubspace.WithKeyTable(providertypes.ParamKeyTable())
+		paramsSubspace.Set(ctx, providertypes.KeyBlocksPerEpoch, providertypes.DefaultBlocksPerEpoch)
+	}
+}

--- a/x/ccv/provider/module.go
+++ b/x/ccv/provider/module.go
@@ -134,7 +134,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 3 }
+func (AppModule) ConsensusVersion() uint64 { return 4 }
 
 // BeginBlock implements the AppModule interface
 func (am AppModule) BeginBlock(ctx sdk.Context, req abci.RequestBeginBlock) {


### PR DESCRIPTION
Epochs code changes the paramaters store, so the new parameter needs to be added to the store via a migration.

Had v4.0.0 and v4.1.0 stayed the same consensus version, provider chains using v4.0.0 would panic when migrating to v4.1.0 because of the missing migration.

To mitigate this issue provider consensus version got bumped to `4` and the migration code was refactored to introduce the `v4` migration.
