### PR TITLE
fix!: update PSS reward distribution to work with SDK v0.50.0 changes

### DIFF
--- a/tests/integration/distribution.go
+++ b/tests/integration/distribution.go
@@ -744,7 +744,7 @@ func (s *CCVTestSuite) TestAllocateTokens() {
 
 	// At this point the distribution module account
 	// only holds the community pool's tokens
-	// since there zero validators outstanding rewards
+	// since there are no validators with outstanding rewards
 	lastCommPool := getDistrAcctBalFn(s.providerCtx())
 
 	// execute BeginBlock to trigger the token allocation

--- a/tests/integration/distribution.go
+++ b/tests/integration/distribution.go
@@ -733,7 +733,7 @@ func (s *CCVTestSuite) TestAllocateTokens() {
 	}
 
 	// Iterate over the validators and
-	// store their current voting power and outstanding rewards
+	// store their outstanding rewards
 	lastValOutRewards := map[string]sdk.DecCoins{}
 	totalValsRewards := sdk.DecCoins{}
 	for _, val := range s.providerChain.Vals.Validators {

--- a/tests/integration/distribution.go
+++ b/tests/integration/distribution.go
@@ -777,7 +777,7 @@ func (s *CCVTestSuite) TestAllocateTokens() {
 		)
 	}
 
-	// check that the total expected rewards is transferred to the distribution module account
+	// check that the total expected rewards are transferred to the distribution module account
 	allocRemPerConsu := providerKeeper.GetConsumerRewardsAllocation(s.providerCtx(), s.consumerChain.ChainID).Rewards
 	totalRewardsDistributed := sdk.NewDecCoinsFromCoins(totalRewards...).Sub(allocRemPerConsu.MulDec(math.LegacyNewDec(int64(consNum))))
 

--- a/tests/integration/distribution.go
+++ b/tests/integration/distribution.go
@@ -732,7 +732,7 @@ func (s *CCVTestSuite) TestAllocateTokens() {
 		)
 	}
 
