### PR TITLE
chore: Try to make coderabbit ignore missing/extra newlines in md files

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -23,7 +23,7 @@ reviews:
               "Assess the unit test code assessing sufficient code coverage for the changes associated in the pull request"
         - path: "**/*.md"
           instructions: |
-              "Assess the documentation for misspellings, grammatical errors, missing documentation and correctness"
+              "Assess the documentation for misspellings, grammatical errors, missing documentation and correctness. Please DO NOT report any missing or superfluous newlines, in particular at the end or beginning of files."
         - path: ".changelog/*"
           instructions: |
               "Assess the changes in the changelog for correctness and completeness, particularly flagging missing changes"


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Updates the instructions to get rid of comments like this one: 
https://github.com/cosmos/interchain-security/pull/1876#discussion_r1599570333


---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated guidelines to exclude reporting of missing or extra newlines at the beginning or end of files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->