### PR TITLE
test: Remove v5.0.0 (pre-release) be tested within e2e compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 COMMIT := $(shell git log -1 --format='%H')
 # Fetch tags and get the latest ICS version by filtering tags by vX.Y.Z and vX.Y.Z-lsm
 # using lazy set to only execute commands when variable is used
-LATEST_RELEASE ?= $(shell git fetch; git tag -l --sort -v:refname 'v*.?' 'v*.?'-lsm 'v*.??' 'v*.??'-lsm | head -n 1)
+# Note: v.5.0.0 is currently excluded from the list as it's a pre-release and will be removed back once it's out of pre-release status
+LATEST_RELEASE ?= $(shell git fetch; git tag -l --sort -v:refname 'v*.?' 'v*.?'-lsm 'v*.??' 'v*.??'-lsm --no-contains v5.0.0 | head -n 1)
 
 # don't override user values
 ifeq (,$(VERSION))

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 COMMIT := $(shell git log -1 --format='%H')
 # Fetch tags and get the latest ICS version by filtering tags by vX.Y.Z and vX.Y.Z-lsm
 # using lazy set to only execute commands when variable is used
-# Note: v.5.0.0 is currently excluded from the list as it's a pre-release and will be removed back once it's out of pre-release status
+# Note: v.5.0.0 is currently excluded from the list as it's a pre-release and will be added back once it's out of pre-release status
 LATEST_RELEASE ?= $(shell git fetch; git tag -l --sort -v:refname 'v*.?' 'v*.?'-lsm 'v*.??' 'v*.??'-lsm --no-contains v5.0.0 | head -n 1)
 
 # don't override user values


### PR DESCRIPTION
## Description

Closes: #XXXX

v5.0.0 is in status pre-release and breaks e2e-compatibility tests in various ways.
This fix will be removed from the list of candidates of 'LAST_VERSION' to be tested
for e2e comaptibility tests.
Note: once v5.0.0 is official release and fix of e2e compatibility tests is in main this change will be reverted.


<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the release management process to exclude pre-release versions from being marked as the latest release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->