### PR TITLE
chore: Change coderabbit config to require high confidence in reported issues

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -11,22 +11,22 @@ reviews:
         - "!docs/"
     path_instructions:
         - path: "**/*.go"
-          instructions: "Review the Golang code for conformity with the Uber Golang style guide, highlighting any deviations."
+          instructions: "Review the Golang code for conformity with the Uber Golang style guide, highlighting any deviations. Only report issues that you have a high degree of confidence in."
         - path: "tests/e2e/*"
           instructions: |
-              "Assess the e2e test code assessing sufficient code coverage for the changes associated in the pull request"
+              "Assess the e2e test code assessing sufficient code coverage for the changes associated in the pull request. Only report issues that you have a high degree of confidence in."
         - path: "tests/integration/*"
           instructions: |
-              "Assess the e2e test code assessing sufficient code coverage for the changes associated in the pull request"
+              "Assess the e2e test code assessing sufficient code coverage for the changes associated in the pull request. Only report issues that you have a high degree of confidence in."
         - path: "**/*_test.go"
           instructions: |
-              "Assess the unit test code assessing sufficient code coverage for the changes associated in the pull request"
+              "Assess the unit test code assessing sufficient code coverage for the changes associated in the pull request. Only report issues that you have a high degree of confidence in."
         - path: "**/*.md"
           instructions: |
-              "Assess the documentation for misspellings, grammatical errors, missing documentation and correctness. Please DO NOT report any missing or superfluous newlines, in particular at the end or beginning of files."
+              "Assess the documentation for misspellings, grammatical errors, missing documentation and correctness. Please DO NOT report any missing or superfluous newlines, in particular at the end or beginning of files. Only report issues that you have a high degree of confidence in."
         - path: ".changelog/*"
           instructions: |
-              "Assess the changes in the changelog for correctness and completeness, particularly flagging missing changes"
+              "Assess the changes in the changelog for correctness and completeness, particularly flagging missing changes. Only report issues that you have a high degree of confidence in."
     auto_review:
         enabled: true
         ignore_title_keywords:


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate sub-template:

* [Production code](?expand=1&template=production.md) - for types `fix`, `feat`, and `refactor`.
* [Docs](?expand=1&template=docs.md) - for documentation changes.
* [Others](?expand=1&template=others.md) - for changes that do not affect production code.

Trying to make coderabbit be less noisy. There is no specific setting for it, so I hope this might help.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated review instructions to improve issue reporting and ensure sufficient code coverage in tests and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->