### PR TITLE
chore: fix struct name in comment

### DIFF
--- a/x/ccv/types/expected_keepers.go
+++ b/x/ccv/types/expected_keepers.go
@@ -143,7 +143,7 @@ type IBCTransferKeeper interface {
 	Transfer(context.Context, *transfertypes.MsgTransfer) (*transfertypes.MsgTransferResponse, error)
 }
 
-// IBCKeeper defines the expected interface needed for opening a
+// IBCCoreKeeper defines the expected interface needed for opening a
 // channel
 type IBCCoreKeeper interface {
 	ChannelOpenInit(


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate sub-template:

* [Production code](?expand=1&template=production.md) - for types `fix`, `feat`, and `refactor`.
* [Docs](?expand=1&template=docs.md) - for documentation changes.
* [Others](?expand=1&template=others.md) - for changes that do not affect production code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Renamed `IBCKeeper` interface to `IBCCoreKeeper` for clearer purpose indication related to channel opening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->