### PR TITLE
fix: Validate consumer commission rate against minimal rate

### DIFF
--- a/testutil/keeper/mocks.go
+++ b/testutil/keeper/mocks.go
@@ -329,6 +329,20 @@ func (mr *MockStakingKeeperMockRecorder) MaxValidators(ctx interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MaxValidators", reflect.TypeOf((*MockStakingKeeper)(nil).MaxValidators), ctx)
 }
 
+// MinCommissionRate mocks base method.
+func (m *MockStakingKeeper) MinCommissionRate(ctx types0.Context) math.LegacyDec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MinCommissionRate", ctx)
+	ret0, _ := ret[0].(math.LegacyDec)
+	return ret0
+}
+
+// MinCommissionRate indicates an expected call of MinCommissionRate.
+func (mr *MockStakingKeeperMockRecorder) MinCommissionRate(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MinCommissionRate", reflect.TypeOf((*MockStakingKeeper)(nil).MinCommissionRate), ctx)
+}
+
 // PowerReduction mocks base method.
 func (m *MockStakingKeeper) PowerReduction(ctx types0.Context) math.Int {
 	m.ctrl.T.Helper()

--- a/x/ccv/provider/keeper/distribution.go
+++ b/x/ccv/provider/keeper/distribution.go
@@ -296,7 +296,7 @@ func (k Keeper) HandleSetConsumerCommissionRate(ctx sdk.Context, chainID string,
 			"commission rate %s is less than 0%%", commissionRate.String())
 	}
 
-	// validate agains tthe minRate
+	// validate agains the minRate
 	minRate := k.stakingKeeper.MinCommissionRate(ctx)
 	if commissionRate.LT(minRate) {
 		return errorsmod.Wrapf(

--- a/x/ccv/provider/keeper/distribution.go
+++ b/x/ccv/provider/keeper/distribution.go
@@ -280,23 +280,7 @@ func (k Keeper) HandleSetConsumerCommissionRate(ctx sdk.Context, chainID string,
 			"unknown consumer chain, with id: %s", chainID)
 	}
 
-	// validate the commission rate
-
-	// check it is not more than 100%
-	if commissionRate.GT(sdk.OneDec()) {
-		return errorsmod.Wrapf(
-			stakingtypes.ErrCommissionHuge,
-			"commission rate %s is greater than 100%%", commissionRate.String())
-	}
-
-	// check it is not less than 0%
-	if commissionRate.LT(sdk.ZeroDec()) {
-		return errorsmod.Wrapf(
-			stakingtypes.ErrCommissionNegative,
-			"commission rate %s is less than 0%%", commissionRate.String())
-	}
-
-	// validate agains the minRate
+	// validate against the minimum commission rate
 	minRate := k.stakingKeeper.MinCommissionRate(ctx)
 	if commissionRate.LT(minRate) {
 		return errorsmod.Wrapf(

--- a/x/ccv/types/expected_keepers.go
+++ b/x/ccv/types/expected_keepers.go
@@ -58,6 +58,7 @@ type StakingKeeper interface {
 	GetRedelegationsFromSrcValidator(ctx sdk.Context, valAddr sdk.ValAddress) (reds []stakingtypes.Redelegation)
 	GetUnbondingType(ctx sdk.Context, id uint64) (unbondingType stakingtypes.UnbondingType, found bool)
 	BlockValidatorUpdates(ctx sdk.Context) []abci.ValidatorUpdate
+	MinCommissionRate(ctx sdk.Context) math.LegacyDec
 }
 
 // SlashingKeeper defines the contract expected to perform ccv slashing


### PR DESCRIPTION
Validate the rate against the minimum when setting the consumer commission rate.
Note this means that the minimum for all consumers is simply the one on the provider.

I messed up the template, but it's a small PR anyways.