### PR TITLE
chore: add ICS `release/v5.1.x` branch to Mergify

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,3 +48,13 @@ updates:
     labels:
       - dependencies
 
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: daily
+    target-branch: "release/v5.1.x"
+    # Only allow automated security-related dependency updates on release branches.
+    open-pull-requests-limit: 0
+    labels:
+      - dependencies
+

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -34,3 +34,11 @@ pull_request_rules:
       backport:
         branches:
           - release/v5.x
+  - name: Backport patches to the release/v5.1.x branch
+    conditions:
+      - base=main
+      - label=A:backport/v5.1.x
+    actions:
+      backport:
+        branches:
+          - release/v5.1.x


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate sub-template:

* [Production code](?expand=1&template=production.md) - for types `fix`, `feat`, and `refactor`.
* [Docs](?expand=1&template=docs.md) - for documentation changes.
* [Others](?expand=1&template=others.md) - for changes that do not affect production code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Configured automated dependency updates for the `release/v5.1.x` branch.
  - Introduced a new pull request rule to backport patches to the `release/v5.1.x` branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->