### PR TITLE
chore: fix spelling errors

### DIFF
--- a/proto/interchain_security/ccv/provider/v1/tx.proto
+++ b/proto/interchain_security/ccv/provider/v1/tx.proto
@@ -15,7 +15,7 @@ service Msg {
   rpc AssignConsumerKey(MsgAssignConsumerKey) returns (MsgAssignConsumerKeyResponse);
   rpc SubmitConsumerMisbehaviour(MsgSubmitConsumerMisbehaviour) returns (MsgSubmitConsumerMisbehaviourResponse);
   rpc SubmitConsumerDoubleVoting(MsgSubmitConsumerDoubleVoting) returns (MsgSubmitConsumerDoubleVotingResponse);
-  rpc OptIn(MsgOptIn) returns (MsgOptInResponse);
+  rpc option(MsgOptIn) returns (MsgOptInResponse);
   rpc OptOut(MsgOptOut) returns (MsgOptOutResponse);
   rpc SetConsumerCommissionRate(MsgSetConsumerCommissionRate) returns (MsgSetConsumerCommissionRateResponse);
 }

--- a/tests/e2e/actions.go
+++ b/tests/e2e/actions.go
@@ -2274,7 +2274,7 @@ type OptInAction struct {
 	Validator ValidatorID
 }
 
