### PR TITLE
feat!: store the minimal power to be in the top N on EndBlock

### DIFF
--- a/x/ccv/provider/keeper/grpc_query_test.go
+++ b/x/ccv/provider/keeper/grpc_query_test.go
@@ -311,6 +311,7 @@ func TestGetConsumerChain(t *testing.T) {
 		pk.SetTopN(ctx, chainID, topN)
 		pk.SetValidatorSetCap(ctx, chainID, validatorSetCaps[i])
 		pk.SetValidatorsPowerCap(ctx, chainID, validatorPowerCaps[i])
+		pk.SetMinimumPowerInTopN(ctx, chainID, expectedMinPowerInTopNs[i])
 		for _, addr := range allowlists[i] {
 			pk.SetAllowlist(ctx, chainID, addr)
 		}

--- a/x/ccv/provider/keeper/keeper.go
+++ b/x/ccv/provider/keeper/keeper.go
@@ -1543,3 +1543,42 @@ func (k Keeper) IsDenylistEmpty(ctx sdk.Context, chainID string) bool {
 
 	return !iterator.Valid()
 }
+
+// SetMinimumPowerInTopN sets the minimum power required for a validator to be in the top N
+// for a given consumer chain.
+func (k Keeper) SetMinimumPowerInTopN(
+	ctx sdk.Context,
+	chainID string,
+	power int64,
+) {
+	store := ctx.KVStore(k.storeKey)
+
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, uint64(power))
+
+	store.Set(types.MinimumPowerInTopNKey(chainID), buf)
+}
+
+// GetMinimumPowerInTopN returns the minimum power required for a validator to be in the top N
+// for a given consumer chain.
+func (k Keeper) GetMinimumPowerInTopN(
+	ctx sdk.Context,
+	chainID string,
+) (int64, bool) {
+	store := ctx.KVStore(k.storeKey)
+	buf := store.Get(types.MinimumPowerInTopNKey(chainID))
+	if buf == nil {
+		return 0, false
+	}
+	return int64(binary.BigEndian.Uint64(buf)), true
+}
+
+// DeleteMinimumPowerInTopN removes the minimum power required for a validator to be in the top N
+// for a given consumer chain.
+func (k Keeper) DeleteMinimumPowerInTopN(
+	ctx sdk.Context,
+	chainID string,
+) {
+	store := ctx.KVStore(k.storeKey)
+	store.Delete(types.MinimumPowerInTopNKey(chainID))
+}

--- a/x/ccv/provider/keeper/keeper_test.go
+++ b/x/ccv/provider/keeper/keeper_test.go
@@ -831,3 +831,33 @@ func TestDenylist(t *testing.T) {
 	require.False(t, providerKeeper.IsDenylisted(ctx, chainID, providerAddr2))
 	require.True(t, providerKeeper.IsDenylistEmpty(ctx, chainID))
 }
+
+func TestMinimumPowerInTopN(t *testing.T) {
+	k, ctx, _, _ := testkeeper.GetProviderKeeperAndCtx(t, testkeeper.NewInMemKeeperParams(t))
+
+	chainID := "testChain"
+	minPower := int64(1000)
+
+	// Set the minimum power in top N
+	k.SetMinimumPowerInTopN(ctx, chainID, minPower)
+
+	// Retrieve the minimum power in top N
+	actualMinPower, found := k.GetMinimumPowerInTopN(ctx, chainID)
+	require.True(t, found)
+	require.Equal(t, minPower, actualMinPower)
+
+	// Update the minimum power
+	newMinPower := int64(2000)
+	k.SetMinimumPowerInTopN(ctx, chainID, newMinPower)
+
+	// Retrieve the updated minimum power in top N
+	newActualMinPower, found := k.GetMinimumPowerInTopN(ctx, chainID)
+	require.True(t, found)
+	require.Equal(t, newMinPower, newActualMinPower)
+
+	// Test when the chain ID does not exist
+	nonExistentChainID := "nonExistentChain"
+	nonExistentMinPower, found := k.GetMinimumPowerInTopN(ctx, nonExistentChainID)
+	require.False(t, found)
+	require.Equal(t, int64(0), nonExistentMinPower)
+}

