### PR TITLE
chore: fixed all-pairs-valconsensus-address CLI command usage

### DIFF
--- a/x/ccv/provider/client/cli/query.go
+++ b/x/ccv/provider/client/cli/query.go
@@ -355,7 +355,7 @@ $ %s query provider registered-consumer-reward-denoms
 
 func CmdAllPairsValConAddrByConsumerChainID() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "all-pairs-valconsensus-address",
+		Use:   "all-pairs-valconsensus-address [consumer-chain-id]",
 		Short: "Query all pairs of valconsensus address by consumer chainId.",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Description

Fixes the CLI commands usage, as its `--help` is unobvious.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the command functionality to include a parameter for specifying the consumer chain ID, improving user specificity in queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->