### PR TITLE
refactor!: Refactor the validator set storage and add provider consensus validator storage

### DIFF
--- a/x/ccv/provider/keeper/provider_consensus.go
+++ b/x/ccv/provider/keeper/provider_consensus.go
@@ -17,7 +17,7 @@ func (k Keeper) SetLastProviderConsensusValidator(
 }
 
 // SetLastProviderConsensusValSet resets the stored last validator set sent to the consensus engine on the provider
-// to the provided nextValidators.
+// to the provided `nextValidators“.
 func (k Keeper) SetLastProviderConsensusValSet(ctx sdk.Context, nextValidators []types.ConsumerValidator) {
 	k.setValSet(ctx, []byte{types.LastProviderConsensusValsPrefix}, nextValidators)
 }

--- a/x/ccv/provider/keeper/provider_consensus.go
+++ b/x/ccv/provider/keeper/provider_consensus.go
@@ -1,0 +1,56 @@
+package keeper
+
+import (
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/interchain-security/v5/x/ccv/provider/types"
+)
+
+// SetLastProviderConsensusValidator sets the given validator to be stored
+// as part of the last provider consensus validator set
+func (k Keeper) SetLastProviderConsensusValidator(
+	ctx sdk.Context,
+	validator types.ConsumerValidator,
+) {
+	k.setValidator(ctx, []byte{types.LastProviderConsensusValsPrefix}, validator)
+}
+
+// SetLastProviderConsensusValSet resets the stored last validator set sent to the consensus engine on the provider
+// to the provided nextValidators.
+func (k Keeper) SetLastProviderConsensusValSet(ctx sdk.Context, nextValidators []types.ConsumerValidator) {
+	k.setValSet(ctx, []byte{types.LastProviderConsensusValsPrefix}, nextValidators)
+}
+
+// DeleteLastProviderConsensusValidator removes the validator with `providerConsAddr` address
+// from the stored last provider consensus validator set
+func (k Keeper) DeleteLastProviderConsensusValidator(
+	ctx sdk.Context,
+	providerConsAddr types.ProviderConsAddress,
+) {
+	k.deleteValidator(ctx, []byte{types.LastProviderConsensusValsPrefix}, providerConsAddr)
+}
+
+// DeleteLastProviderConsensusValSet deletes all the stored validators from the
+// last provider consensus validator set
+func (k Keeper) DeleteLastProviderConsensusValSet(
+	ctx sdk.Context,
+) {
+	k.deleteValSet(ctx, []byte{types.LastProviderConsensusValsPrefix})
+}
+
+// GetLastProviderConsensusValSet returns the last stored
+// validator set sent to the consensus engine on the provider
+func (k Keeper) GetLastProviderConsensusValSet(
+	ctx sdk.Context,
+) []types.ConsumerValidator {
+	return k.getValSet(ctx, []byte{types.LastProviderConsensusValsPrefix})
+}
+
+// GetLastTotalProviderConsensusPower returns the total power of the last stored
+// validator set sent to the consensus engine on the provider
+func (k Keeper) GetLastTotalProviderConsensusPower(
+	ctx sdk.Context,
+) math.Int {
+	return k.getTotalPower(ctx, []byte{types.LastProviderConsensusValsPrefix})
+}

