### PR TITLE
fix!: register provider v3 to v4 migration handler

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,7 +2,7 @@
 
 This guide provides instructions for upgrading to specific versions of Replicated Security.
 
-## [v4.1.x](https://github.com/cosmos/interchain-security/releases/tag/v4.1.0-rc1) and [v4.1.x-lsm](https://github.com/cosmos/interchain-security/releases/tag/v4.1.0-lsm-rc1)
+## [v4.1.x](https://github.com/cosmos/interchain-security/releases/tag/v4.1.0-rc2) and [v4.1.x-lsm](https://github.com/cosmos/interchain-security/releases/tag/v4.1.0-lsm-rc2)
 
 ### Provider
 

--- a/x/ccv/provider/module.go
+++ b/x/ccv/provider/module.go
@@ -112,6 +112,9 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	if err := cfg.RegisterMigration(providertypes.ModuleName, 2, m.Migrate2to3); err != nil {
 		panic(fmt.Sprintf("failed to register migrator for %s: %s", providertypes.ModuleName, err))
 	}
+	if err := cfg.RegisterMigration(providertypes.ModuleName, 3, m.Migrate3to4); err != nil {
+		panic(fmt.Sprintf("failed to register migrator for %s: %s", providertypes.ModuleName, err))
+	}
 }
 
 // InitGenesis performs genesis initialization for the provider module. It returns no validator updates.


### PR DESCRIPTION
This code registers a migration handler that was missing in https://github.com/cosmos/interchain-security/pull/1762.

This was discovered during upgrade testing.