-func (tr TestConfig) optIn(action OptInAction, target ExecutionTarget, verbose bool) {
+func (tr TestConfig) option(action OptInAction, target ExecutionTarget, verbose bool) {
 	// Note: to get error response reported back from this command '--gas auto' needs to be set.
 	gas := "auto"
 	// Unfortunately, --gas auto does not work with CometMock. so when using CometMock, just use --gas 9000000 then
@@ -2283,7 +2283,7 @@ func (tr TestConfig) optIn(action OptInAction, target ExecutionTarget, verbose b
 	}
 
 	// Use: "opt-in [consumer-chain-id] [consumer-pubkey]",
-	optIn := fmt.Sprintf(
+	option := fmt.Sprintf(
 		`%s tx provider opt-in %s --from validator%s --chain-id %s --home %s --node %s --gas %s --keyring-backend test -y -o json`,
 		tr.chainConfigs[ChainID("provi")].BinaryName,
 		string(tr.chainConfigs[action.Chain].ChainId),
@@ -2296,11 +2296,11 @@ func (tr TestConfig) optIn(action OptInAction, target ExecutionTarget, verbose b
 
 	cmd := target.ExecCommand(
 		"/bin/bash", "-c",
-		optIn,
+		option,
 	)
 
 	if verbose {
-		fmt.Println("optIn cmd:", cmd.String())
+		fmt.Println("option cmd:", cmd.String())
 	}
 
 	bz, err := cmd.CombinedOutput()
@@ -2333,7 +2333,7 @@ func (tr TestConfig) optOut(action OptOutAction, target ExecutionTarget, verbose
 	}
 
 	// Use: "opt-out [consumer-chain-id]",
-	optIn := fmt.Sprintf(
+	option := fmt.Sprintf(
 		`%s tx provider opt-out %s --from validator%s --chain-id %s --home %s --node %s --gas %s --keyring-backend test -y -o json`,
 		tr.chainConfigs[ChainID("provi")].BinaryName,
 		string(tr.chainConfigs[action.Chain].ChainId),
@@ -2346,7 +2346,7 @@ func (tr TestConfig) optOut(action OptOutAction, target ExecutionTarget, verbose
 
 	cmd := target.ExecCommand(
 		"/bin/bash", "-c",
-		optIn,
+		option,
 	)
 
 	if verbose {

--- a/tests/e2e/steps_partial_set_security.go
+++ b/tests/e2e/steps_partial_set_security.go
@@ -55,7 +55,7 @@ func stepsOptInChain() []Step {
 		},
 		// Οpt in "alice" and "bob" so the chain is not empty when it is about to start. Note, that "alice" and "bob" use
 		// the provider's public key (see `UseConsumerKey` is set to `false` in `getDefaultValidators`) and hence do not
-		// need a consumer-key assigment.
+		// need a consumer-key assignment.
 		{
 			Action: OptInAction{
 				Chain:     ChainID("consu"),

--- a/tests/e2e/test_driver.go
+++ b/tests/e2e/test_driver.go
@@ -139,7 +139,7 @@ func (td *DefaultDriver) runAction(action interface{}) error {
 	case SubmitChangeRewardDenomsProposalAction:
 		td.testCfg.submitChangeRewardDenomsProposal(action, td.target, td.verbose)
 	case OptInAction:
-		td.testCfg.optIn(action, td.target, td.verbose)
+		td.testCfg.option(action, td.target, td.verbose)
 	case OptOutAction:
 		td.testCfg.optOut(action, td.target, td.verbose)
 	default:

--- a/tests/integration/distribution.go
+++ b/tests/integration/distribution.go
@@ -1117,7 +1117,7 @@ func (s *CCVTestSuite) TestMultiConsumerRewardsDistribution() {
 				bundle.GetCtx(),
 				accountKeeper.GetModuleAccount(bundle.GetCtx(), consumertypes.ConsumerToSendToProviderName).GetAddress(),
 			)
-			s.Require().Len(pool, 1, "consumer reward pool cannot have mutiple token denoms")
+			s.Require().Len(pool, 1, "consumer reward pool cannot have multiple token denoms")
 			rewardsPerConsumer = pool[0]
 		}
 

--- a/tests/mbt/model/ccv_pss.qnt
+++ b/tests/mbt/model/ccv_pss.qnt
@@ -79,7 +79,7 @@ module ccv_pss {
     // Opts a validator in for a consumer chain the provider.
     // Possible before the consumer chain starts running,
     // and will then be applied when the consumer chain starts running.
-    pure def OptIn(currentState: ProtocolState, consumer: Chain, validator: Node): Result = {
+    pure def option(currentState: ProtocolState, consumer: Chain, validator: Node): Result = {
         pure val optedInVals = currentState.providerState.optedInVals.get(consumer)
         pure val newOptedInVals = optedInVals.union(Set(validator))
         Ok({

--- a/tests/mbt/model/ccv_pss_model.qnt
+++ b/tests/mbt/model/ccv_pss_model.qnt
@@ -14,13 +14,13 @@ module ccv_pss_model {
     }
 
     action OptIn_Deterministic(consumer: Chain, validator: Node): bool = {
-        val res = OptIn(currentState, consumer, validator)
+        val res = option(currentState, consumer, validator)
         all {
             currentState' = res.newState,
             trace' = trace.append(
                 {
                     ...emptyAction,
-                    kind: "OptIn",
+                    kind: "option",
                     consumerChain: consumer,
                     validator: validator
                 }
@@ -83,7 +83,7 @@ module ccv_pss_model {
 
     val CanOptIn = {
         not(
-            trace[length(trace)-1].kind == "OptIn"
+            trace[length(trace)-1].kind == "option"
             and
             trace[length(trace)-1].expectedError == ""
         )

--- a/x/ccv/provider/handler.go
+++ b/x/ccv/provider/handler.go
@@ -27,7 +27,7 @@ func NewHandler(k *keeper.Keeper) sdk.Handler {
 			res, err := msgServer.SubmitConsumerDoubleVoting(sdk.WrapSDKContext(ctx), msg)
 			return sdk.WrapServiceResult(ctx, res, err)
 		case *types.MsgOptIn:
-			res, err := msgServer.OptIn(sdk.WrapSDKContext(ctx), msg)
+			res, err := msgServer.option(sdk.WrapSDKContext(ctx), msg)
 			return sdk.WrapServiceResult(ctx, res, err)
 		case *types.MsgOptOut:
 			res, err := msgServer.OptOut(sdk.WrapSDKContext(ctx), msg)

--- a/x/ccv/provider/keeper/msg_server.go
+++ b/x/ccv/provider/keeper/msg_server.go
@@ -137,7 +137,7 @@ func (k msgServer) SubmitConsumerDoubleVoting(goCtx context.Context, msg *types.
 	return &types.MsgSubmitConsumerDoubleVotingResponse{}, nil
 }
 
-func (k msgServer) OptIn(goCtx context.Context, msg *types.MsgOptIn) (*types.MsgOptInResponse, error) {
+func (k msgServer) option(goCtx context.Context, msg *types.MsgOptIn) (*types.MsgOptInResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	valAddress, err := sdk.ValAddressFromBech32(msg.ProviderAddr)


### PR DESCRIPTION
This PR fixes typos in the codebase.
Please review it, and merge if everything is fine.
If there are proto changes, run `make proto-gen` and commit the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed the `OptIn` function to `option` across various modules for consistency.
  
- **Bug Fixes**
  - Corrected a typo in the error message regarding consumer reward pool token denominations.
  - Fixed a comment typo related to consumer-key assignment in chain setup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->