### PR TITLE
chore: Make coderabbit ignore docs folder

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -8,6 +8,7 @@ reviews:
     collapse_walkthrough: true
     path_filters:
         - "!api/"
+        - "!docs/"
     path_instructions:
         - path: "**/*.go"
           instructions: "Review the Golang code for conformity with the Uber Golang style guide, highlighting any deviations."


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Coderabbit is really spammy on large markdown files, see https://github.com/cosmos/interchain-security/pull/1859
I think we should probably not have it run on the docs.

It's been doing ok on code imo, so I don't want to get rid of it completely, but just want to remove it from the docs specifically, since the noise-signal ratio was not very good there,

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct `docs:` prefix in the PR title
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)
- [ ] Checked that the documentation website can be built and deployed successfully (run `make build-docs`)