--- a/x/ccv/provider/keeper/partial_set_security_test.go
+++ b/x/ccv/provider/keeper/partial_set_security_test.go
@@ -135,6 +135,11 @@ func TestHandleOptOutFromTopNChain(t *testing.T) {
 
 	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 4, []stakingtypes.Validator{valA, valB, valC, valD}, []int64{1, 2, 3, 4}, -1) // -1 to allow mocks AnyTimes
 
+	// initialize the minPowerInTopN correctly
+	minPowerInTopN, err := providerKeeper.ComputeMinPowerInTopN(ctx, []stakingtypes.Validator{valA, valB, valC, valD}, 50)
+	require.NoError(t, err)
+	providerKeeper.SetMinimumPowerInTopN(ctx, chainID, minPowerInTopN)
+
 	// opt in all validators
 	providerKeeper.SetOptedIn(ctx, chainID, types.NewProviderConsAddress(valAConsAddr))
 	providerKeeper.SetOptedIn(ctx, chainID, types.NewProviderConsAddress(valBConsAddr))
@@ -282,7 +287,7 @@ func TestOptInTopNValidators(t *testing.T) {
 	require.Empty(t, providerKeeper.GetAllOptedIn(ctx, "chainID"))
 }
 
-func TestComputeMinPowerToOptIn(t *testing.T) {
+func TestComputeMinPowerInTopN(t *testing.T) {
 	providerKeeper, ctx, ctrl, mocks := testkeeper.GetProviderKeeperAndCtx(t, testkeeper.NewInMemKeeperParams(t))
 	defer ctrl.Finish()
 
@@ -303,50 +308,50 @@ func TestComputeMinPowerToOptIn(t *testing.T) {
 		createStakingValidator(ctx, mocks, 5, 6, 5),
 	}
 
-	m, err := providerKeeper.ComputeMinPowerToOptIn(ctx, bondedValidators, 100)
+	m, err := providerKeeper.ComputeMinPowerInTopN(ctx, bondedValidators, 100)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), m)
 
-	m, err = providerKeeper.ComputeMinPowerToOptIn(ctx, bondedValidators, 97)
+	m, err = providerKeeper.ComputeMinPowerInTopN(ctx, bondedValidators, 97)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), m)
 
-	m, err = providerKeeper.ComputeMinPowerToOptIn(ctx, bondedValidators, 96)
+	m, err = providerKeeper.ComputeMinPowerInTopN(ctx, bondedValidators, 96)
 	require.NoError(t, err)
 	require.Equal(t, int64(3), m)
 
-	m, err = providerKeeper.ComputeMinPowerToOptIn(ctx, bondedValidators, 85)
+	m, err = providerKeeper.ComputeMinPowerInTopN(ctx, bondedValidators, 85)
 	require.NoError(t, err)
 	require.Equal(t, int64(3), m)
 
-	m, err = providerKeeper.ComputeMinPowerToOptIn(ctx, bondedValidators, 84)
+	m, err = providerKeeper.ComputeMinPowerInTopN(ctx, bondedValidators, 84)
 	require.NoError(t, err)
 	require.Equal(t, int64(5), m)
 
-	m, err = providerKeeper.ComputeMinPowerToOptIn(ctx, bondedValidators, 65)
+	m, err = providerKeeper.ComputeMinPowerInTopN(ctx, bondedValidators, 65)
 	require.NoError(t, err)
 	require.Equal(t, int64(5), m)
 
-	m, err = providerKeeper.ComputeMinPowerToOptIn(ctx, bondedValidators, 64)
+	m, err = providerKeeper.ComputeMinPowerInTopN(ctx, bondedValidators, 64)
 	require.NoError(t, err)
 	require.Equal(t, int64(6), m)
 
