### PR TITLE
chore: fix spelling errors

### DIFF
--- a/docs/docs/adrs/adr-018-remove-vscmatured.md
+++ b/docs/docs/adrs/adr-018-remove-vscmatured.md
@@ -37,7 +37,7 @@ This would result in a discrepancy between a light client’s view of the `Unbon
 ## Decision
 
 This ADR proposes the removal of `VSCMaturedPackets`. The reason is twofold. 
-First, `VSCMaturedPackets` provide a "false" sense of correctness as the attack discribed above is still possible.
+First, `VSCMaturedPackets` provide a "false" sense of correctness as the attack described above is still possible.
 Second, `VSCMaturedPackets` add considerable complexity to the ICS protocol -- an extra message plus the pausing of unbonding operations that can affect the UX.
 
 To simplify the upgrading process, removing `VSCMaturedPackets` can be done in two releases:


### PR DESCRIPTION
This PR fixes typos in the codebase.
Please review it, and merge if everything is fine.
If there are proto changes, run `make proto-gen` and commit the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the Architectural Decision Record (ADR) to clarify the rationale behind the removal of `VSCMaturedPackets`, improving understanding of its impact on the protocol.
	- Corrected a typo in the ADR for enhanced clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->