--- a/x/ccv/provider/keeper/provider_consensus_test.go
+++ b/x/ccv/provider/keeper/provider_consensus_test.go
@@ -1,0 +1,102 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/cometbft/cometbft/proto/tendermint/crypto"
+	"github.com/stretchr/testify/require"
+
+	testkeeper "github.com/cosmos/interchain-security/v5/testutil/keeper"
+	"github.com/cosmos/interchain-security/v5/x/ccv/provider/types"
+)
+
+func TestSetLastProviderConsensusValidator(t *testing.T) {
+	providerKeeper, ctx, ctrl, _ := testkeeper.GetProviderKeeperAndCtx(t, testkeeper.NewInMemKeeperParams(t))
+	defer ctrl.Finish()
+
+	validator := types.ConsumerValidator{
+		ProviderConsAddr:  []byte("providerConsAddr"),
+		Power:             2,
+		ConsumerPublicKey: &crypto.PublicKey{},
+	}
+
+	providerKeeper.SetLastProviderConsensusValidator(ctx, validator)
+
+	// Retrieve the stored validator
+	storedValidator := providerKeeper.GetLastProviderConsensusValSet(ctx)[0]
+
+	require.Equal(t, validator, storedValidator, "stored validator does not match")
+}
+
+func TestSetLastProviderConsensusValSet(t *testing.T) {
+	providerKeeper, ctx, ctrl, _ := testkeeper.GetProviderKeeperAndCtx(t, testkeeper.NewInMemKeeperParams(t))
+	defer ctrl.Finish()
+
+	validator1 := types.ConsumerValidator{
+		ProviderConsAddr:  []byte("providerConsAddr1"),
+		Power:             2,
+		ConsumerPublicKey: &crypto.PublicKey{},
+	}
+
+	validator2 := types.ConsumerValidator{
+		ProviderConsAddr:  []byte("providerConsAddr2"),
+		Power:             3,
+		ConsumerPublicKey: &crypto.PublicKey{},
+	}
+
+	nextValidators := []types.ConsumerValidator{validator1, validator2}
+
+	providerKeeper.SetLastProviderConsensusValSet(ctx, nextValidators)
+
+	// Retrieve the stored validator set
+	storedValidators := providerKeeper.GetLastProviderConsensusValSet(ctx)
+	require.Equal(t, nextValidators, storedValidators, "stored validator set does not match")
+}
+
+func TestDeleteLastProviderConsensusValidator(t *testing.T) {
+	providerKeeper, ctx, ctrl, _ := testkeeper.GetProviderKeeperAndCtx(t, testkeeper.NewInMemKeeperParams(t))
+	defer ctrl.Finish()
+
+	validator := types.ConsumerValidator{
+		ProviderConsAddr:  []byte("providerConsAddr"),
+		Power:             2,
+		ConsumerPublicKey: &crypto.PublicKey{},
+	}
+
+	providerKeeper.SetLastProviderConsensusValidator(ctx, validator)
+
+	// Delete the stored validator
+	providerKeeper.DeleteLastProviderConsensusValidator(ctx, types.NewProviderConsAddress(validator.ProviderConsAddr))
+
+	// Ensure the validator is deleted
+	storedValidators := providerKeeper.GetLastProviderConsensusValSet(ctx)
+	require.Empty(t, storedValidators, "validator set should be empty")
+}
+
+func TestDeleteLastProviderConsensusValSet(t *testing.T) {
+	providerKeeper, ctx, ctrl, _ := testkeeper.GetProviderKeeperAndCtx(t, testkeeper.NewInMemKeeperParams(t))
+	defer ctrl.Finish()
+
+	validator1 := types.ConsumerValidator{
+		ProviderConsAddr:  []byte("providerConsAddr1"),
+		Power:             2,
+		ConsumerPublicKey: &crypto.PublicKey{},
+	}
+
+	validator2 := types.ConsumerValidator{
+		ProviderConsAddr:  []byte("providerConsAddr2"),
+		Power:             3,
+		ConsumerPublicKey: &crypto.PublicKey{},
+	}
+
+	nextValidators := []types.ConsumerValidator{validator1, validator2}
+
+	providerKeeper.SetLastProviderConsensusValSet(ctx, nextValidators)
+
+	// Delete the stored validator set
+	providerKeeper.DeleteLastProviderConsensusValSet(ctx)
+
+	// Ensure the validator set is empty
+	storedValidators := providerKeeper.GetLastProviderConsensusValSet(ctx)
+	require.Empty(t, storedValidators, "validator set should be empty")
+}

