### PR TITLE
fix: compatibility test change

### DIFF
--- a/tests/e2e/steps_compatibility.go
+++ b/tests/e2e/steps_compatibility.go
@@ -90,18 +90,6 @@ func compstepsStartConsumerChain(consumerName string, proposalIndex, chainIndex 
 			},
 		},
 		{
-			// op should fail - key already assigned by the same validator
-			Action: AssignConsumerPubKeyAction{
-				Chain:           ChainID(consumerName),
-				Validator:       ValidatorID("carol"),
-				ConsumerPubkey:  getDefaultValidators()[ValidatorID("carol")].ConsumerValPubKey,
-				ReconfigureNode: false,
-				ExpectError:     true,
-				ExpectedError:   "a validator has assigned the consumer key already: consumer key is already in use by a validator",
-			},
-			State: State{},
-		},
-		{
 			// op should fail - key already assigned by another validator
 			Action: AssignConsumerPubKeyAction{
 				Chain:     ChainID(consumerName),


### PR DESCRIPTION
<!--
The production pull request template is for types feat, fix, or refactor.
-->

## Description

Compatibility test runs the provider for version `v4.4.0` but in `v4.4.0` this PR's removed testcase is not failing:
```
2024/07/18 18:17:58 expected error not raised: expected: 'a validator has assigned the consumer key already: consumer key is already in use by a validator', got 'gas estimate: 32519
{"height":"0","txhash":"110BA23D8388914624EC58F8842683B7DC238635CE93FD69F20A28E27541B9D2","codespace":"","code":0,"data":"","raw_log":"[]","logs":[],"info":"","gas_wanted":"0","gas_used":"0","tx":null,"timestamp":"","events":[]}
'
```
 The testcase starts failing after the change performed [here](https://github.com/cosmos/interchain-security/pull/2062).

This PR removes this testcase so that the compatibility test does not complain. Note however, that the removed testcase still resides [here](https://github.com/cosmos/interchain-security/blob/main/tests/e2e/steps_start_chains.go#L89-L98) (e.g., in the `happy-path`) and hence we do not miss anything by removing this testcase from the compatibility test.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] Added `!` to the type prefix if the change is [state-machine breaking](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes)
* [ ] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
* [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] Provided a link to the relevant issue or specification
* [ ] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/00-intro.md)
* [ ] Included the necessary unit and integration [tests](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry to `CHANGELOG.md`
* [ ] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [ ] Confirmed all CI checks have passed
* [ ] If this PR is library API breaking, bump the go.mod version string of the repo, and follow through on a new major release

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` the type prefix if the change is state-machine breaking
* [ ] confirmed this PR does not introduce changes requiring state migrations, OR confirmed migration code has been added to consumer and/or provider modules
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed a test case that checked for operation failure when a consumer public key is assigned by the same validator, refining the testing logic.
	- Updated the remaining test case to focus on failure conditions related to consumer public keys assigned by different validators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->