### PR TITLE
test: add E2E test for power-shaping features

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -181,6 +181,102 @@ jobs:
           go-version: "1.21" # The Go version to download (if necessary) and use.
       - name: E2E consumer-double-downtime tests
         run: go run ./tests/e2e/... --tc consumer-double-downtime
+  partial-set-security-opt-in-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - uses: actions/checkout@v4
+      - name: Checkout LFS objects
+        run: git lfs checkout
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21" # The Go version to download (if necessary) and use.
+      - name: E2E partial set security opt-in chain
+        run: go run ./tests/e2e/... --tc partial-set-security-opt-in
+  partial-set-security-top-n-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - uses: actions/checkout@v4
+      - name: Checkout LFS objects
+        run: git lfs checkout
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21" # The Go version to download (if necessary) and use.
+      - name: E2E partial set security Top N chain
+        run: go run ./tests/e2e/... --tc partial-set-security-top-n
+  partial-set-security-validator-set-cap-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - uses: actions/checkout@v4
+      - name: Checkout LFS objects
+        run: git lfs checkout
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21" # The Go version to download (if necessary) and use.
+      - name: E2E partial set security validator-set cap
+        run: go run ./tests/e2e/... --tc partial-set-security-validator-set-cap
+  partial-set-security-validators-power-cap-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - uses: actions/checkout@v4
+      - name: Checkout LFS objects
+        run: git lfs checkout
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21" # The Go version to download (if necessary) and use.
+      - name: E2E partial set security validators-power cap
+        run: go run ./tests/e2e/... --tc partial-set-security-validators-power-cap
+  partial-set-security-validators-allowlisted-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - uses: actions/checkout@v4
+      - name: Checkout LFS objects
+        run: git lfs checkout
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21" # The Go version to download (if necessary) and use.
+      - name: E2E partial set security allowlist
+        run: go run ./tests/e2e/... --tc partial-set-security-validators-allowlisted
+  partial-set-security-validators-denylisted-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+      - uses: actions/checkout@v4
+      - name: Checkout LFS objects
+        run: git lfs checkout
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21" # The Go version to download (if necessary) and use.
+      - name: E2E partial set security denylist
+        run: go run ./tests/e2e/... --tc partial-set-security-validators-denylisted
 
   nightly-test-fail:
     needs:
@@ -193,6 +289,12 @@ jobs:
       - consumer-misbehaviour-test
       - consumer-double-sign-test
       - consumer-double-downtime-test
+      - partial-set-security-opt-in-test
+      - partial-set-security-top-n-test
+      - partial-set-security-validator-set-cap-test
+      - partial-set-security-validators-power-cap-test
+      - partial-set-security-validators-allowlisted-test
+      - partial-set-security-validators-denylisted-test
     if: ${{ failure() }}
     runs-on: ubuntu-latest
     steps:

--- a/tests/e2e/actions.go
+++ b/tests/e2e/actions.go
@@ -261,6 +261,10 @@ type SubmitConsumerAdditionProposalAction struct {
 	InitialHeight       clienttypes.Height
 	DistributionChannel string
 	TopN                uint32
+	ValidatorsPowerCap  uint32
+	ValidatorSetCap     uint32
+	Allowlist           []string
+	Denylist            []string
 }
 
 func (tr TestConfig) submitConsumerAdditionProposal(
@@ -287,6 +291,10 @@ func (tr TestConfig) submitConsumerAdditionProposal(
 		Deposit:                           fmt.Sprint(action.Deposit) + `stake`,
 		DistributionTransmissionChannel:   action.DistributionChannel,
 		TopN:                              action.TopN,
+		ValidatorsPowerCap:                action.ValidatorsPowerCap,
+		ValidatorSetCap:                   action.ValidatorSetCap,
+		Allowlist:                         action.Allowlist,
+		Denylist:                          action.Denylist,
 	}
 
 	bz, err := json.Marshal(prop)

--- a/tests/e2e/main.go
+++ b/tests/e2e/main.go
@@ -168,6 +168,30 @@ var stepChoices = map[string]StepChoice{
 		description: "test partial set security for a Top-N chain",
 		testConfig:  DefaultTestCfg,
 	},
+	"partial-set-security-validator-set-cap": {
+		name:        "partial-set-security-validator-set-cap",
+		steps:       stepsValidatorSetCappedChain(),
+		description: "test partial set security for an Opt-In chain that is validator-set capped",
+		testConfig:  DefaultTestCfg,
+	},
+	"partial-set-security-validators-power-cap": {
+		name:        "partial-set-security-validators-power-cap",
+		steps:       stepsValidatorsPowerCappedChain(),
+		description: "test partial set security for an Opt-In chain that has its validators' power capped",
+		testConfig:  DefaultTestCfg,
+	},
+	"partial-set-security-validators-allowlisted": {
+		name:        "partial-set-security-validators-allowlisted",
+		steps:       stepsValidatorsAllowlistedChain(),
+		description: "test partial set security for an Opt-In chain that has some validators allowlisted",
+		testConfig:  DefaultTestCfg,
+	},
+	"partial-set-security-validators-denylisted": {
+		name:        "partial-set-security-validators-denylisted",
+		steps:       stepsValidatorsDenylistedChain(),
+		description: "test partial set security for an Opt-In chain that has a validator denylisted",
+		testConfig:  DefaultTestCfg,
+	},
 }
 
 func getTestCaseUsageString() string {
@@ -254,6 +278,8 @@ func getTestCases(selectedPredefinedTests, selectedTestFiles TestSet, providerVe
 			"democracy-reward", "democracy",
 			"slash-throttle", "consumer-double-sign", "consumer-misbehaviour",
 			"consumer-double-downtime", "partial-set-security-opt-in", "partial-set-security-top-n",
+			"partial-set-security-validator-set-cap", "partial-set-security-validators-power-cap",
+			"partial-set-security-validators-allowlisted", "partial-set-security-validators-denylisted",
 		}
 		if includeMultiConsumer != nil && *includeMultiConsumer {
 			selectedPredefinedTests = append(selectedPredefinedTests, "multiconsumer")

--- a/tests/e2e/steps_partial_set_security.go
+++ b/tests/e2e/steps_partial_set_security.go
@@ -1000,3 +1000,895 @@ func stepsTopNChain() []Step {
 
 	return s
 }
+
+// stepsValidatorSetCappedChain starts a provider chain and an Opt-In chain that is validator-set capped
+func stepsValidatorSetCappedChain() []Step {
+	s := []Step{
+		{
+			Action: StartChainAction{
+				Chain: ChainID("provi"),
+				Validators: []StartChainValidator{
+					{Id: ValidatorID("alice"), Stake: 100000000, Allocation: 10000000000},
+					{Id: ValidatorID("bob"), Stake: 200000000, Allocation: 10000000000},
+					{Id: ValidatorID("carol"), Stake: 300000000, Allocation: 10000000000},
+				},
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 100,
+						ValidatorID("bob"):   200,
+						ValidatorID("carol"): 300,
+					},
+				},
+			},
+		},
+		{
+			Action: SubmitConsumerAdditionProposalAction{
+				Chain:         ChainID("provi"),
+				From:          ValidatorID("alice"),
+				Deposit:       10000001,
+				ConsumerChain: ChainID("consu"),
+				SpawnTime:     0,
+				InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+				TopN:          0,
+				// we can have at most 2 validators validating the consumer chain
+				ValidatorSetCap: 2,
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					Proposals: &map[uint]Proposal{
+						1: ConsumerAdditionProposal{
+							Deposit:       10000001,
+							Chain:         ChainID("consu"),
+							SpawnTime:     0,
+							InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+							Status:        "PROPOSAL_STATUS_VOTING_PERIOD",
+						},
+					},
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {},
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+		// Οpt in "alice", "bob", and "carol." Note, that "alice" and "bob" use the provider's public key
+		// (see `UseConsumerKey` is set to `false` in `getDefaultValidators`) and hence do not need a consumer-key assigment.
+		{
+			Action: OptInAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("alice"),
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						// chain is not running yet and hence noone has to validate
+						ValidatorID("alice"): {},
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+		{
+			Action: OptInAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("bob"),
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {},
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+		{
+			Action: OptInAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("carol"),
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {},
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+		{
+			// assign the consumer key "carol" is using on the consumer chain to be the one "carol" uses when opting in
+			Action: AssignConsumerPubKeyAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("carol"),
+				// reconfigure the node -> validator was using provider key
+				// until this point -> key matches config.consumerValPubKey for "carol"
+				ConsumerPubkey:  getDefaultValidators()[ValidatorID("carol")].ConsumerValPubKey,
+				ReconfigureNode: true,
+			},
+			State: State{},
+		},
+		{
+			Action: VoteGovProposalAction{
+				Chain:      ChainID("provi"),
+				From:       []ValidatorID{ValidatorID("alice"), ValidatorID("bob")},
+				Vote:       []string{"yes", "yes"},
+				PropNumber: 1,
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					Proposals: &map[uint]Proposal{
+						1: ConsumerAdditionProposal{
+							Deposit:       10000001,
+							Chain:         ChainID("consu"),
+							SpawnTime:     0,
+							InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+							Status:        "PROPOSAL_STATUS_PASSED",
+						},
+					},
+				},
+			},
+		},
+		{
+			Action: StartConsumerChainAction{
+				ConsumerChain: ChainID("consu"),
+				ProviderChain: ChainID("provi"),
+				Validators: []StartChainValidator{
+					{Id: ValidatorID("alice"), Stake: 100000000, Allocation: 10000000000},
+					{Id: ValidatorID("bob"), Stake: 200000000, Allocation: 10000000000},
+					{Id: ValidatorID("carol"), Stake: 300000000, Allocation: 10000000000},
+				},
+				// For consumers that're launching with the provider being on an earlier version
+				// of ICS before the soft opt-out threshold was introduced, we need to set the
+				// soft opt-out threshold to 0.05 in the consumer genesis to ensure that the
+				// consumer binary doesn't panic. Sdk requires that all params are set to valid
+				// values from the genesis file.
+				GenesisChanges: ".app_state.ccvconsumer.params.soft_opt_out_threshold = \"0.05\"",
+			},
+			State: State{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						// alice does not validate because the consumer chain is validator-set capped to 2 validators and
+						// bob and carol have more power than alice
+						ValidatorID("alice"): 0,
+						ValidatorID("bob"):   200,
+						ValidatorID("carol"): 300,
+					},
+				},
+			},
+		},
+		{
+			Action: AddIbcConnectionAction{
+				ChainA:  ChainID("consu"),
+				ChainB:  ChainID("provi"),
+				ClientA: 0,
+				ClientB: 0,
+			},
+			State: State{},
+		},
+		{
+			Action: AddIbcChannelAction{
+				ChainA:      ChainID("consu"),
+				ChainB:      ChainID("provi"),
+				ConnectionA: 0,
+				PortA:       "consumer",
+				PortB:       "provider",
+				Order:       "ordered",
+			},
+			State: State{},
+		},
+		{
+			Action: OptOutAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("carol"),
+			},
+			State: State{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 0,
+						ValidatorID("bob"):   200,
+						// "carol" has opted out, but the VSCPacket capturing the opt-out was not relayed yet
+						ValidatorID("carol"): 300,
+					},
+				},
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {"consu"},
+						ValidatorID("bob"):   {"consu"},
+						ValidatorID("carol"): {}, // "carol" does not have to validate anymore because it opted out
+					},
+				},
+			},
+		},
+		{
+			Action: RelayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID("consu"),
+				Port:    "provider",
+				Channel: 0,
+			},
+			State: State{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						// "alice" is now validating the consumer chain as well because the chain is capped to 2 validators
+						// and "carol" just opted out
+						ValidatorID("alice"): 100,
+						ValidatorID("bob"):   200,
+						// "carol" has now opted out
+						ValidatorID("carol"): 0,
+					},
+				},
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {"consu"},
+						ValidatorID("bob"):   {"consu"},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+	}
+
+	return s
+}
+
+// stepsValidatorsPowerCappedChain starts a provider chain and an Opt-In chain that is validators-power capped
+func stepsValidatorsPowerCappedChain() []Step {
+	s := []Step{
+		{
+			Action: StartChainAction{
+				Chain: ChainID("provi"),
+				Validators: []StartChainValidator{
+					{Id: ValidatorID("alice"), Stake: 100000000, Allocation: 10000000000},
+					{Id: ValidatorID("bob"), Stake: 200000000, Allocation: 10000000000},
+					{Id: ValidatorID("carol"), Stake: 300000000, Allocation: 10000000000},
+				},
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 100,
+						ValidatorID("bob"):   200,
+						ValidatorID("carol"): 300,
+					},
+				},
+			},
+		},
+		{
+			Action: SubmitConsumerAdditionProposalAction{
+				Chain:         ChainID("provi"),
+				From:          ValidatorID("alice"),
+				Deposit:       10000001,
+				ConsumerChain: ChainID("consu"),
+				SpawnTime:     0,
+				InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+				TopN:          0,
+				// Set the power cap to 34%. No validator can have more than 34% of the voting power on the consumer chain
+				ValidatorsPowerCap: 34,
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					Proposals: &map[uint]Proposal{
+						1: ConsumerAdditionProposal{
+							Deposit:       10000001,
+							Chain:         ChainID("consu"),
+							SpawnTime:     0,
+							InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+							Status:        "PROPOSAL_STATUS_VOTING_PERIOD",
+						},
+					},
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {},
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+		// Οpt in "alice", "bob", and "carol." Note, that "alice" and "bob" use the provider's public key
+		// (see `UseConsumerKey` is set to `false` in `getDefaultValidators`) and hence do not need a consumer-key assigment.
+		{
+			Action: OptInAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("alice"),
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {}, // chain is not running yet
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+		{
+			Action: OptInAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("bob"),
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {},
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+		{
+			Action: OptInAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("carol"),
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {},
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+		{
+			// assign the consumer key "carol" is using on the consumer chain to be the one "carol" uses when opting in
+			Action: AssignConsumerPubKeyAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("carol"),
+				// reconfigure the node -> validator was using provider key
+				// until this point -> key matches config.consumerValPubKey for "carol"
+				ConsumerPubkey:  getDefaultValidators()[ValidatorID("carol")].ConsumerValPubKey,
+				ReconfigureNode: true,
+			},
+			State: State{},
+		},
+		{
+			Action: VoteGovProposalAction{
+				Chain:      ChainID("provi"),
+				From:       []ValidatorID{ValidatorID("alice"), ValidatorID("bob")},
+				Vote:       []string{"yes", "yes"},
+				PropNumber: 1,
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					Proposals: &map[uint]Proposal{
+						1: ConsumerAdditionProposal{
+							Deposit:       10000001,
+							Chain:         ChainID("consu"),
+							SpawnTime:     0,
+							InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+							Status:        "PROPOSAL_STATUS_PASSED",
+						},
+					},
+				},
+			},
+		},
+		{
+			Action: StartConsumerChainAction{
+				ConsumerChain: ChainID("consu"),
+				ProviderChain: ChainID("provi"),
+				Validators: []StartChainValidator{
+					{Id: ValidatorID("alice"), Stake: 100000000, Allocation: 10000000000},
+					{Id: ValidatorID("bob"), Stake: 200000000, Allocation: 10000000000},
+					{Id: ValidatorID("carol"), Stake: 300000000, Allocation: 10000000000},
+				},
+				// For consumers that're launching with the provider being on an earlier version
+				// of ICS before the soft opt-out threshold was introduced, we need to set the
+				// soft opt-out threshold to 0.05 in the consumer genesis to ensure that the
+				// consumer binary doesn't panic. Sdk requires that all params are set to valid
+				// values from the genesis file.
+				GenesisChanges: ".app_state.ccvconsumer.params.soft_opt_out_threshold = \"0.05\"",
+			},
+			State: State{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						// the powers of the validators on the consumer chain are different from the provider chain
+						// because the consumer chain is power capped. Note that the total power is 600 (= 194 + 203 + 203)
+						// and 203 / 600.0 = 0.338 < 34% that is the power cap.
+						ValidatorID("alice"): 194,
+						ValidatorID("bob"):   203,
+						ValidatorID("carol"): 203,
+					},
+				},
+			},
+		},
+		{
+			Action: AddIbcConnectionAction{
+				ChainA:  ChainID("consu"),
+				ChainB:  ChainID("provi"),
+				ClientA: 0,
+				ClientB: 0,
+			},
+			State: State{},
+		},
+		{
+			Action: AddIbcChannelAction{
+				ChainA:      ChainID("consu"),
+				ChainB:      ChainID("provi"),
+				ConnectionA: 0,
+				PortA:       "consumer",
+				PortB:       "provider",
+				Order:       "ordered",
+			},
+			State: State{},
+		},
+		{
+			Action: OptOutAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("carol"),
+			},
+			State: State{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 194,
+						ValidatorID("bob"):   203,
+						ValidatorID("carol"): 203,
+					},
+				},
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {"consu"},
+						ValidatorID("bob"):   {"consu"},
+						ValidatorID("carol"): {}, // "carol" does not have to validate anymore because it opted out
+					},
+				},
+			},
+		},
+		{
+			Action: RelayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID("consu"),
+				Port:    "provider",
+				Channel: 0,
+			},
+			State: State{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						// "carol" has opted out, and we only have 2 validators left validating. Power capping only operates
+						// in a best-effort basis and with 2 validators we cannot guarantee that no validator has more
+						// than 34% of the voting power. In this case, both validators get the same voting power (50% = 101 / 202).
+						ValidatorID("alice"): 101,
+						ValidatorID("bob"):   101,
+						ValidatorID("carol"): 0,
+					},
+				},
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {"consu"},
+						ValidatorID("bob"):   {"consu"},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+	}
+
+	return s
+}
+
+// stepsValidatorsAllowlistedChain starts a provider chain and an Opt-In chain with an allowlist
+func stepsValidatorsAllowlistedChain() []Step {
+	s := []Step{
+		{
+			Action: StartChainAction{
+				Chain: ChainID("provi"),
+				Validators: []StartChainValidator{
+					{Id: ValidatorID("alice"), Stake: 100000000, Allocation: 10000000000},
+					{Id: ValidatorID("bob"), Stake: 200000000, Allocation: 10000000000},
+					{Id: ValidatorID("carol"), Stake: 300000000, Allocation: 10000000000},
+				},
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 100,
+						ValidatorID("bob"):   200,
+						ValidatorID("carol"): 300,
+					},
+				},
+			},
+		},
+		{
+			Action: SubmitConsumerAdditionProposalAction{
+				Chain:         ChainID("provi"),
+				From:          ValidatorID("alice"),
+				Deposit:       10000001,
+				ConsumerChain: ChainID("consu"),
+				SpawnTime:     0,
+				InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+				TopN:          0,
+				// only "alice" and "bob" are allowlisted (see `getDefaultValidators` in `tests/e2e/config.go`)
+				Allowlist: []string{"cosmosvalcons1qmq08eruchr5sf5s3rwz7djpr5a25f7xw4mceq",
+					"cosmosvalcons1nx7n5uh0ztxsynn4sje6eyq2ud6rc6klc96w39"},
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					Proposals: &map[uint]Proposal{
+						1: ConsumerAdditionProposal{
+							Deposit:       10000001,
+							Chain:         ChainID("consu"),
+							SpawnTime:     0,
+							InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+							Status:        "PROPOSAL_STATUS_VOTING_PERIOD",
+						},
+					},
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {},
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+		// Οpt in "alice", "bob", and "carol." Note, that "alice" and "bob" use the provider's public key
+		// (see `UseConsumerKey` is set to `false` in `getDefaultValidators`) and hence do not need a consumer-key assigment.
+		{
+			Action: OptInAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("alice"),
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {}, // chain is not running yet
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+		{
+			Action: OptInAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("bob"),
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {},
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+		{
+			Action: OptInAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("carol"),
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {},
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+		{
+			// assign the consumer key "carol" is using on the consumer chain to be the one "carol" uses when opting in
+			Action: AssignConsumerPubKeyAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("carol"),
+				// reconfigure the node -> validator was using provider key
+				// until this point -> key matches config.consumerValPubKey for "carol"
+				ConsumerPubkey:  getDefaultValidators()[ValidatorID("carol")].ConsumerValPubKey,
+				ReconfigureNode: true,
+			},
+			State: State{},
+		},
+		{
+			Action: VoteGovProposalAction{
+				Chain:      ChainID("provi"),
+				From:       []ValidatorID{ValidatorID("alice"), ValidatorID("bob")},
+				Vote:       []string{"yes", "yes"},
+				PropNumber: 1,
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					Proposals: &map[uint]Proposal{
+						1: ConsumerAdditionProposal{
+							Deposit:       10000001,
+							Chain:         ChainID("consu"),
+							SpawnTime:     0,
+							InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+							Status:        "PROPOSAL_STATUS_PASSED",
+						},
+					},
+				},
+			},
+		},
+		{
+			Action: StartConsumerChainAction{
+				ConsumerChain: ChainID("consu"),
+				ProviderChain: ChainID("provi"),
+				Validators: []StartChainValidator{
+					{Id: ValidatorID("alice"), Stake: 100000000, Allocation: 10000000000},
+					{Id: ValidatorID("bob"), Stake: 200000000, Allocation: 10000000000},
+					{Id: ValidatorID("carol"), Stake: 300000000, Allocation: 10000000000},
+				},
+				// For consumers that're launching with the provider being on an earlier version
+				// of ICS before the soft opt-out threshold was introduced, we need to set the
+				// soft opt-out threshold to 0.05 in the consumer genesis to ensure that the
+				// consumer binary doesn't panic. Sdk requires that all params are set to valid
+				// values from the genesis file.
+				GenesisChanges: ".app_state.ccvconsumer.params.soft_opt_out_threshold = \"0.05\"",
+			},
+			State: State{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 100,
+						ValidatorID("bob"):   200,
+						// "carol" is not allowlisted and hence does not validate the consumer chain
+						ValidatorID("carol"): 0,
+					},
+				},
+			},
+		},
+		{
+			Action: AddIbcConnectionAction{
+				ChainA:  ChainID("consu"),
+				ChainB:  ChainID("provi"),
+				ClientA: 0,
+				ClientB: 0,
+			},
+			State: State{},
+		},
+		{
+			Action: AddIbcChannelAction{
+				ChainA:      ChainID("consu"),
+				ChainB:      ChainID("provi"),
+				ConnectionA: 0,
+				PortA:       "consumer",
+				PortB:       "provider",
+				Order:       "ordered",
+			},
+			State: State{},
+		},
+		{
+			Action: RelayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID("consu"),
+				Port:    "provider",
+				Channel: 0,
+			},
+			State: State{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 100,
+						ValidatorID("bob"):   200,
+						ValidatorID("carol"): 0,
+					},
+				},
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {"consu"},
+						ValidatorID("bob"):   {"consu"},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+	}
+
+	return s
+}
+
+// stepsValidatorsDenylistedChain starts a provider chain and an Opt-In chain with a denylist
+func stepsValidatorsDenylistedChain() []Step {
+	s := []Step{
+		{
+			Action: StartChainAction{
+				Chain: ChainID("provi"),
+				Validators: []StartChainValidator{
+					{Id: ValidatorID("alice"), Stake: 100000000, Allocation: 10000000000},
+					{Id: ValidatorID("bob"), Stake: 200000000, Allocation: 10000000000},
+					{Id: ValidatorID("carol"), Stake: 300000000, Allocation: 10000000000},
+				},
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 100,
+						ValidatorID("bob"):   200,
+						ValidatorID("carol"): 300,
+					},
+				},
+			},
+		},
+		{
+			Action: SubmitConsumerAdditionProposalAction{
+				Chain:         ChainID("provi"),
+				From:          ValidatorID("alice"),
+				Deposit:       10000001,
+				ConsumerChain: ChainID("consu"),
+				SpawnTime:     0,
+				InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+				TopN:          0,
+				// only "bob" is allowlisted (see `getDefaultValidators` in `tests/e2e/config.go`)
+				Denylist: []string{"cosmosvalcons1nx7n5uh0ztxsynn4sje6eyq2ud6rc6klc96w39"},
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					Proposals: &map[uint]Proposal{
+						1: ConsumerAdditionProposal{
+							Deposit:       10000001,
+							Chain:         ChainID("consu"),
+							SpawnTime:     0,
+							InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+							Status:        "PROPOSAL_STATUS_VOTING_PERIOD",
+						},
+					},
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {},
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+		// Οpt in "alice", "bob", and "carol." Note, that "alice" and "bob" use the provider's public key
+		// (see `UseConsumerKey` is set to `false` in `getDefaultValidators`) and hence do not need a consumer-key assigment.
+		{
+			Action: OptInAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("alice"),
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {}, // chain is not running yet
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+		{
+			Action: OptInAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("bob"),
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {},
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+		{
+			Action: OptInAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("carol"),
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {},
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {},
+					},
+				},
+			},
+		},
+		{
+			// assign the consumer key "carol" is using on the consumer chain to be the one "carol" uses when opting in
+			Action: AssignConsumerPubKeyAction{
+				Chain:     ChainID("consu"),
+				Validator: ValidatorID("carol"),
+				// reconfigure the node -> validator was using provider key
+				// until this point -> key matches config.consumerValPubKey for "carol"
+				ConsumerPubkey:  getDefaultValidators()[ValidatorID("carol")].ConsumerValPubKey,
+				ReconfigureNode: true,
+			},
+			State: State{},
+		},
+		{
+			Action: VoteGovProposalAction{
+				Chain:      ChainID("provi"),
+				From:       []ValidatorID{ValidatorID("alice"), ValidatorID("bob")},
+				Vote:       []string{"yes", "yes"},
+				PropNumber: 1,
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					Proposals: &map[uint]Proposal{
+						1: ConsumerAdditionProposal{
+							Deposit:       10000001,
+							Chain:         ChainID("consu"),
+							SpawnTime:     0,
+							InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+							Status:        "PROPOSAL_STATUS_PASSED",
+						},
+					},
+				},
+			},
+		},
+		{
+			Action: StartConsumerChainAction{
+				ConsumerChain: ChainID("consu"),
+				ProviderChain: ChainID("provi"),
+				Validators: []StartChainValidator{
+					{Id: ValidatorID("alice"), Stake: 100000000, Allocation: 10000000000},
+					{Id: ValidatorID("bob"), Stake: 200000000, Allocation: 10000000000},
+					{Id: ValidatorID("carol"), Stake: 300000000, Allocation: 10000000000},
+				},
+				// For consumers that're launching with the provider being on an earlier version
+				// of ICS before the soft opt-out threshold was introduced, we need to set the
+				// soft opt-out threshold to 0.05 in the consumer genesis to ensure that the
+				// consumer binary doesn't panic. Sdk requires that all params are set to valid
+				// values from the genesis file.
+				GenesisChanges: ".app_state.ccvconsumer.params.soft_opt_out_threshold = \"0.05\"",
+			},
+			State: State{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 100,
+						// "bob" is denylisted and hence does not valiate the consumer chain
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 300,
+					},
+				},
+			},
+		},
+		{
+			Action: AddIbcConnectionAction{
+				ChainA:  ChainID("consu"),
+				ChainB:  ChainID("provi"),
+				ClientA: 0,
+				ClientB: 0,
+			},
+			State: State{},
+		},
+		{
+			Action: AddIbcChannelAction{
+				ChainA:      ChainID("consu"),
+				ChainB:      ChainID("provi"),
+				ConnectionA: 0,
+				PortA:       "consumer",
+				PortB:       "provider",
+				Order:       "ordered",
+			},
+			State: State{},
+		},
+		{
+			Action: RelayPacketsAction{
+				ChainA:  ChainID("provi"),
+				ChainB:  ChainID("consu"),
+				Port:    "provider",
+				Channel: 0,
+			},
+			State: State{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): 100,
+						ValidatorID("bob"):   0,
+						ValidatorID("carol"): 300,
+					},
+				},
+				ChainID("provi"): ChainState{
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {"consu"},
+						ValidatorID("bob"):   {},
+						ValidatorID("carol"): {"consu"},
+					},
+				},
+			},
+		},
+	}
+
+	return s
+}