--- a/x/ccv/provider/keeper/provider_consensus_test.go
+++ b/x/ccv/provider/keeper/provider_consensus_test.go
@@ -3,6 +3,7 @@ package keeper_test
 import (
 	"testing"
 
+	"cosmossdk.io/math"
 	"github.com/cometbft/cometbft/proto/tendermint/crypto"
 	"github.com/stretchr/testify/require"
 
@@ -99,4 +100,25 @@ func TestDeleteLastProviderConsensusValSet(t *testing.T) {
 	// Ensure the validator set is empty
 	storedValidators := providerKeeper.GetLastProviderConsensusValSet(ctx)
 	require.Empty(t, storedValidators, "validator set should be empty")
+}
+
+func TestGetLastTotalProviderConsensusPower(t *testing.T) {
+	providerKeeper, ctx, ctrl, _ := testkeeper.GetProviderKeeperAndCtx(t, testkeeper.NewInMemKeeperParams(t))
+	defer ctrl.Finish()
+	validator1 := types.ConsumerValidator{
+		ProviderConsAddr:  []byte("providerConsAddr1"),
+		Power:             2,
+		ConsumerPublicKey: &crypto.PublicKey{},
+	}
+	validator2 := types.ConsumerValidator{
+		ProviderConsAddr:  []byte("providerConsAddr2"),
+		Power:             3,
+		ConsumerPublicKey: &crypto.PublicKey{},
+	}
+	nextValidators := []types.ConsumerValidator{validator1, validator2}
+	providerKeeper.SetLastProviderConsensusValSet(ctx, nextValidators)
+	// Get the total power of the last stored validator set
+	totalPower := providerKeeper.GetLastTotalProviderConsensusPower(ctx)
+	expectedTotalPower := math.NewInt(5)
+	require.Equal(t, expectedTotalPower, totalPower, "total power does not match")
 }

--- a/x/ccv/provider/keeper/validator_set_storage.go
+++ b/x/ccv/provider/keeper/validator_set_storage.go
@@ -77,10 +77,10 @@ func (k Keeper) isValidator(ctx sdk.Context, prefix []byte, providerAddr types.P
 // getValSet returns all the validators stored under the given prefix.
 func (k Keeper) getValSet(
 	ctx sdk.Context,
-	key []byte,
+	prefix []byte,
 ) (validators []types.ConsumerValidator) {
 	store := ctx.KVStore(k.storeKey)
-	iterator := storetypes.KVStorePrefixIterator(store, key)
+	iterator := storetypes.KVStorePrefixIterator(store, prefix)
 	defer iterator.Close()
 
 	for ; iterator.Valid(); iterator.Next() {

--- a/x/ccv/provider/keeper/validator_set_storage.go
+++ b/x/ccv/provider/keeper/validator_set_storage.go
@@ -95,6 +95,7 @@ func (k Keeper) getValSet(
 	return validators
 }
 
+// getTotalPower computes the total power of all the consumer validators stored under the given prefix.
 func (k Keeper) getTotalPower(ctx sdk.Context, prefix []byte) math.Int {
 	totalPower := math.ZeroInt()
 	validators := k.getValSet(ctx, prefix)

--- a/x/ccv/provider/keeper/validator_set_storage.go
+++ b/x/ccv/provider/keeper/validator_set_storage.go
@@ -1,0 +1,105 @@
+package keeper
+
+import (
+	"fmt"
+
+	"cosmossdk.io/math"
+	storetypes "cosmossdk.io/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/interchain-security/v5/x/ccv/provider/types"
+)
+
+// getValidatorKey constructs the key to access a given validator, stored under a given prefix.
+func (k Keeper) getValidatorKey(prefix []byte, providerAddr types.ProviderConsAddress) []byte {
+	return append(prefix, providerAddr.ToSdkConsAddr()...)
+}
+
+// setValidator stores the given `validator` in the validator set stored under the given prefix.
+func (k Keeper) setValidator(
+	ctx sdk.Context,
+	prefix []byte,
+	validator types.ConsumerValidator,
+) {
+	store := ctx.KVStore(k.storeKey)
+	bz, err := validator.Marshal()
+	if err != nil {
+		panic(fmt.Errorf("failed to marshal ConsumerValidator: %w", err))
+	}
+
+	store.Set(k.getValidatorKey(prefix, types.NewProviderConsAddress(validator.ProviderConsAddr)), bz)
+}
+
+// setValSet resets the validator set stored under the given prefix to the provided `nextValidators`.
+func (k Keeper) setValSet(ctx sdk.Context, prefix []byte, nextValidators []types.ConsumerValidator) {
+	k.deleteValSet(ctx, prefix)
+	for _, val := range nextValidators {
+		k.setValidator(ctx, prefix, val)
+	}
+}
+
+// deleteValidator removes validator with `providerAddr` address from the
+// validator set stored under the given prefix.
+func (k Keeper) deleteValidator(
+	ctx sdk.Context,
+	prefix []byte,
+	providerConsAddr types.ProviderConsAddress,
+) {
+	store := ctx.KVStore(k.storeKey)
+	store.Delete(k.getValidatorKey(prefix, providerConsAddr))
+}
+
+// deleteValSet deletes all the stored consumer validators under the given prefix.
+func (k Keeper) deleteValSet(
+	ctx sdk.Context,
+	prefix []byte,
+) {
+	store := ctx.KVStore(k.storeKey)
+	iterator := storetypes.KVStorePrefixIterator(store, prefix)
+
+	var keysToDel [][]byte
+	defer iterator.Close()
+	for ; iterator.Valid(); iterator.Next() {
+		keysToDel = append(keysToDel, iterator.Key())
+	}
+	for _, delKey := range keysToDel {
+		store.Delete(delKey)
+	}
+}
+
+// isValidator returns `true` if the validator with `providerAddr` exists
+// in the validator set stored under the given prefix.
+func (k Keeper) isValidator(ctx sdk.Context, prefix []byte, providerAddr types.ProviderConsAddress) bool {
+	store := ctx.KVStore(k.storeKey)
+	return store.Get(k.getValidatorKey(prefix, providerAddr)) != nil
+}
+
+// getValSet returns all the validators stored under the given prefix.
+func (k Keeper) getValSet(
+	ctx sdk.Context,
+	key []byte,
+) (validators []types.ConsumerValidator) {
+	store := ctx.KVStore(k.storeKey)
+	iterator := storetypes.KVStorePrefixIterator(store, key)
+	defer iterator.Close()
+
+	for ; iterator.Valid(); iterator.Next() {
+		iterator.Value()
+		var validator types.ConsumerValidator
+		if err := validator.Unmarshal(iterator.Value()); err != nil {
+			panic(fmt.Errorf("failed to unmarshal ConsumerValidator: %w", err))
+		}
+		validators = append(validators, validator)
+	}
+
+	return validators
+}
+
+func (k Keeper) getTotalPower(ctx sdk.Context, prefix []byte) math.Int {
+	totalPower := math.ZeroInt()
+	validators := k.getValSet(ctx, prefix)
+	for _, val := range validators {
+		totalPower = totalPower.Add(math.NewInt(val.Power))
+	}
+	return totalPower
+}

--- a/x/ccv/provider/keeper/validator_set_update.go
+++ b/x/ccv/provider/keeper/validator_set_update.go
@@ -12,8 +12,8 @@ import (
 	ccv "github.com/cosmos/interchain-security/v5/x/ccv/types"
 )
 
-// GetConsumerChainKey returns the store key for consumer validators of the consumer chain with `chainID`
-func (k Keeper) GetConsumerChainKey(ctx sdk.Context, chainID string) []byte {
+// GetConsumerChainConsensusValidatorsKey returns the store key for consumer validators of the consumer chain with `chainID`
+func (k Keeper) GetConsumerChainConsensusValidatorsKey(ctx sdk.Context, chainID string) []byte {
 	return types.ChainIdWithLenKey(types.ConsumerValidatorBytePrefix, chainID)
 }
 
@@ -23,13 +23,13 @@ func (k Keeper) SetConsumerValidator(
 	chainID string,
 	validator types.ConsumerValidator,
 ) {
-	k.setValidator(ctx, k.GetConsumerChainKey(ctx, chainID), validator)
+	k.setValidator(ctx, k.GetConsumerChainConsensusValidatorsKey(ctx, chainID), validator)
 }
 
 // SetConsumerValSet resets the current consumer validators with the `nextValidators` computed by
 // `FilterValidators` and hence this method should only be called after `FilterValidators` has completed.
 func (k Keeper) SetConsumerValSet(ctx sdk.Context, chainID string, nextValidators []types.ConsumerValidator) {
-	k.setValSet(ctx, k.GetConsumerChainKey(ctx, chainID), nextValidators)
+	k.setValSet(ctx, k.GetConsumerChainConsensusValidatorsKey(ctx, chainID), nextValidators)
 }
 
 // DeleteConsumerValidator removes consumer validator with `providerAddr` address
@@ -38,7 +38,7 @@ func (k Keeper) DeleteConsumerValidator(
 	chainID string,
 	providerConsAddr types.ProviderConsAddress,
 ) {
-	k.deleteValidator(ctx, k.GetConsumerChainKey(ctx, chainID), providerConsAddr)
+	k.deleteValidator(ctx, k.GetConsumerChainConsensusValidatorsKey(ctx, chainID), providerConsAddr)
 }
 
 // DeleteConsumerValSet deletes all the stored consumer validators for chain `chainID`
@@ -46,13 +46,13 @@ func (k Keeper) DeleteConsumerValSet(
 	ctx sdk.Context,
 	chainID string,
 ) {
-	k.deleteValSet(ctx, k.GetConsumerChainKey(ctx, chainID))
+	k.deleteValSet(ctx, k.GetConsumerChainConsensusValidatorsKey(ctx, chainID))
 }
 
 // IsConsumerValidator returns `true` if the consumer validator with `providerAddr` exists for chain `chainID`
 // and `false` otherwise
 func (k Keeper) IsConsumerValidator(ctx sdk.Context, chainID string, providerAddr types.ProviderConsAddress) bool {
-	return k.isValidator(ctx, k.GetConsumerChainKey(ctx, chainID), providerAddr)
+	return k.isValidator(ctx, k.GetConsumerChainConsensusValidatorsKey(ctx, chainID), providerAddr)
 }
 
 // GetConsumerValSet returns all the consumer validators for chain `chainID`
@@ -60,7 +60,7 @@ func (k Keeper) GetConsumerValSet(
 	ctx sdk.Context,
 	chainID string,
 ) []types.ConsumerValidator {
-	return k.getValSet(ctx, k.GetConsumerChainKey(ctx, chainID))
+	return k.getValSet(ctx, k.GetConsumerChainConsensusValidatorsKey(ctx, chainID))
 }
 
 // DiffValidators compares the current and the next epoch's consumer validators and returns the `ValidatorUpdate` diff

--- a/x/ccv/provider/keeper/validator_set_update.go
+++ b/x/ccv/provider/keeper/validator_set_update.go
@@ -3,7 +3,6 @@ package keeper
 import (
 	"fmt"
 
-	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
@@ -13,28 +12,24 @@ import (
 	ccv "github.com/cosmos/interchain-security/v5/x/ccv/types"
 )
 
+// GetConsumerChainKey returns the store key for consumer validators of the consumer chain with `chainID`
+func (k Keeper) GetConsumerChainKey(ctx sdk.Context, chainID string) []byte {
+	return types.ChainIdWithLenKey(types.ConsumerValidatorBytePrefix, chainID)
+}
+
 // SetConsumerValidator sets provided consumer `validator` on the consumer chain with `chainID`
 func (k Keeper) SetConsumerValidator(
 	ctx sdk.Context,
 	chainID string,
 	validator types.ConsumerValidator,
 ) {
-	store := ctx.KVStore(k.storeKey)
-	bz, err := validator.Marshal()
-	if err != nil {
-		panic(fmt.Errorf("failed to marshal ConsumerValidator: %w", err))
-	}
-
-	store.Set(types.ConsumerValidatorKey(chainID, validator.ProviderConsAddr), bz)
+	k.setValidator(ctx, k.GetConsumerChainKey(ctx, chainID), validator)
 }
 
 // SetConsumerValSet resets the current consumer validators with the `nextValidators` computed by
 // `FilterValidators` and hence this method should only be called after `FilterValidators` has completed.
 func (k Keeper) SetConsumerValSet(ctx sdk.Context, chainID string, nextValidators []types.ConsumerValidator) {
-	k.DeleteConsumerValSet(ctx, chainID)
-	for _, val := range nextValidators {
-		k.SetConsumerValidator(ctx, chainID, val)
-	}
+	k.setValSet(ctx, k.GetConsumerChainKey(ctx, chainID), nextValidators)
 }
 
 // DeleteConsumerValidator removes consumer validator with `providerAddr` address
@@ -43,8 +38,7 @@ func (k Keeper) DeleteConsumerValidator(
 	chainID string,
 	providerConsAddr types.ProviderConsAddress,
 ) {
-	store := ctx.KVStore(k.storeKey)
-	store.Delete(types.ConsumerValidatorKey(chainID, providerConsAddr.ToSdkConsAddr()))
+	k.deleteValidator(ctx, k.GetConsumerChainKey(ctx, chainID), providerConsAddr)
 }
 
 // DeleteConsumerValSet deletes all the stored consumer validators for chain `chainID`
@@ -52,47 +46,21 @@ func (k Keeper) DeleteConsumerValSet(
 	ctx sdk.Context,
 	chainID string,
 ) {
-	store := ctx.KVStore(k.storeKey)
-	key := types.ChainIdWithLenKey(types.ConsumerValidatorBytePrefix, chainID)
-	iterator := storetypes.KVStorePrefixIterator(store, key)
-
-	var keysToDel [][]byte
-	defer iterator.Close()
-	for ; iterator.Valid(); iterator.Next() {
-		keysToDel = append(keysToDel, iterator.Key())
-	}
-	for _, delKey := range keysToDel {
-		store.Delete(delKey)
-	}
+	k.deleteValSet(ctx, k.GetConsumerChainKey(ctx, chainID))
 }
 
 // IsConsumerValidator returns `true` if the consumer validator with `providerAddr` exists for chain `chainID`
 // and `false` otherwise
 func (k Keeper) IsConsumerValidator(ctx sdk.Context, chainID string, providerAddr types.ProviderConsAddress) bool {
-	store := ctx.KVStore(k.storeKey)
-	return store.Get(types.ConsumerValidatorKey(chainID, providerAddr.ToSdkConsAddr())) != nil
+	return k.isValidator(ctx, k.GetConsumerChainKey(ctx, chainID), providerAddr)
 }
 
 // GetConsumerValSet returns all the consumer validators for chain `chainID`
 func (k Keeper) GetConsumerValSet(
 	ctx sdk.Context,
 	chainID string,
-) (validators []types.ConsumerValidator) {
-	store := ctx.KVStore(k.storeKey)
-	key := types.ChainIdWithLenKey(types.ConsumerValidatorBytePrefix, chainID)
-	iterator := storetypes.KVStorePrefixIterator(store, key)
-	defer iterator.Close()
-
-	for ; iterator.Valid(); iterator.Next() {
-		iterator.Value()
-		var validator types.ConsumerValidator
-		if err := validator.Unmarshal(iterator.Value()); err != nil {
-			panic(fmt.Errorf("failed to unmarshal ConsumerValidator: %w", err))
-		}
-		validators = append(validators, validator)
-	}
-
-	return validators
+) []types.ConsumerValidator {
+	return k.getValSet(ctx, k.GetConsumerChainKey(ctx, chainID))
 }
 
 // DiffValidators compares the current and the next epoch's consumer validators and returns the `ValidatorUpdate` diff

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -187,6 +187,10 @@ const (
 	// minimum power required to be in the top N per consumer chain.
 	MinimumPowerInTopNBytePrefix
 
+	// LastProviderConsensusValsPrefix is byte prefix for storing the last validator set
+	// sent to the consensus engine of the provider chain
+	LastProviderConsensusValsPrefix
+
 	// NOTE: DO NOT ADD NEW BYTE PREFIXES HERE WITHOUT ADDING THEM TO getAllKeyPrefixes() IN keys_test.go
 )
 
@@ -619,6 +623,12 @@ func ConsumerCommissionRateKey(chainID string, providerAddr ProviderConsAddress)
 
 func MinimumPowerInTopNKey(chainID string) []byte {
 	return ChainIdWithLenKey(MinimumPowerInTopNBytePrefix, chainID)
+}
+
+// LastProviderConsensusValidatorKey returns the key of the validator with `providerAddr`
+// in the last validator set sent to the consensus engine of the provider chain
+func LastProviderConsensusValidatorKey(providerAddr []byte) []byte {
+	return append([]byte{LastProviderConsensusValsPrefix}, providerAddr...)
 }
 
 //

--- a/x/ccv/provider/types/keys.go
+++ b/x/ccv/provider/types/keys.go
@@ -187,7 +187,7 @@ const (
 	// minimum power required to be in the top N per consumer chain.
 	MinimumPowerInTopNBytePrefix
 
-	// LastProviderConsensusValsPrefix is byte prefix for storing the last validator set
+	// LastProviderConsensusValsPrefix is the byte prefix for storing the last validator set
 	// sent to the consensus engine of the provider chain
 	LastProviderConsensusValsPrefix
 

--- a/x/ccv/provider/types/keys_test.go
+++ b/x/ccv/provider/types/keys_test.go
@@ -62,6 +62,7 @@ func getAllKeyPrefixes() []byte {
 		providertypes.ConsumerRewardsAllocationBytePrefix,
 		providertypes.ConsumerCommissionRatePrefix,
 		providertypes.MinimumPowerInTopNBytePrefix,
+		providertypes.LastProviderConsensusValsPrefix,
 		providertypes.ParametersByteKey,
 	}
 }


### PR DESCRIPTION
<!--
The production pull request template is for types feat, fix, or refactor.
-->

## Description

Closes: Part of #1913 
<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Refactors the validator set storage.
This is done to allow storing a separate validator set under its own individual key,
namely the provider consensus validator set, without ever clashing with the storage
for consumer chains here.

Changes:

* Introduce new, more flexible helper methods for storing valsets in validator_set_storage
* Change the existing valset methods in validator_set_update to use the new helpers
* Introduce provider_consensus, where the new wrapper methods are used to store the provider consensus validator set

The provider_consensus methods are not used yet, but will be in a future PR.
I want to split the functionality and keep this PR small to keep it easy to review

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] Added `!` to the type prefix if the change is [state-machine breaking](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes)
* [ ] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
* [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] Provided a link to the relevant issue or specification
* [x] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/00-intro.md)
* [x] Included the necessary unit and integration [tests](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry to `CHANGELOG.md`
* [x] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [x] Confirmed all CI checks have passed
* [ ] If this PR is library API breaking, bump the go.mod version string of the repo, and follow through on a new major release

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` the type prefix if the change is state-machine breaking
* [ ] confirmed this PR does not introduce changes requiring state migrations, OR confirmed migration code has been added to consumer and/or provider modules
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced management of the last provider consensus validator set, including setting, resetting, deleting, and retrieving validator sets and their powers.
  
- **Refactor**
	- Consolidated key retrieval logic and simplified operations for handling consumer validators.

- **Tests**
	- Added tests to validate setting, retrieving, and deleting provider consensus validators and validator sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->