### PR TITLE
build: use dedicated CI runner for tests

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,10 +9,11 @@ on:
   merge_group:
 permissions:
   contents: read
+
 jobs:
   golangci:
     name: golangci-lint
-    runs-on: ubuntu-latest
+    runs-on: Gaia-Runner-medium
     steps:
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
+    runs-on: Gaia-Runner-medium
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -60,7 +60,7 @@ jobs:
           path: ./profile.out
 
   test-integration:
-    runs-on: ubuntu-latest
+    runs-on: Gaia-Runner-medium
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -91,7 +91,7 @@ jobs:
           path: ./integration-profile.out
 
   test-mbt:
-    runs-on: ubuntu-latest
+    runs-on: Gaia-Runner-medium
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -168,7 +168,7 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
   test-e2e:
-    runs-on: ubuntu-latest
+    runs-on: Gaia-Runner-medium
     steps:
       - uses: actions/checkout@v4
         with:
@@ -230,7 +230,7 @@ jobs:
           make test-e2e-compatibility-tests-latest
 
   test-cometmock:
-    runs-on: ubuntu-latest
+    runs-on: Gaia-Runner-medium
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Use dedicated runner for required tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI workflows to use `Gaia-Runner-medium` instead of `ubuntu-latest` for linting and testing jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->