### PR TITLE
test: fix e2e compatiblity tests for provider v4.3.0-lsm

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -36,7 +36,7 @@ jobs:
         # Run compatibility tests for different consumer (-cv) and provider (-pv) versions.
         # Combination of all provider versions with consumer versions are tested.
         # For new versions to be tested add/modify -pc/-cv parameters.
-        run: go run ./tests/e2e/... --tc compatibility -pv latest -pv v4.3.0-lsm -pv v3.3.3-lsm -cv latest -cv v4.3.0 -cv v3.3.0 -cv v3.2.0
+        run: go run ./tests/e2e/... --tc compatibility -pv latest -pv v4.3.0-lsm -pv v3.3.3-lsm -cv latest -cv v4.3.0 -cv v3.3.0
   happy-path-test:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -36,7 +36,7 @@ jobs:
         # Run compatibility tests for different consumer (-cv) and provider (-pv) versions.
         # Combination of all provider versions with consumer versions are tested.
         # For new versions to be tested add/modify -pc/-cv parameters.
-        run: go run ./tests/e2e/... --tc compatibility -pv latest -pv v4.0.0 -pv v3.3.3-lsm -cv latest -cv v4.0.0 -cv v3.3.0 -cv v3.2.0
+        run: go run ./tests/e2e/... --tc compatibility -pv latest -pv v4.3.0-lsm -pv v3.3.3-lsm -cv latest -cv v4.3.0 -cv v3.3.0 -cv v3.2.0
   happy-path-test:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/tests/e2e/config.go
+++ b/tests/e2e/config.go
@@ -491,7 +491,7 @@ func CompatibilityTestConfig(providerVersion, consumerVersion string) TestConfig
 				".app_state.provider.params.slash_meter_replenish_period = \"3s\"",
 		}
 	} else if semver.Compare(semver.MajorMinor(providerVersion), "v4.3.0") >= 0 && strings.HasSuffix(providerVersion, "-lsm") {
-		// v4.3.0-lsm introduced 'expedited governance proposal' which are not in main northe genesis needs a
+		// v4.3.0-lsm introduced 'expedited governance proposal' which needs `expedited_voting_period` parameter to be set in genesis
 		fmt.Println("Using provider chain config for versions >= v4.3.0-lsm")
 		providerConfig = ChainConfig{
 			ChainId:        ChainID("provi"),


### PR DESCRIPTION
## Description

Issue: e2e compatiblity tests are failing with provider version v4.3.0-lsm

Reason:
since v4.3.0-lsm provider supports expedited governance proposal
which requires to set related parameter in genesis file.
current compatibility tests failed not setting this parameter with a valid value.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated nightly end-to-end tests to include version changes for provider and consumer configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->