### PR TITLE
test: Fix use of hardcoded cosmos... address

### DIFF
--- a/tests/integration/distribution.go
+++ b/tests/integration/distribution.go
@@ -138,7 +138,8 @@ func (s *CCVTestSuite) TestRewardsDistribution() {
 	consuValsRewards := consumerValsOutstandingRewardsFunc(s.providerCtx())
 
 	// increase the block height so validators are eligible for consumer rewards (see `IsEligibleForConsumerRewards`)
-	numberOfBlocksToStartReceivingRewards := providerKeeper.GetNumberOfEpochsToStartReceivingRewards(s.providerCtx()) * providerKeeper.GetBlocksPerEpoch(s.providerCtx())
+	numberOfBlocksToStartReceivingRewards :=
+		providerKeeper.GetNumberOfEpochsToStartReceivingRewards(s.providerCtx()) * providerKeeper.GetBlocksPerEpoch(s.providerCtx())
 
 	for s.providerCtx().BlockHeight() <= numberOfBlocksToStartReceivingRewards {
 		s.providerChain.NextBlock()

--- a/tests/integration/distribution.go
+++ b/tests/integration/distribution.go
@@ -566,8 +566,7 @@ func (s *CCVTestSuite) TestIBCTransferMiddleware() {
 		},
 		{
 			"IBC Transfer coin denom isn't registered",
-			func(ctx sdk.Context, keeper *providerkeeper.Keeper, bankKeeper icstestingutils.TestBankKeeper) {
-			},
+			func(ctx sdk.Context, keeper *providerkeeper.Keeper, bankKeeper icstestingutils.TestBankKeeper) {},
 			false,
 			false,
 		},


### PR DESCRIPTION
## Description

Closes: #N/A

Changes handling of a hardcoded address to be done with fixed prefix

This should fix an issue that was surfaced by consumer chains that run this test, since their bech32 prefix is different

This is to address an issue that was surfaced by a consumer chain when upgrading to ICSv5.1.1

In general, if we want to offer our tests to consumer chains to test against, we cannot hardcode cosmos... addresses (at least in the integration and unit tests, where it seems this will mess things up)

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved accuracy of the "IBC Transfer recipient is not the consumer rewards pool address" test case by using a dynamic address instead of a hardcoded one.
  
- **Tests**
	- Enhanced test readability and functionality through streamlined setup functions.
	- Ensured consistent passing of the test suite context in test cases for better integration.
	- Introduced a new variable for improved test accuracy in the IBC Transfer middleware scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->