### PR TITLE
feat!: store the minimal power to be in the top N on EndBlock, instead of computing on-the-fly

### DIFF
--- a/x/ccv/provider/keeper/grpc_query.go
+++ b/x/ccv/provider/keeper/grpc_query.go
@@ -284,7 +284,10 @@ func (k Keeper) QueryConsumerChainsValidatorHasToValidate(goCtx context.Context,
 					return nil, status.Error(codes.InvalidArgument, "invalid provider address")
 				}
 				power := k.stakingKeeper.GetLastValidatorPower(ctx, val.GetOperator())
-				minPowerToOptIn := k.ComputeMinPowerToOptIn(ctx, chainID, k.stakingKeeper.GetLastValidators(ctx), topN)
+				minPowerToOptIn, found := k.GetMinimumPowerInTopN(ctx, chainID)
+				if !found {
+					return nil, status.Errorf(codes.InvalidArgument, "cannot find minimum power in top N for chain %v", chainID)
+				}
 
 				// Check if the validator's voting power is smaller
 				// than the minimum and hence not automatically opted in

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -1313,7 +1313,7 @@ func (k Keeper) SetMinimumPowerInTopN(
 	buf := make([]byte, 8)
 	binary.BigEndian.PutUint64(buf, uint64(power))
 
-	store.Set(types.TopNKey(chainID), buf)
+	store.Set(types.MinimumPowerInTopNKey(chainID), buf)
 }
 
 // GetMinimumPowerInTopN returns the minimum power required for a validator to be in the top N
@@ -1323,7 +1323,7 @@ func (k Keeper) GetMinimumPowerInTopN(
 	chainID string,
 ) (int64, bool) {
 	store := ctx.KVStore(k.storeKey)
-	buf := store.Get(types.TopNKey(chainID))
+	buf := store.Get(types.MinimumPowerInTopNKey(chainID))
 	if buf == nil {
 		return 0, false
 	}

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -1300,3 +1300,32 @@ func (k Keeper) DeleteConsumerCommissionRate(
 	store := ctx.KVStore(k.storeKey)
 	store.Delete(types.ConsumerCommissionRateKey(chainID, providerAddr))
 }
+
+// SetMinimumPowerInTopN sets the minimum power required for a validator to be in the top N
+// for a given consumer chain.
+func (k Keeper) SetMinimumPowerInTopN(
+	ctx sdk.Context,
+	chainID string,
+	power int64,
+) {
+	store := ctx.KVStore(k.storeKey)
+
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, uint64(power))
+
+	store.Set(types.TopNKey(chainID), buf)
+}
+
+// GetMinimumPowerInTopN returns the minimum power required for a validator to be in the top N
+// for a given consumer chain.
+func (k Keeper) GetMinimumPowerInTopN(
+	ctx sdk.Context,
+	chainID string,
+) (int64, bool) {
+	store := ctx.KVStore(k.storeKey)
+	buf := store.Get(types.TopNKey(chainID))
+	if buf == nil {
+		return 0, false
+	}
+	return int64(binary.BigEndian.Uint64(buf)), true
+}

--- a/x/ccv/provider/keeper/keeper_test.go
+++ b/x/ccv/provider/keeper/keeper_test.go
@@ -740,3 +740,24 @@ func TestConsumerCommissionRate(t *testing.T) {
 	_, found = providerKeeper.GetConsumerCommissionRate(ctx, "chainID", providerAddr2)
 	require.False(t, found)
 }
+
+func TestMinimumPowerInTopN(t *testing.T) {
+	k, ctx, _, _ := testkeeper.GetProviderKeeperAndCtx(t, testkeeper.NewInMemKeeperParams(t))
+
+	chainID := "testChain"
+	minPower := int64(1000)
+
+	// Set the minimum power in top N
+	k.SetMinimumPowerInTopN(ctx, chainID, minPower)
+
+	// Retrieve the minimum power in top N
+	gotMinPower, found := k.GetMinimumPowerInTopN(ctx, chainID)
+	require.True(t, found)
+	require.Equal(t, minPower, gotMinPower)
+
+	// Test when the chain ID does not exist
+	nonExistentChainID := "nonExistentChain"
+	nonExistentMinPower, found := k.GetMinimumPowerInTopN(ctx, nonExistentChainID)
+	require.False(t, found)
+	require.Equal(t, int64(0), nonExistentMinPower)
+}

