### PR TITLE
fix!: change ack processing in provider middleware

### DIFF
--- a/x/ccv/provider/ibc_middleware.go
+++ b/x/ccv/provider/ibc_middleware.go
@@ -120,7 +120,7 @@ func (im IBCMiddleware) OnRecvPacket(
 	// we know that the IBC transfer succeeded. That entails
 	// that the packet data is valid and can be safely
 	// deserialized without checking errors.
-	if ack.Success() {
+	if ack == nil {
 		// execute the middleware logic only if the sender is a consumer chain
 		consumerID, err := im.keeper.IdentifyConsumerChainIDFromIBCPacket(ctx, packet)
 		if err != nil {


### PR DESCRIPTION
Fixes issue uncovered during gaia provider testing.

Provider middleware was not correctly handling all possible middlewares `OnRecv` calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Modified the acknowledgment check in packet reception to enhance reliability in message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->