### PR TITLE
docs: fix broken link on docs page

### DIFF
--- a/docs/docs/adrs/intro.md
+++ b/docs/docs/adrs/intro.md
@@ -26,7 +26,7 @@ If recorded decisions turned out to be lacking, convene a discussion, record the
 
 Note the context/background should be written in the present tense.
 
-To suggest an ADR, please make use of the [ADR template](./templates/adr-template.md) provided.
+To suggest an ADR, please make use of the [ADR template](https://github.com/cosmos/interchain-security/blob/main/docs/docs/adrs/templates/adr-template.md) provided.
 
 ## Table of Contents
 


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct `docs:` prefix in the PR title
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)
- [ ] Checked that the documentation website can be built and deployed successfully (run `make build-docs`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the link to the ADR template in `intro.md` to point to a new location on GitHub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->