-	m, err = providerKeeper.ComputeMinPowerToOptIn(ctx, bondedValidators, 50)
+	m, err = providerKeeper.ComputeMinPowerInTopN(ctx, bondedValidators, 50)
 	require.NoError(t, err)
 	require.Equal(t, int64(6), m)
 
-	m, err = providerKeeper.ComputeMinPowerToOptIn(ctx, bondedValidators, 40)
+	m, err = providerKeeper.ComputeMinPowerInTopN(ctx, bondedValidators, 40)
 	require.NoError(t, err)
 	require.Equal(t, int64(10), m)
 
-	m, err = providerKeeper.ComputeMinPowerToOptIn(ctx, bondedValidators, 1)
+	m, err = providerKeeper.ComputeMinPowerInTopN(ctx, bondedValidators, 1)
 	require.NoError(t, err)
 	require.Equal(t, int64(10), m)
 
-	_, err = providerKeeper.ComputeMinPowerToOptIn(ctx, bondedValidators, 0)
+	_, err = providerKeeper.ComputeMinPowerInTopN(ctx, bondedValidators, 0)
 	require.Error(t, err)
 
-	_, err = providerKeeper.ComputeMinPowerToOptIn(ctx, bondedValidators, 101)
+	_, err = providerKeeper.ComputeMinPowerInTopN(ctx, bondedValidators, 101)
 	require.Error(t, err)
 }
 

--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -233,8 +233,11 @@ func (k Keeper) QueueVSCPackets(ctx sdk.Context) {
 
 		if topN > 0 {
 			// in a Top-N chain, we automatically opt in all validators that belong to the top N
-			minPower, err := k.ComputeMinPowerToOptIn(ctx, bondedValidators, topN)
+			minPower, err := k.ComputeMinPowerInTopN(ctx, bondedValidators, topN)
 			if err == nil {
+				// set the minimal power of validators in the top N in the store
+				k.SetMinimumPowerInTopN(ctx, chainID, minPower)
+
 				k.OptInTopNValidators(ctx, chainID, bondedValidators, minPower)
 			} else {
 				// we just log here and do not panic because panic-ing would halt the provider chain

--- a/x/ccv/provider/migrations/migrator.go
+++ b/x/ccv/provider/migrations/migrator.go
@@ -54,7 +54,10 @@ func (m Migrator) Migrate4to5(ctx sdktypes.Context) error {
 }
 
 // Migrate5to6 migrates x/ccvprovider state from consensus version 5 to 6.
-// The migration consists of initializing new provider chain params using params from the legacy store.
+// The migration consists of
+// - computing and storing the minimal power in the top N for all registered consumer chains.
+// - initializing new provider chain params using params from the legacy store.
 func (m Migrator) Migrate5to6(ctx sdktypes.Context) error {
+	v6.MigrateMinPowerInTopN(ctx, m.providerKeeper)
 	return v6.MigrateLegacyParams(ctx, m.providerKeeper, m.paramSpace)
 }

--- a/x/ccv/provider/migrations/v6/migrations.go
+++ b/x/ccv/provider/migrations/v6/migrations.go
@@ -19,3 +19,33 @@ func MigrateLegacyParams(ctx sdk.Context, keeper providerkeeper.Keeper, legacyPa
 	keeper.Logger(ctx).Info("successfully migrated legacy provider parameters")
 	return nil
 }
+
+func MigrateMinPowerInTopN(ctx sdk.Context, providerKeeper providerkeeper.Keeper) {
+	// we only get the registered consumer chains and not also the proposed consumer chains because
+	// the minimal power is first set when the consumer chain addition proposal passes
+	registeredConsumerChains := providerKeeper.GetAllRegisteredConsumerChainIDs(ctx)
+
+	for _, chain := range registeredConsumerChains {
+		// get the top N
+		topN, found := providerKeeper.GetTopN(ctx, chain)
+		if !found {
+			providerKeeper.Logger(ctx).Error("failed to get top N", "chain", chain)
+			continue
+		} else if topN == 0 {
+			providerKeeper.Logger(ctx).Info("top N is 0, not setting minimal power", "chain", chain)
+		} else {
+			// set the minimal power in the top N
+			bondedValidators, err := providerKeeper.GetLastBondedValidators(ctx)
+			if err != nil {
+				providerKeeper.Logger(ctx).Error("failed to get last bonded validators", "chain", chain, "error", err)
+				continue
+			}
+			minPower, err := providerKeeper.ComputeMinPowerInTopN(ctx, bondedValidators, topN)
+			if err != nil {
+				providerKeeper.Logger(ctx).Error("failed to compute min power in top N", "chain", chain, "topN", topN, "error", err)
+				continue
+			}
+			providerKeeper.SetMinimumPowerInTopN(ctx, chain, minPower)
+		}
+	}
+}

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -183,6 +183,10 @@ const (
 	// per validator per consumer chain
 	ConsumerCommissionRatePrefix
 
+	// MinimumPowerInTopNBytePrefix is the byte prefix for storing the
+	// minimum power required to be in the top N per consumer chain.
+	MinimumPowerInTopNBytePrefix
+
 	// NOTE: DO NOT ADD NEW BYTE PREFIXES HERE WITHOUT ADDING THEM TO getAllKeyPrefixes() IN keys_test.go
 )
 
@@ -611,6 +615,10 @@ func ConsumerCommissionRateKey(chainID string, providerAddr ProviderConsAddress)
 		chainID,
 		providerAddr.ToSdkConsAddr(),
 	)
+}
+
+func MinimumPowerInTopNKey(chainID string) []byte {
+	return ChainIdWithLenKey(MinimumPowerInTopNBytePrefix, chainID)
 }
 
 //

--- a/x/ccv/provider/types/keys_test.go
+++ b/x/ccv/provider/types/keys_test.go
@@ -61,6 +61,7 @@ func getAllKeyPrefixes() []byte {
 		providertypes.TopNBytePrefix,
 		providertypes.ConsumerRewardsAllocationBytePrefix,
 		providertypes.ConsumerCommissionRatePrefix,
+		providertypes.MinimumPowerInTopNBytePrefix,
 		providertypes.ParametersByteKey,
 	}
 }


