### PR TITLE
fix: print test name instead of config name

### DIFF
--- a/tests/e2e/main.go
+++ b/tests/e2e/main.go
@@ -277,7 +277,7 @@ func parseArguments() (err error) {
 
 type testStepsWithConfig struct {
 	config TestConfigType
-	steps  []Step
+	steps  StepChoice
 }
 
 func getTestCases(selectedPredefinedTests, selectedTestFiles TestSet, providerVersions,
@@ -316,13 +316,12 @@ func getTestCases(selectedPredefinedTests, selectedTestFiles TestSet, providerVe
 			log.Fatalf("Step choice '%s' not found.\nsee usage info:\n%s", tc, getTestCaseUsageString())
 		}
 
-		testSteps := stepChoices[tc].steps
 		if testConfig == "" {
 			testConfig = stepChoices[tc].testConfig
 		}
 		tests = append(tests, testStepsWithConfig{
 			config: testConfig,
-			steps:  testSteps,
+			steps:  stepChoices[tc],
 		},
 		)
 	}
@@ -351,7 +350,11 @@ func getTestCases(selectedPredefinedTests, selectedTestFiles TestSet, providerVe
 
 		tests = append(tests, testStepsWithConfig{
 			config: testConfig,
-			steps:  testCase,
+			steps: StepChoice{
+				name:        testFileName,
+				steps:       testCase,
+				description: fmt.Sprintf("Steps from file %s", testFileName),
+			},
 		})
 	}
 

--- a/tests/e2e/test_runner.go
+++ b/tests/e2e/test_runner.go
@@ -19,7 +19,7 @@ const (
 // It sets up the test environment and the test driver to run the tests
 type TestRunner struct {
 	config     TestConfig
-	steps      []Step
+	stepChoice StepChoice
 	testDriver TestCaseDriver
 	target     ExecutionTarget
 	verbose    bool
@@ -86,7 +86,7 @@ func (tr *TestRunner) Run() error {
 	}
 
 	tr.testDriver = GetTestCaseDriver(tr.config)
-	err = tr.testDriver.Run(tr.steps, tr.target, tr.verbose)
+	err = tr.testDriver.Run(tr.stepChoice.steps, tr.target, tr.verbose)
 	if err != nil {
 		tr.result.Failed()
 		// not tearing down environment for troubleshooting reasons on container
@@ -118,13 +118,13 @@ func (tr *TestRunner) Setup(testCfg TestConfig) error {
 	return nil
 }
 
-func CreateTestRunner(config TestConfig, steps []Step, target ExecutionTarget, verbose bool) TestRunner {
+func CreateTestRunner(config TestConfig, stepChoice StepChoice, target ExecutionTarget, verbose bool) TestRunner {
 	return TestRunner{
-		target:  target,
-		steps:   steps,
-		config:  config,
-		verbose: verbose,
-		result:  TestResult{Status: TEST_STATUS_NOTRUN},
+		target:     target,
+		stepChoice: stepChoice,
+		config:     config,
+		verbose:    verbose,
+		result:     TestResult{Status: TEST_STATUS_NOTRUN},
 	}
 }
 
@@ -135,7 +135,7 @@ func (tr *TestRunner) Info() string {
 Test name : %s
 Target: %s
 ------------------------------------------`,
-		tr.config.name,
+		tr.stepChoice.name,
 		tr.target.Info(),
 	)
 }
@@ -150,7 +150,7 @@ Target: %s
 - Duration: %s
 - StartTime: %s
 ------------------------------------------`,
-		tr.config.name,
+		tr.stepChoice.name,
 		tr.target.Info(),
 		tr.result.Status,
 		tr.result.Result,


### PR DESCRIPTION
## Description

Fixes a bug where the e2e framework would output the name of the config, not of the step choice (which is much more descriptive).

Now both are displayed.

Output before:

```
------------------------------------------
Test name : default
Target: 
Docker
        Consumer version: default (current workspace)
        Provider version: default (current workspace)
        Docker image: cosmos-ics:local
        Docker container: interchain-security-instance
------------------------------------------
```

output after:

```
------------------------------------------
Test name : happy-path
Config: default
Target: 
Docker
        Consumer version: default (current workspace)
        Provider version: default (current workspace)
        Docker image: cosmos-ics:local
        Docker container: interchain-security-instance
------------------------------------------
```

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
