### PR TITLE
docs: update docs deployment

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -66,8 +66,8 @@ The script switches branches while building the versioned docs - **please note t
 
 # Legacy documentation
 
-`legacy-docs-page` [branch](https://github.com/cosmos/interchain-security/tree/legacy-docs-page) contains documentation for versions `<= v4.0.0`. These versions were built using docusaurus `v2.4.0` which is not compatible with docusaurus `v3.x` used at the time of writing. It was not feasible to port the legacy docs from `v2.4.0` because `v3.x` is not compatible with it and it required changing all release branches.
+`legacy-docs-page` [branch](https://github.com/cosmos/interchain-security/tree/legacy-docs-page) contains documentation for versions `<= v4.0.0`. These versions were built using docusaurus `v2.4.0` which is not compatible with docusaurus `v3.x` used at the time of writing. It was not feasible to port the legacy docs from `v2.4.0` because `v3.x` is not compatible with it and it required changing all release branches and cutting patch releases.
 
-The `legacy` directory on `legacy-docs-page` was created manually, by modifying `docusaurus.config.js` and `versions.json` on `https://github.com/cosmos/interchain-security/releases/v3.3.1-lsm` and generating the static pages manually using `npm run build`.
+The `./docs/legacy` directory on `legacy-docs-page` was created manually, by modifying `docusaurus.config.js` and `versions.json` on `https://github.com/cosmos/interchain-security/releases/v3.3.1-lsm` and generating the static pages manually using `npm run build`.
 
-The `legacy` directory gets included into the rest of the documentation using a simple `cp` command during the deploy process using the [build_deploy.sh](./build_deploy.sh) script. It is **not** included during local builds.
+The `./docs/legacy` directory gets included into the rest of the documentation using a simple `cp` command during the deploy process using the [build_deploy.sh](./build_deploy.sh) script. It is **not** included during local builds.

--- a/docs/build_deploy.sh
+++ b/docs/build_deploy.sh
@@ -1,9 +1,12 @@
 #!/bin/sh
 
+# build versioned docs prepared by sync_versions.sh
 echo "building docusaurus main docs"
 npm ci && npm run build
-# copy legacy docs to build folder
-git fetch origin legacy-docs-page
+
+# copy "legacy" docs directory into the final build directory
+# the directory is in "docs/legacy" of the source branch (legacy-docs-page)
+# the build environment must be in "./docs" for this to work as expected
 git checkout origin/legacy-docs-page -- legacy
 cp -r ./legacy ./build/
 mv build ~/output


### PR DESCRIPTION
Fixes issues in docs build:

```shell
git fetch origin legacy-docs-page
git checkout origin/legacy-docs-page -- legacy

# output
 * branch              legacy-docs-page -> FETCH_HEAD
error: pathspec 'legacy' did not match any file(s) known to git
cp: cannot stat './legacy': No such file or directory
```

The [legacy docs branch](https://github.com/cosmos/interchain-security/tree/legacy-docs-page) was changed to have `./docs/legacy` tree structure instead of just `./legacy`.

This was needed because the working dir of the deploy scripts is `./interchain-security/docs` instead of just `./interchain-security`
