### PR TITLE
test: Add integration test reproducing the LastValidators exceeding MaxValidators bug

### DIFF
--- a/tests/integration/unbonding.go
+++ b/tests/integration/unbonding.go
@@ -488,7 +488,7 @@ func (s *CCVTestSuite) TestTooManyLastValidators() {
 	// verify that the number of bonded validators is decreased by one
 	s.Require().Equal(len(lastVals)-1, len(sk.GetLastValidators(s.providerCtx())))
 
-	// update maximum validator to the equal number of bonded validators
+	// update maximum validator to equal the number of bonded validators
 	p.MaxValidators = uint32(len(sk.GetLastValidators(s.providerCtx())))
 	sk.SetParams(s.providerCtx(), p)
 

--- a/tests/integration/unbonding.go
+++ b/tests/integration/unbonding.go
@@ -468,7 +468,7 @@ func (s *CCVTestSuite) TestTooManyLastValidators() {
 	// get current staking params
 	p := sk.GetParams(s.providerCtx())
 
-	// get validators, which are all active atm
+	// get validators, which are all active at the moment
 	vals := sk.GetAllValidators(s.providerCtx())
 	s.Require().Equal(len(vals), len(sk.GetLastValidators(s.providerCtx())))
 

--- a/testutil/integration/debug_test.go
+++ b/testutil/integration/debug_test.go
@@ -303,3 +303,7 @@ func TestAllocateTokensToValidator(t *testing.T) {
 func TestMultiConsumerRewardsDistribution(t *testing.T) {
 	runCCVTestByName(t, "TestMultiConsumerRewardsDistribution")
 }
+
+func TestTooManyLastValidators(t *testing.T) {
+	runCCVTestByName(t, "TestTooManyLastValidators")
+}

--- a/testutil/integration/interfaces.go
+++ b/testutil/integration/interfaces.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"time"
 
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	ibctesting "github.com/cosmos/ibc-go/v7/testing"
 
 	"cosmossdk.io/math"
@@ -106,6 +107,9 @@ type TestStakingKeeper interface {
 	) (ubd types.UnbondingDelegation, found bool)
 	GetAllValidators(ctx sdk.Context) (validators []types.Validator)
 	GetValidatorSet() types.ValidatorSet
+	GetParams(ctx sdk.Context) stakingtypes.Params
+	SetParams(ctx sdk.Context, p stakingtypes.Params) error
+	ApplyAndReturnValidatorSetUpdates(ctx sdk.Context) (updates []abci.ValidatorUpdate, err error)
 }
 
 type TestBankKeeper interface {

--- a/testutil/keeper/mocks.go
+++ b/testutil/keeper/mocks.go
@@ -119,6 +119,20 @@ func (mr *MockStakingKeeperMockRecorder) GetLastValidators(ctx interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastValidators", reflect.TypeOf((*MockStakingKeeper)(nil).GetLastValidators), ctx)
 }
 
+// GetParams mocks base method.
+func (m *MockStakingKeeper) GetParams(ctx types0.Context) types5.Params {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetParams", ctx)
+	ret0, _ := ret[0].(types5.Params)
+	return ret0
+}
+
+// GetParams indicates an expected call of GetParams.
+func (mr *MockStakingKeeperMockRecorder) GetParams(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParams", reflect.TypeOf((*MockStakingKeeper)(nil).GetParams), ctx)
+}
+
 // GetRedelegationByUnbondingID mocks base method.
 func (m *MockStakingKeeper) GetRedelegationByUnbondingID(ctx types0.Context, id uint64) (types5.Redelegation, bool) {
 	m.ctrl.T.Helper()
@@ -355,6 +369,20 @@ func (m *MockStakingKeeper) PutUnbondingOnHold(ctx types0.Context, id uint64) er
 func (mr *MockStakingKeeperMockRecorder) PutUnbondingOnHold(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutUnbondingOnHold", reflect.TypeOf((*MockStakingKeeper)(nil).PutUnbondingOnHold), ctx, id)
+}
+
+// SetParams mocks base method.
+func (m *MockStakingKeeper) SetParams(ctx types0.Context, p types5.Params) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetParams", ctx, p)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetParams indicates an expected call of SetParams.
+func (mr *MockStakingKeeperMockRecorder) SetParams(ctx, p interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetParams", reflect.TypeOf((*MockStakingKeeper)(nil).SetParams), ctx, p)
 }
 
 // Slash mocks base method.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new test function `TestTooManyLastValidators` to simulate scenarios causing a panic due to inconsistent state in the staking module.
  - Added methods for interacting with the staking keeper, including jailing/un-jailing validators and updating validator set parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->