--- a/x/ccv/provider/keeper/partial_set_security_test.go
+++ b/x/ccv/provider/keeper/partial_set_security_test.go
@@ -127,6 +127,11 @@ func TestHandleOptOutFromTopNChain(t *testing.T) {
 
 	mocks.MockStakingKeeper.EXPECT().GetLastValidators(ctx).Return([]stakingtypes.Validator{valA, valB, valC, valD}).AnyTimes()
 
+	// set the minimum power in the top N
+	// compute it
+	minPower := providerKeeper.ComputeMinPowerInTopN(ctx, chainID, []stakingtypes.Validator{valA, valB, valC, valD}, 50)
+	providerKeeper.SetMinimumPowerInTopN(ctx, chainID, minPower)
+
 	// opt in all validators
 	providerKeeper.SetOptedIn(ctx, chainID, types.NewProviderConsAddress(valAConsAddr))
 	providerKeeper.SetOptedIn(ctx, chainID, types.NewProviderConsAddress(valBConsAddr))

--- a/x/ccv/provider/keeper/partial_set_security_test.go
+++ b/x/ccv/provider/keeper/partial_set_security_test.go
@@ -274,19 +274,19 @@ func TestComputeMinPowerToOptIn(t *testing.T) {
 		createStakingValidator(ctx, mocks, 5, 6),
 	}
 
-	require.Equal(t, int64(1), providerKeeper.ComputeMinPowerToOptIn(ctx, "chainID", bondedValidators, 100))
-	require.Equal(t, int64(1), providerKeeper.ComputeMinPowerToOptIn(ctx, "chainID", bondedValidators, 97))
-	require.Equal(t, int64(3), providerKeeper.ComputeMinPowerToOptIn(ctx, "chainID", bondedValidators, 96))
-	require.Equal(t, int64(3), providerKeeper.ComputeMinPowerToOptIn(ctx, "chainID", bondedValidators, 85))
-	require.Equal(t, int64(5), providerKeeper.ComputeMinPowerToOptIn(ctx, "chainID", bondedValidators, 84))
-	require.Equal(t, int64(5), providerKeeper.ComputeMinPowerToOptIn(ctx, "chainID", bondedValidators, 65))
-	require.Equal(t, int64(6), providerKeeper.ComputeMinPowerToOptIn(ctx, "chainID", bondedValidators, 64))
-	require.Equal(t, int64(6), providerKeeper.ComputeMinPowerToOptIn(ctx, "chainID", bondedValidators, 41))
-	require.Equal(t, int64(10), providerKeeper.ComputeMinPowerToOptIn(ctx, "chainID", bondedValidators, 40))
-	require.Equal(t, int64(10), providerKeeper.ComputeMinPowerToOptIn(ctx, "chainID", bondedValidators, 1))
+	require.Equal(t, int64(1), providerKeeper.ComputeMinPowerInTopN(ctx, "chainID", bondedValidators, 100))
+	require.Equal(t, int64(1), providerKeeper.ComputeMinPowerInTopN(ctx, "chainID", bondedValidators, 97))
+	require.Equal(t, int64(3), providerKeeper.ComputeMinPowerInTopN(ctx, "chainID", bondedValidators, 96))
+	require.Equal(t, int64(3), providerKeeper.ComputeMinPowerInTopN(ctx, "chainID", bondedValidators, 85))
+	require.Equal(t, int64(5), providerKeeper.ComputeMinPowerInTopN(ctx, "chainID", bondedValidators, 84))
+	require.Equal(t, int64(5), providerKeeper.ComputeMinPowerInTopN(ctx, "chainID", bondedValidators, 65))
+	require.Equal(t, int64(6), providerKeeper.ComputeMinPowerInTopN(ctx, "chainID", bondedValidators, 64))
+	require.Equal(t, int64(6), providerKeeper.ComputeMinPowerInTopN(ctx, "chainID", bondedValidators, 41))
+	require.Equal(t, int64(10), providerKeeper.ComputeMinPowerInTopN(ctx, "chainID", bondedValidators, 40))
+	require.Equal(t, int64(10), providerKeeper.ComputeMinPowerInTopN(ctx, "chainID", bondedValidators, 1))
 
 	// exceptional case when we erroneously call with `topN == 0`
-	require.Equal(t, int64(math.MaxInt64), providerKeeper.ComputeMinPowerToOptIn(ctx, "chainID", bondedValidators, 0))
+	require.Equal(t, int64(math.MaxInt64), providerKeeper.ComputeMinPowerInTopN(ctx, "chainID", bondedValidators, 0))
 }
 
 // TestShouldConsiderOnlyOptIn returns true if `validator` is opted in, in `chainID.

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -279,8 +279,9 @@ func (k Keeper) MakeConsumerGenesis(
 
 	if prop.Top_N > 0 {
 		// in a Top-N chain, we automatically opt in all validators that belong to the top N
-		minPower := k.ComputeMinPowerToOptIn(ctx, chainID, bondedValidators, prop.Top_N)
+		minPower := k.ComputeMinPowerInTopN(ctx, chainID, bondedValidators, prop.Top_N)
 		k.OptInTopNValidators(ctx, chainID, bondedValidators, minPower)
+		k.SetMinimumPowerInTopN(ctx, chainID, minPower)
 	}
 
 	nextValidators := k.ComputeNextEpochConsumerValSet(ctx, chainID, bondedValidators,

--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -225,7 +225,14 @@ func (k Keeper) QueueVSCPackets(ctx sdk.Context) {
 
 		if topN, found := k.GetTopN(ctx, chain.ChainId); found && topN > 0 {
 			// in a Top-N chain, we automatically opt in all validators that belong to the top N
-			minPower := k.ComputeMinPowerToOptIn(ctx, chain.ChainId, bondedValidators, topN)
+
+			// compute the minimal power in the top N
+			minPower := k.ComputeMinPowerInTopN(ctx, chain.ChainId, bondedValidators, topN)
+
+			// set the minimal power of validators in the top N ˇin the store
+			k.SetMinimumPowerInTopN(ctx, chain.ChainId, minPower)
+
+			// opt in the validators
 			k.OptInTopNValidators(ctx, chain.ChainId, bondedValidators, minPower)
 		}
 

--- a/x/ccv/provider/migrations/vPSS/migrations.go
+++ b/x/ccv/provider/migrations/vPSS/migrations.go
@@ -3,19 +3,25 @@ package vPSS
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	providerkeeper "github.com/cosmos/interchain-security/v4/x/ccv/provider/keeper"
 )
 
 // This migration only takes already registered chains into account.
 // If a chain is in voting while the upgrade happens, this is not sufficient,
 // and a migration to rewrite the proposal is needed.
-func MigrateTopNForRegisteredChains(ctx sdk.Context, providerKeeper providerkeeper.Keeper) {
+func MigrateTopNForRegisteredChains(ctx sdk.Context, providerKeeper providerkeeper.Keeper, stakingKeeper stakingkeeper.Keeper) {
 	// get all consumer chains
 	registeredConsumerChains := providerKeeper.GetAllConsumerChains(ctx)
 
-	// Set the topN of each chain to 95
 	for _, chain := range registeredConsumerChains {
+		// Set the topN of each chain to 95
 		providerKeeper.SetTopN(ctx, chain.ChainId, 95)
+
+		// set the minimal power in the top N
+		bondedValidators := stakingKeeper.GetLastValidators(ctx)
+		minPower := providerKeeper.ComputeMinPowerInTopN(ctx, chain.ChainId, bondedValidators, 95)
+		providerKeeper.SetMinimumPowerInTopN(ctx, chain.ChainId, minPower)
 	}
 }
 

--- a/x/ccv/provider/migrations/vPSS/migrations.go
+++ b/x/ccv/provider/migrations/vPSS/migrations.go
@@ -3,25 +3,19 @@ package vPSS
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	stakingkeeper "github.com/cosmos/cosmos-sdk/x/staking/keeper"
 	providerkeeper "github.com/cosmos/interchain-security/v4/x/ccv/provider/keeper"
 )
 
 // This migration only takes already registered chains into account.
 // If a chain is in voting while the upgrade happens, this is not sufficient,
 // and a migration to rewrite the proposal is needed.
-func MigrateTopNForRegisteredChains(ctx sdk.Context, providerKeeper providerkeeper.Keeper, stakingKeeper stakingkeeper.Keeper) {
+func MigrateTopNForRegisteredChains(ctx sdk.Context, providerKeeper providerkeeper.Keeper) {
 	// get all consumer chains
 	registeredConsumerChains := providerKeeper.GetAllConsumerChains(ctx)
 
+	// Set the topN of each chain to 95
 	for _, chain := range registeredConsumerChains {
-		// Set the topN of each chain to 95
 		providerKeeper.SetTopN(ctx, chain.ChainId, 95)
-
-		// set the minimal power in the top N
-		bondedValidators := stakingKeeper.GetLastValidators(ctx)
-		minPower := providerKeeper.ComputeMinPowerInTopN(ctx, chain.ChainId, bondedValidators, 95)
-		providerKeeper.SetMinimumPowerInTopN(ctx, chain.ChainId, minPower)
 	}
 }
 

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -166,7 +166,7 @@ const (
 	// per validator per consumer chain
 	ConsumerCommissionRatePrefix
 
-	// ConsumerCommissionRateDenomPrefix is the byte prefix for storing the
+	// MinimumPowerInTopNBytePrefix is the byte prefix for storing the
 	// minimum power required to be in the top N per consumer chain.
 	MinimumPowerInTopNBytePrefix
 

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -166,6 +166,10 @@ const (
 	// per validator per consumer chain
 	ConsumerCommissionRatePrefix
 
+	// ConsumerCommissionRateDenomPrefix is the byte prefix for storing the
+	// minimum power required to be in the top N per consumer chain.
+	MinimumPowerInTopNBytePrefix
+
 	// NOTE: DO NOT ADD NEW BYTE PREFIXES HERE WITHOUT ADDING THEM TO getAllKeyPrefixes() IN keys_test.go
 )
 
@@ -562,6 +566,10 @@ func ConsumerCommissionRateKey(chainID string, providerAddr ProviderConsAddress)
 		chainID,
 		providerAddr.ToSdkConsAddr(),
 	)
+}
+
+func MinimumPowerInTopNKey(chainID string) []byte {
+	return ChainIdWithLenKey(MinimumPowerInTopNBytePrefix, chainID)
 }
 
 //

--- a/x/ccv/provider/types/keys_test.go
+++ b/x/ccv/provider/types/keys_test.go
@@ -61,6 +61,7 @@ func getAllKeyPrefixes() []byte {
 		providertypes.TopNBytePrefix,
 		providertypes.ConsumerRewardsAllocationBytePrefix,
 		providertypes.ConsumerCommissionRatePrefix,
+		providertypes.MinimumPowerInTopNBytePrefix,
 	}
 }
 


### PR DESCRIPTION
<!--
The production pull request template is for types feat, fix, or refactor.
-->

## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Compute the minimal power in the top N on EndBlock, when we compute it anyways for sending VSCPackets.

This should, at worst, delay the ability to opt out by an epoch
(intuitively, when someone is allowed to opt out not because their own power decreases, but because others powers increase, they would still compare against the old, stored MinPowerInTopN and not be allowed to opt out.
This would be solved after the epoch ends and the MinPowerInTopN is updated, however.)

NOTE: Needs a migration; the MInPowerToOptIn needs to be initialized during the migration

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] Added `!` to the type prefix if the change is [state-machine breaking](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes)
* [ ] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
* [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] Provided a link to the relevant issue or specification
* [ ] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/00-intro.md)
* [ ] Included the necessary unit and integration [tests](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry to `CHANGELOG.md`
* [ ] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [ ] Confirmed all CI checks have passed
* [ ] If this PR is library API breaking, bump the go.mod version string of the repo, and follow through on a new major release

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` the type prefix if the change is state-machine breaking
* [ ] confirmed this PR does not introduce changes requiring state migrations, OR confirmed migration code has been added to consumer and/or provider modules
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