### PR DESCRIPTION
backport of (#1952)

* Store the minimal power among the top N in EndBlock

* Finish merge

* Fix unit tests

* Fix store method for the min power

* Fix migration

* Revert migration changes

* Change comment to proper name for key

* Add staking keeper to migration

* Revert "Add staking keeper to migration"

This reverts commit 575cfd3ccec7732e0d1488d80bda7f6172110cf7.

* Rename migration

* Update x/ccv/provider/keeper/grpc_query.go

* Clean up minimal power in top N on StopConsumerChain

* Set min power in consumer modification proposal

* Address comments

* Use GetLastBondedValidators instead of GetLastValidators

* Add migration

* Add comment for migration

* Improve comment in migration

* Handle case where topN is not found

* Add test for updating minimum power in top N

* Merged tests

* Rename updatedMinPower->newUpdatedMinPower

* Address comments

Please go to the `Preview` tab and select the appropriate sub-template:

* [Production code](?expand=1&template=production.md) - for types `fix`, `feat`, and `refactor`.
* [Docs](?expand=1&template=docs.md) - for documentation changes.
* [Others](?expand=1&template=others.md) - for changes that do not affect production code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced functionality to set, get, and delete minimum power required for a validator to be in the top N for consumer chains.
	- Updated migration to compute and store minimum power in the top N for all registered consumer chains.

- **Bug Fixes**
	- Enhanced error handling and logging for cases where minimum power values are not found.

- **Refactor**
	- Renamed functions related to computing and setting minimum power to improve clarity.
	- Updated logic in various functions to incorporate new minimum power settings.

- **Tests**
	- Added and updated tests to validate new minimum power functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->