### PR TITLE
docs: rm extra sections from docusaurus cfg

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -45,14 +45,6 @@ const config = {
               label: "main",
               banner: "unreleased",
             },
-            "v4.2.0-docs": {
-              path: "/v4.2.0/",
-              label: "v4.2.0",
-              banner: "none",
-            },
-            "v5.0.0": {
-              banner: "unreleased",
-            },
           },
           remarkPlugins: [remarkMath],
           rehypePlugins: [rehypeKatex],


### PR DESCRIPTION
Update `docusaurus.config.js` to prevent subpages from being built.

During the build process the tool would try to reference `v5.0.0` and `v4.2.0` docs which are not available on this branch. This would cause the build pipeline to break in a very confusing way and cause some docs pages to not appear in the dropdown selector menus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated documentation configuration by removing outdated version entries, streamlining the version management process.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->