### PR TITLE
fix: fix signer in the commission rate message

### DIFF
--- a/proto/interchain_security/ccv/provider/v1/tx.proto
+++ b/proto/interchain_security/ccv/provider/v1/tx.proto
@@ -285,7 +285,7 @@ message MsgSetConsumerCommissionRate {
     ];
   // signer address
   string signer = 4 [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  }
+}
 
 
 message MsgSetConsumerCommissionRateResponse {}

--- a/x/ccv/provider/client/cli/tx.go
+++ b/x/ccv/provider/client/cli/tx.go
@@ -325,7 +325,8 @@ func NewSetConsumerCommissionRateCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			msg := types.NewMsgSetConsumerCommissionRate(args[0], commission, sdk.ValAddress(providerValAddr))
+			signer := clientCtx.GetFromAddress().String()
+			msg := types.NewMsgSetConsumerCommissionRate(args[0], commission, sdk.ValAddress(providerValAddr), signer)
 			if err := msg.ValidateBasic(); err != nil {
 				return err
 			}

--- a/x/ccv/provider/types/msg.go
+++ b/x/ccv/provider/types/msg.go
@@ -424,11 +424,12 @@ func (msg MsgOptOut) ValidateBasic() error {
 }
 
 // NewMsgSetConsumerCommissionRate creates a new MsgSetConsumerCommissionRate msg instance.
-func NewMsgSetConsumerCommissionRate(chainID string, commission math.LegacyDec, providerValidatorAddress sdk.ValAddress) *MsgSetConsumerCommissionRate {
+func NewMsgSetConsumerCommissionRate(chainID string, commission math.LegacyDec, providerValidatorAddress sdk.ValAddress, signer string) *MsgSetConsumerCommissionRate {
 	return &MsgSetConsumerCommissionRate{
 		ChainId:      chainID,
 		Rate:         commission,
 		ProviderAddr: providerValidatorAddress.String(),
+		Signer:       signer,
 	}
 }
 


### PR DESCRIPTION
## Description
Issuing a `MsgSetConsumerCommissionRate` message was giving us back:
```
gaiad tx provider set-consumer-commission-rate pion-1 0.15 --from apple --gas auto --gas-adjustment 2 --gas-prices 0.005uatom -y
Error: rpc error: code = Unknown desc = rpc error: code = Unknown desc = no cosmos.msg.v1.signer option found for message interchain_security.ccv.provider.v1.MsgSetConsumerCommissionRate;
```
We [added the `signer`](https://github.com/cosmos/interchain-security/pull/2095) but we still received that the address is missing.

This PR fixes this issue by setting the `Signer` field in the message. After this PR changes, when we issue a 
`MsgSetConsumerCommissionRate` against a local `gaiad` node we get:
```
failed to execute message; message index: 0: unknown consumer chain, with id: chain-1: no consumer chain with this chain id'
```
which means the message got parsed correctly and was about to be [handled](https://github.com/cosmos/interchain-security/blob/v5.1.0/x/ccv/provider/keeper/distribution.go#L318).

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] Added `!` to the type prefix if the change is [state-machine breaking](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes)
* [ ] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
* [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] Provided a link to the relevant issue or specification
* [ ] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/00-intro.md)
* [ ] Included the necessary unit and integration [tests](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry to `CHANGELOG.md`
* [ ] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [ ] Confirmed all CI checks have passed
* [ ] If this PR is library API breaking, bump the go.mod version string of the repo, and follow through on a new major release

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` the type prefix if the change is state-machine breaking
* [ ] confirmed this PR does not introduce changes requiring state migrations, OR confirmed migration code has been added to consumer and/or provider modules
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced transaction validation by including a signer address in the consumer commission rate message creation.
  
- **Bug Fixes**
	- Minor structural adjustment to the message definition for improved clarity, with no impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->