### PR TITLE
chore:  rm mbt, trace tests from CI; fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,7 +38,7 @@ updates:
     labels:
       - dependencies
 
-    - package-ecosystem: gomod
+  - package-ecosystem: gomod
     directory: "/"
     schedule:
       interval: daily

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,7 @@ jobs:
 
   repo-analysis:
     runs-on: ubuntu-latest
-    needs: [tests, test-integration, test-mbt]
+    needs: [tests, test-integration]
     steps:
       - uses: actions/checkout@v4
       - uses: technote-space/get-diff-action@v6.1.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,49 +90,6 @@ jobs:
           name: "${{ github.sha }}-integration-coverage"
           path: ./integration-profile.out
 
-  test-mbt:
-    runs-on: Gaia-Runner-medium
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.22"
-          check-latest: true
-          cache: true
-          cache-dependency-path: go.sum
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ">= 18"
-          check-latest: true
-      - run: npm i @informalsystems/quint -g
-      - uses: technote-space/get-diff-action@v6.1.2
-        id: git_diff
-        with:
-          PATTERNS: |
-            **/*.go
-            go.mod
-            go.sum
-            **/go.mod
-            **/go.sum
-            **/Makefile
-            Makefile
-      - name: mbt tests
-        if: env.GIT_DIFF
-        run: |
-          make test-mbt-cov
-      - uses: actions/upload-artifact@v4
-        if: env.GIT_DIFF
-        with:
-          name: "${{ github.sha }}-mbt-coverage"
-          path: ./mbt-profile.out
-      - name: Archive MBT traces
-        uses: actions/upload-artifact@v4
-        if: ${{ success() || failure() }} # to upload the traces only when the test failed
-        with:
-          name: mbt-traces
-          path: tests/mbt/driver/traces
-          retention-days: 6 # to not clog our cloud storage too much, we retain only for a few days
-
   repo-analysis:
     runs-on: ubuntu-latest
     needs: [tests, test-integration, test-mbt]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -186,36 +186,6 @@ jobs:
         run: |
           make test-e2e-compatibility-tests-latest
 
-  test-trace:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
-      - name: checkout LFS objects
-        run: git lfs checkout
-      - uses: actions/setup-go@v5
-        with:
-          go-version: "1.22"
-          check-latest: true
-          cache: true
-          cache-dependency-path: go.sum
-      - uses: technote-space/get-diff-action@v6.1.2
-        id: git_diff
-        with:
-          PATTERNS: |
-            **/*.go
-            go.mod
-            go.sum
-            **/go.mod
-            **/go.sum
-            **/Makefile
-            Makefile
-            Dockerfile*
-      - name: trace-e2e tests
-        if: env.GIT_DIFF
-        run: |
-          make test-trace
   model-analysis:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

Closes: #N/A

MBT is currently deprecated, and the tests fail regularly starting with the upgrade to Cosmos sdk v50.
Trace tests are doing the same work as e2e tests, so we are disabling them for the time being.

Dependabot configuration was broken a couple weeks ago.

For more context, see https://github.com/cosmos/interchain-security/issues/1987 for a brief overview of the future plans for randomized testing. 

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Removed redundant `test-mbt` and `test-trace` jobs from the CI workflow.
	- Adjusted indentation in the `.github/dependabot.yml` file for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->