### PR TITLE
fix!: return a SlashAck even if the validator is not a consumer validator

### DIFF
--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -405,7 +405,8 @@ func (k Keeper) HandleSlashPacket(ctx sdk.Context, chainID string, data ccv.Slas
 	if !k.IsConsumerValidator(ctx, chainID, providerConsAddr) {
 		k.Logger(ctx).Error("cannot jail validator %s that does not belong to consumer %s valset",
 			providerConsAddr.String(), chainID)
-		// drop packet
+		// drop packet but return a slash ack so that the consumer can send another slash packet
+		k.AppendSlashAck(ctx, chainID, consumerConsAddr.String())
 		return
 	}
 


### PR DESCRIPTION
## Description

**Problem**
If the provider receives a slash packet from a consumer chain for a validator `V` and `V` is not a `ConsumerValidator`, then we simply return without queueing a `SlackAck` to send back to the consumer. This could lead to having a validator that is not validating a consumer chain but the validator is not being slashed.

To see this, think of the following scenario where during epoch 0 we have validators `V0`, `V1`, and `V2` as `ConsumerValidator`s, then during epoch 1 `V0` is not a `ConsumerValidator` anymore and then `V0` is a `ConsumerValidator` during epoch 2.
<img width="1031" alt="scenario" src="https://github.com/cosmos/interchain-security/assets/8606729/82158f04-0946-4535-bae4-b1a0b7e4fe95">
Now assume, that during epoch 1, the provider receives a slash packet to slash `V0`. This could happen if the `VSCPacket` that was sent at the end of epoch 0 has not yet reached the consumer chain. Because `V0` is not currently a `ConsumerValidator`, the provider would not append a `SlashAck`. Now consider that `V0` is again a `ConsumerValidator` at epoch 2 and `V0` is down on the consumer chain and has to be slashed on the provider. Because the [outstanding downtime](https://github.com/cosmos/interchain-security/blob/v4.0.0/x/ccv/consumer/keeper/relay.go#L149) has not been reset, the consumer chain would not send a slash packet to the provider. So, now, we are in a situation where `V0` is not validating but cannot be slashed.

**Solution**
Append a `SlashAck` to be sent back to the consumer.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] Added `!` to the type prefix if the change is [state-machine breaking](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes)
* [x] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
* [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] Provided a link to the relevant issue or specification
* [ ] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/00-intro.md)
* [ ] Included the necessary unit and integration [tests](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry to `CHANGELOG.md`
* [ ] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [x] Confirmed all CI checks have passed
* [ ] If this PR is library API breaking, bump the go.mod version string of the repo, and follow through on a new major release

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` the type prefix if the change is state-machine breaking
* [ ] confirmed this PR does not introduce changes requiring state migrations, OR confirmed migration code has been added to consumer and/or provider modules
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
