### PR TITLE
fix!: drop chain proposals with empty validator set at spawn time

### DIFF
--- a/testutil/keeper/expectations.go
+++ b/testutil/keeper/expectations.go
@@ -57,8 +57,6 @@ func GetMocksForMakeConsumerGenesis(ctx sdk.Context, mocks *MockedKeepers,
 
 		mocks.MockClientKeeper.EXPECT().GetSelfConsensusState(gomock.Any(),
 			clienttypes.GetSelfHeight(ctx)).Return(&ibctmtypes.ConsensusState{}, nil).Times(1),
-
-		mocks.MockStakingKeeper.EXPECT().GetLastValidators(gomock.Any()).Times(1),
 	}
 }
 

--- a/testutil/keeper/unit_test_helpers.go
+++ b/testutil/keeper/unit_test_helpers.go
@@ -215,6 +215,7 @@ func SetupForStoppingConsumerChain(t *testing.T, ctx sdk.Context,
 	providerKeeper *providerkeeper.Keeper, mocks MockedKeepers,
 ) {
 	t.Helper()
+	mocks.MockStakingKeeper.EXPECT().GetLastValidators(gomock.Any()).Times(1)
 	expectations := GetMocksForCreateConsumerClient(ctx, &mocks,
 		"chainID", clienttypes.NewHeight(4, 5))
 	expectations = append(expectations, GetMocksForSetConsumerChain(ctx, &mocks, "chainID")...)

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -397,7 +397,7 @@ func (k Keeper) BeginBlockInit(ctx sdk.Context) {
 
 		if len(consumerGenesis.Provider.InitialValSet) == 0 {
 			// drop the proposal
-			ctx.Logger().Info("consumer genesis initial validator set cannot be empty")
+			ctx.Logger().Info("consumer genesis initial validator set is empty - no validators opted in")
 			continue
 		}
 

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -388,6 +388,19 @@ func (k Keeper) BeginBlockInit(ctx sdk.Context) {
 			continue
 		}
 
+		consumerGenesis, found := k.GetConsumerGenesis(cachedCtx, prop.ChainId)
+		if !found {
+			// drop the proposal
+			ctx.Logger().Info("consumer genesis could not be created")
+			continue
+		}
+
+		if len(consumerGenesis.Provider.InitialValSet) == 0 {
+			// drop the proposal
+			ctx.Logger().Info("consumer genesis initial validator set cannot be empty")
+			continue
+		}
+
 		// The cached context is created with a new EventManager so we merge the event
 		// into the original context
 		ctx.EventManager().EmitEvents(cachedCtx.EventManager().Events())

--- a/x/ccv/provider/proposal_handler_test.go
+++ b/x/ccv/provider/proposal_handler_test.go
@@ -96,6 +96,7 @@ func TestProviderProposalHandler(t *testing.T) {
 		// Mock expectations depending on expected outcome
 		switch {
 		case tc.expValidConsumerAddition:
+			mocks.MockStakingKeeper.EXPECT().GetLastValidators(gomock.Any()).Times(1)
 			gomock.InOrder(testkeeper.GetMocksForCreateConsumerClient(
 				ctx, &mocks, "chainID", clienttypes.NewHeight(2, 3),
 			)...)


### PR DESCRIPTION
<!--
The production pull request template is for types feat, fix, or refactor.
-->

## Description

Closes: #1886 

**Problem**
We do not drop consumer chains that are voted on and that end up having an empty validator set in their consumer genesis (e.g., an _Opt In_ chain where no validator opts in during the voting period).

**Solution**
Drop proposals at spawn time if the validator set in the consumer genesis is empty.
A nicer solution would have been to have `MakeConsumerGenesis` return an error if the initial validator set is empty. However, this would have needed quite some refactoring and we would like to cut a release by tomorrow.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] Added `!` to the type prefix if the change is [state-machine breaking](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes)
* [x] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
* [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] Provided a link to the relevant issue or specification
* [ ] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/00-intro.md)
* [ ] Included the necessary unit and integration [tests](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry to `CHANGELOG.md`
* [ ] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [ ] Confirmed all CI checks have passed
* [ ] If this PR is library API breaking, bump the go.mod version string of the repo, and follow through on a new major release

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` the type prefix if the change is state-machine breaking
* [ ] confirmed this PR does not introduce changes requiring state migrations, OR confirmed migration code has been added to consumer and/or provider modules
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Added validation to ensure the consumer genesis initial validator set is not empty before processing proposals.

- **Tests**
  - Enhanced unit tests to include expectations for `GetLastValidators` method in multiple test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->