-	// Iterate over the validators and
+	// iterate over the validators and verify that no validator has outstanding rewards
 	totalValsRewards := sdk.DecCoins{}
 	for _, val := range s.providerChain.Vals.Validators {
 		valRewards, err := distributionKeeper.GetValidatorOutstandingRewards(s.providerCtx(), sdk.ValAddress(val.Address))

--- a/tests/integration/distribution.go
+++ b/tests/integration/distribution.go
@@ -761,7 +761,7 @@ func (s *CCVTestSuite) TestAllocateTokens() {
 
 	rewardsPerChain, _ := rewardsPerConsumerDec.
 		MulDecTruncate(math.LegacyOneDec().Sub(communityTax)).TruncateDecimal()
-	validatorsExpRewardsPerchain := sdk.NewDecCoinsFromCoins(rewardsPerChain...).QuoDec(math.LegacyNewDec(int64(valNum)))
+	validatorsExpRewardsPerChain := sdk.NewDecCoinsFromCoins(rewardsPerChain...).QuoDec(math.LegacyNewDec(int64(valNum)))
 	// multiply by the number of consumers
 	validatorsExpRewards := validatorsExpRewardsPerchain.MulDec(math.LegacyNewDec(int64(consNum)))
 

--- a/x/ccv/provider/keeper/distribution.go
+++ b/x/ccv/provider/keeper/distribution.go
@@ -121,13 +121,13 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 		// compute rewards for validators
 		consumerRewards := alloc.Rewards
 		voteMultiplier := math.LegacyOneDec().Sub(communityTax)
-		feeMultiplier := consumerRewards.MulDecTruncate(voteMultiplier)
+		validatorRewards := consumerRewards.MulDecTruncate(voteMultiplier)
 
 		// compute remaining rewards for the community pool
-		remaining := consumerRewards.Sub(feeMultiplier)
+		remaining := consumerRewards.Sub(validatorRewards)
 
 		// transfer validators rewards to distribution module account
-		feeMultiplierTrunc, feeMultiplierChange := feeMultiplier.TruncateDecimal()
+		feeMultiplierTrunc, feeMultiplierChange := validatorRewards.TruncateDecimal()
 		err = k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ConsumerRewardsPool, distrtypes.ModuleName, feeMultiplierTrunc)
 		if err != nil {
 			k.Logger(ctx).Error(

--- a/x/ccv/provider/keeper/distribution.go
+++ b/x/ccv/provider/keeper/distribution.go
@@ -127,8 +127,8 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 		remaining := consumerRewards.Sub(validatorRewards)
 
 		// transfer validators rewards to distribution module account
-		validatorRewardsTrunc, validatorRewardsChange := validatorRewards.TruncateDecimal()
-		err = k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ConsumerRewardsPool, distrtypes.ModuleName, validatorRewardsTrunc)
+		validatorsRewardsTrunc, validatorsRewardsChange := validatorRewards.TruncateDecimal()
+		err = k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ConsumerRewardsPool, distrtypes.ModuleName, validatorsRewardsTrunc)
 		if err != nil {
 			k.Logger(ctx).Error(
 				"cannot send rewards to distribution module account %s: %s",
@@ -142,12 +142,12 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 		k.AllocateTokensToConsumerValidators(
 			ctx,
 			consumerChainID,
-			sdk.NewDecCoinsFromCoins(validatorRewardsTrunc...),
+			sdk.NewDecCoinsFromCoins(validatorsRewardsTrunc...),
 		)
 
 		// allocate remaining rewards to the community pool
-		remainingCoins, remainingChanges := remaining.TruncateDecimal()
-		err = k.distributionKeeper.FundCommunityPool(context.Context(ctx), remainingCoins, k.accountKeeper.GetModuleAccount(ctx, types.ConsumerRewardsPool).GetAddress())
+		remainingRewards, remainingChanges := remaining.TruncateDecimal()
+		err = k.distributionKeeper.FundCommunityPool(context.Context(ctx), remainingRewards, k.accountKeeper.GetModuleAccount(ctx, types.ConsumerRewardsPool).GetAddress())
 		if err != nil {
 			k.Logger(ctx).Error(
 				"fail to allocate rewards from consumer chain %s to community pool: %s",
@@ -158,7 +158,7 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 		}
 
 		// set consumer allocations to the remaining rewards decimals
-		alloc.Rewards = validatorRewardsChange.Add(remainingChanges...)
+		alloc.Rewards = validatorsRewardsChange.Add(remainingChanges...)
 		k.SetConsumerRewardsAllocation(ctx, consumerChainID, alloc)
 	}
 }

--- a/x/ccv/provider/keeper/distribution.go
+++ b/x/ccv/provider/keeper/distribution.go
@@ -121,13 +121,13 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 		// compute rewards for validators
 		consumerRewards := alloc.Rewards
 		voteMultiplier := math.LegacyOneDec().Sub(communityTax)
-		validatorRewards := consumerRewards.MulDecTruncate(voteMultiplier)
+		validatorsRewards := consumerRewards.MulDecTruncate(voteMultiplier)
 
 		// compute remaining rewards for the community pool
-		remaining := consumerRewards.Sub(validatorRewards)
+		remaining := consumerRewards.Sub(validatorsRewards)
 
 		// transfer validators rewards to distribution module account
-		validatorsRewardsTrunc, validatorsRewardsChange := validatorRewards.TruncateDecimal()
+		validatorsRewardsTrunc, validatorsRewardsChange := validatorsRewards.TruncateDecimal()
 		err = k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ConsumerRewardsPool, distrtypes.ModuleName, validatorsRewardsTrunc)
 		if err != nil {
 			k.Logger(ctx).Error(

--- a/x/ccv/provider/keeper/distribution.go
+++ b/x/ccv/provider/keeper/distribution.go
@@ -76,29 +76,20 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 
 	// Iterate over all registered consumer chains
 	for _, consumerChainID := range k.GetAllRegisteredConsumerChainIDs(ctx) {
-		// transfer the consumer rewards to the distribution module account
-		// note that the rewards transferred are only consumer whitelisted denoms
-		rewardsCollected, err := k.TransferConsumerRewardsToDistributionModule(ctx, consumerChainID)
-		if err != nil {
-			k.Logger(ctx).Error(
-				"fail to transfer rewards to distribution module for chain %s: %s",
-				consumerChainID,
-				err,
-			)
-			continue
-		}
 
 		// note that it's possible that no rewards are collected even though the
 		// reward pool isn't empty. This can happen if the reward pool holds some tokens
 		// of non-whitelisted denominations.
-		if rewardsCollected.IsZero() {
+		alloc := k.GetConsumerRewardsAllocation(ctx, consumerChainID)
+		if alloc.Rewards.IsZero() {
 			continue
 		}
 
 		// temporary workaround to keep CanWithdrawInvariant happy
 		// general discussions here: https://github.com/cosmos/cosmos-sdk/issues/2906#issuecomment-441867634
 		if k.ComputeConsumerTotalVotingPower(ctx, consumerChainID) == 0 {
-			err := k.distributionKeeper.FundCommunityPool(context.Context(ctx), rewardsCollected, k.accountKeeper.GetModuleAccount(ctx, types.ConsumerRewardsPool).GetAddress())
+			rewardsToSend, rewardsChange := alloc.Rewards.TruncateDecimal()
+			err := k.distributionKeeper.FundCommunityPool(context.Context(ctx), rewardsToSend, k.accountKeeper.GetModuleAccount(ctx, types.ConsumerRewardsPool).GetAddress())
 			if err != nil {
 				k.Logger(ctx).Error(
 					"fail to allocate rewards from consumer chain %s to community pool: %s",
@@ -106,12 +97,17 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 					err,
 				)
 			}
+
+			// set the consumer allocation to the remaining reward decimals
+			alloc.Rewards = rewardsChange
+			k.SetConsumerRewardsAllocation(ctx, consumerChainID, alloc)
+
 			return
 		}
 
-		// calculate the reward allocations
-		rewardsCollectedDec := sdk.NewDecCoinsFromCoins(rewardsCollected...)
-		remaining := rewardsCollectedDec
+		// Consumer rewards are distributed between the validators and the community pool.
+		// The decimals resulting from the distribution are expected to remain in the consumer reward allocations.
+
 		communityTax, err := k.distributionKeeper.GetCommunityTax(ctx)
 		if err != nil {
 			k.Logger(ctx).Error(
@@ -121,19 +117,36 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 			)
 			continue
 		}
+
+		// compute rewards for validators
+		consumerRewards := alloc.Rewards
 		voteMultiplier := math.LegacyOneDec().Sub(communityTax)
-		feeMultiplier := rewardsCollectedDec.MulDecTruncate(voteMultiplier)
+		feeMultiplier := consumerRewards.MulDecTruncate(voteMultiplier)
+
+		// compute remaining rewards for the community pool
+		remaining := consumerRewards.Sub(feeMultiplier)
+
+		// transfer validators rewards to distribution module account
+		feeMultiplierTrunc, feeMultiplierChange := feeMultiplier.TruncateDecimal()
+		err = k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ConsumerRewardsPool, distrtypes.ModuleName, feeMultiplierTrunc)
+		if err != nil {
+			k.Logger(ctx).Error(
+				"cannot send rewards to distribution module account %s: %s",
+				consumerChainID,
+				err,
+			)
+			continue
+		}
 
 		// allocate tokens to consumer validators
-		feeAllocated := k.AllocateTokensToConsumerValidators(
+		k.AllocateTokensToConsumerValidators(
 			ctx,
 			consumerChainID,
-			feeMultiplier,
+			sdk.NewDecCoinsFromCoins(feeMultiplierTrunc...),
 		)
-		remaining = remaining.Sub(feeAllocated)
 
-		// allocate community funding
-		remainingCoins, _ := remaining.TruncateDecimal()
+		// allocate remaining rewards to the community pool
+		remainingCoins, remainingChanges := remaining.TruncateDecimal()
 		err = k.distributionKeeper.FundCommunityPool(context.Context(ctx), remainingCoins, k.accountKeeper.GetModuleAccount(ctx, types.ConsumerRewardsPool).GetAddress())
 		if err != nil {
 			k.Logger(ctx).Error(
@@ -143,6 +156,10 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 			)
 			continue
 		}
+
+		// set consumer allocations to the remaining rewards decimals
+		alloc.Rewards = feeMultiplierChange.Add(remainingChanges...)
+		k.SetConsumerRewardsAllocation(ctx, consumerChainID, alloc)
 	}
 }
 
@@ -203,39 +220,6 @@ func (k Keeper) AllocateTokensToConsumerValidators(
 	}
 
 	return allocated
-}
-
-// TransferConsumerRewardsToDistributionModule transfers the rewards allocation of the given consumer chain
-// from the consumer rewards pool to the distribution module
-func (k Keeper) TransferConsumerRewardsToDistributionModule(
-	ctx sdk.Context,
-	chainID string,
-) (sdk.Coins, error) {
-	// Get coins of the consumer rewards allocation
-	allocation := k.GetConsumerRewardsAllocation(ctx, chainID)
-
-	if allocation.Rewards.IsZero() {
-		return sdk.Coins{}, nil
-	}
-
-	// Truncate coin rewards
-	rewardsToSend, remRewards := allocation.Rewards.TruncateDecimal()
-
-	// NOTE the consumer rewards allocation isn't a module account, however its coins
-	// are held in the consumer reward pool module account. Thus the consumer
-	// rewards allocation must be reduced separately from the SendCoinsFromModuleToAccount call.
-
-	// Update consumer rewards allocation with the remaining decimal coins
-	allocation.Rewards = remRewards
-
-	// Send coins to distribution module account
-	err := k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ConsumerRewardsPool, distrtypes.ModuleName, rewardsToSend)
-	if err != nil {
-		return sdk.Coins{}, err
-	}
-
-	k.SetConsumerRewardsAllocation(ctx, chainID, allocation)
-	return rewardsToSend, nil
 }
 
 // consumer reward pools getter and setter

--- a/x/ccv/provider/keeper/distribution.go
+++ b/x/ccv/provider/keeper/distribution.go
@@ -127,8 +127,8 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 		remaining := consumerRewards.Sub(validatorRewards)
 
 		// transfer validators rewards to distribution module account
-		feeMultiplierTrunc, feeMultiplierChange := validatorRewards.TruncateDecimal()
-		err = k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ConsumerRewardsPool, distrtypes.ModuleName, feeMultiplierTrunc)
+		validatorRewardsTrunc, validatorRewardsChange := validatorRewards.TruncateDecimal()
+		err = k.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ConsumerRewardsPool, distrtypes.ModuleName, validatorRewardsTrunc)
 		if err != nil {
 			k.Logger(ctx).Error(
 				"cannot send rewards to distribution module account %s: %s",
@@ -142,7 +142,7 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 		k.AllocateTokensToConsumerValidators(
 			ctx,
 			consumerChainID,
-			sdk.NewDecCoinsFromCoins(feeMultiplierTrunc...),
+			sdk.NewDecCoinsFromCoins(validatorRewardsTrunc...),
 		)
 
 		// allocate remaining rewards to the community pool
@@ -158,7 +158,7 @@ func (k Keeper) AllocateTokens(ctx sdk.Context) {
 		}
 
 		// set consumer allocations to the remaining rewards decimals
-		alloc.Rewards = feeMultiplierChange.Add(remainingChanges...)
+		alloc.Rewards = validatorRewardsChange.Add(remainingChanges...)
 		k.SetConsumerRewardsAllocation(ctx, consumerChainID, alloc)
 	}
 }


### PR DESCRIPTION
SDK v0.50.x changes the methods for interacting with the community pool of the distribution module. The current PSS reward distribution data flow is as follows:

1. A consumer sends rewards to the provider module.
2. The provider module sends rewards to the distribution module.
3. The distribution module sends a fraction of the rewards to the validators.
4. The remaining rewards are allocated to the community pool (tokens stay in the distribution module account).

In SDK v0.50.x, step 4 is no longer possible, and the community pool must be updated using the [FundCommunityPool](https://github.com/cosmos/cosmos-sdk/blob/release/v0.50.x/x/distribution/keeper/keeper.go#L206) method, which combines sending funds to the distribution module account (step 1) and allocating them to the community pool (step 4).

Therefore, the PSS reward distribution data flow must be updated:

1. A consumer sends rewards to the provider module.
2. The provider module sends a fraction of the rewards to the distribution module.
3. The distribution module sends a fraction of the rewards to the validators.
4. The provider module sends the remaining rewards to the community pool using  `FundCommunityPool`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accuracy of reward allocation between consumers, validators, and the community pool.
  - Ensured proper handling of remaining reward decimals for precise distribution.

- **Tests**
  - Enhanced reward distribution test scenarios to verify pool balances during transfers and allocations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->