--- a/tests/e2e/steps_partial_set_security.go
+++ b/tests/e2e/steps_partial_set_security.go
@@ -1715,7 +1715,7 @@ func stepsValidatorsDenylistedChain() []Step {
 				SpawnTime:     0,
 				InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
 				TopN:          0,
-				// only "bob" is allowlisted (see `getDefaultValidators` in `tests/e2e/config.go`)
+				// only "bob" is denylisted (see `getDefaultValidators` in `tests/e2e/config.go`)
 				Denylist: []string{"cosmosvalcons1nx7n5uh0ztxsynn4sje6eyq2ud6rc6klc96w39"},
 			},
 			State: State{


### PR DESCRIPTION
## Description

Added some _simple_ E2E tests to verify that the basic behavior of the power-shaping features works as expected. Specifically, we test that validator-set capping, validators-power capping, allowlisting, and denylisting work.

Verified tests run successfully with:
```
go run ./tests/e2e/... --tc partial-set-security-validator-set-cap
go run ./tests/e2e/... --tc partial-set-security-validators-power-cap
go run ./tests/e2e/... --tc partial-set-security-validators-allowlisted
go run ./tests/e2e/... --tc partial-set-security-validators-denylisted
```


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced testing capabilities by adding new test cases and steps for partial set security scenarios in an Opt-In chain. This includes handling validator-set caps, validators' power caps, allowlists, and denylists.

- **Tests**
	- Introduced functions to set up specific chain configurations such as validator-set capped, validators-power capped, allowlisted, and denylisted chains in end-to-end tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->