### PR TITLE
docs: improve changelog for Inactive Provider Validators

### DIFF
--- a/.changelog/unreleased/api-breaking/provider/2079-inactive-validators.md
+++ b/.changelog/unreleased/api-breaking/provider/2079-inactive-validators.md
@@ -7,7 +7,7 @@
     the maximum number of validators that will be passed to the provider consensus engine.
   - Add `no_valupdates_genutil` and `no_valupdates_staking`, "wrapper" modules around 
     the Cosmos SDK's native genutil and staking modules. Both modules provide the exact 
-    same functionality as the native modules, except returning validator set updates 
+    same functionality as the native modules, except for *not* returning validator set updates 
     to the provider consensus engine.
   - Return the first `max_provider_consensus_validators` validators (sorted by largest amount of stake first)
     to the provider consensus engine. 

--- a/.changelog/unreleased/api-breaking/provider/2079-inactive-validators.md
+++ b/.changelog/unreleased/api-breaking/provider/2079-inactive-validators.md
@@ -1,0 +1,15 @@
+- Add the _Inactive Provider Validators_ feature (as per 
+  [ADR-017](https://cosmos.github.io/interchain-security/adrs/adr-017-allowing-inactive-validators)),
+  which entails the following changes on the provider.
+  ([\#2079](https://github.com/cosmos/interchain-security/pull/2079))
+
+  - Add `max_provider_consensus_validators`, a provider module param that sets 
+    the maximum number of validators that will be passed to the provider consensus engine.
+  - Add `no_valupdates_genutil` and `no_valupdates_staking`, "wrapper" modules around 
+    the Cosmos SDK's native genutil and staking modules. Both modules provide the exact 
+    same functionality as the native modules, except returning validator set updates 
+    to the provider consensus engine.
+  - Return the first `max_provider_consensus_validators` validators (sorted by largest amount of stake first)
+    to the provider consensus engine. 
+  - Use the `max_validators` validators as basis for the validator sets sent to the consumers 
+    (`max_validators` is a staking module param).

--- a/.changelog/unreleased/features/provider/2035-min-stake-max-rank.md
+++ b/.changelog/unreleased/features/provider/2035-min-stake-max-rank.md
@@ -1,2 +1,3 @@
-- Add minimum stake requirement to let consumer chains
-  determine requirements for validators that validate their chain. ([\#2035](https://github.com/cosmos/interchain-security/pull/2035))
+- Add `min_stake`, a power shaping configuration that enables consumers to set 
+  the minimum amount of provider stake every validator needs to be eligible to opt-in.
+  ([\#2035](https://github.com/cosmos/interchain-security/pull/2035))

--- a/.changelog/unreleased/features/provider/2035-min-stake-max-rank.md
+++ b/.changelog/unreleased/features/provider/2035-min-stake-max-rank.md
@@ -1,3 +1,3 @@
-- Add `min_stake`, a power shaping configuration that enables consumers to set 
+- Add `min_stake`, a power shaping configuration parameter that enables consumers to set 
   the minimum amount of provider stake every validator needs to be eligible to opt-in.
   ([\#2035](https://github.com/cosmos/interchain-security/pull/2035))

--- a/.changelog/unreleased/features/provider/2066-allow-inactive-vals.md
+++ b/.changelog/unreleased/features/provider/2066-allow-inactive-vals.md
@@ -1,0 +1,3 @@
+- Add `allow_inactive_vals`, a power shaping configuration that enables consumers 
+  to specify whether validators outside the active provider validator set are eligible to opt-in. 
+  ([\#2066](https://github.com/cosmos/interchain-security/pull/2066))

--- a/.changelog/unreleased/features/provider/2066-allow-inactive-vals.md
+++ b/.changelog/unreleased/features/provider/2066-allow-inactive-vals.md
@@ -1,3 +1,3 @@
-- Add `allow_inactive_vals`, a power shaping configuration that enables consumers 
+- Add `allow_inactive_vals`, a power shaping configuration parameter that enables consumers 
   to specify whether validators outside the active provider validator set are eligible to opt-in. 
   ([\#2066](https://github.com/cosmos/interchain-security/pull/2066))

--- a/.changelog/unreleased/features/provider/2066-inactive-vals.md
+++ b/.changelog/unreleased/features/provider/2066-inactive-vals.md
@@ -1,1 +1,0 @@
-- Add the `allow_inactive_vals` parameter for consumer chains to choose whether inactive validators can validate their chain ([\#2066](https://github.com/cosmos/interchain-security/pull/2066))

--- a/.changelog/unreleased/features/provider/2079-inactive-validators.md
+++ b/.changelog/unreleased/features/provider/2079-inactive-validators.md
@@ -7,7 +7,7 @@
     the maximum number of validators that will be passed to the provider consensus engine.
   - Add `no_valupdates_genutil` and `no_valupdates_staking`, "wrapper" modules around 
     the Cosmos SDK's native genutil and staking modules. Both modules provide the exact 
-    same functionality as the native modules, except returning validator set updates 
+    same functionality as the native modules, except for *not* returning validator set updates 
     to the provider consensus engine.
   - Return the first `max_provider_consensus_validators` validators (sorted by largest amount of stake first)
     to the provider consensus engine. 

--- a/.changelog/unreleased/features/provider/2079-inactive-validators.md
+++ b/.changelog/unreleased/features/provider/2079-inactive-validators.md
@@ -1,0 +1,15 @@
+- Add the _Inactive Provider Validators_ feature (as per 
+  [ADR-017](https://cosmos.github.io/interchain-security/adrs/adr-017-allowing-inactive-validators)),
+  which entails the following changes on the provider.
+  ([\#2079](https://github.com/cosmos/interchain-security/pull/2079))
+
+  - Add `max_provider_consensus_validators`, a provider module param that sets 
+    the maximum number of validators that will be passed to the provider consensus engine.
+  - Add `no_valupdates_genutil` and `no_valupdates_staking`, "wrapper" modules around 
+    the Cosmos SDK's native genutil and staking modules. Both modules provide the exact 
+    same functionality as the native modules, except returning validator set updates 
+    to the provider consensus engine.
+  - Return the first `max_provider_consensus_validators` validators (sorted by largest amount of stake first)
+    to the provider consensus engine. 
+  - Use the `max_validators` validators as basis for the validator sets sent to the consumers 
+    (`max_validators` is a staking module param).

--- a/.changelog/unreleased/state-breaking/provider/2035-min-stake-max-rank.md
+++ b/.changelog/unreleased/state-breaking/provider/2035-min-stake-max-rank.md
@@ -1,2 +1,3 @@
-- Add minimum stake requirement to let consumer chains
-  determine requirements for validators that validate their chain. ([\#2035](https://github.com/cosmos/interchain-security/pull/2035))
+- Add `min_stake`, a power shaping configuration that enables consumers to set 
+  the minimum amount of provider stake every validator needs to be eligible to opt-in.
+  ([\#2035](https://github.com/cosmos/interchain-security/pull/2035))

--- a/.changelog/unreleased/state-breaking/provider/2035-min-stake-max-rank.md
+++ b/.changelog/unreleased/state-breaking/provider/2035-min-stake-max-rank.md
@@ -1,3 +1,3 @@
-- Add `min_stake`, a power shaping configuration that enables consumers to set 
+- Add `min_stake`, a power shaping configuration parameter that enables consumers to set 
   the minimum amount of provider stake every validator needs to be eligible to opt-in.
   ([\#2035](https://github.com/cosmos/interchain-security/pull/2035))

--- a/.changelog/unreleased/state-breaking/provider/2066-allow-inactive-vals.md
+++ b/.changelog/unreleased/state-breaking/provider/2066-allow-inactive-vals.md
@@ -1,0 +1,3 @@
+- Add `allow_inactive_vals`, a power shaping configuration that enables consumers 
+  to specify whether validators outside the active provider validator set are eligible to opt-in. 
+  ([\#2066](https://github.com/cosmos/interchain-security/pull/2066))

--- a/.changelog/unreleased/state-breaking/provider/2066-allow-inactive-vals.md
+++ b/.changelog/unreleased/state-breaking/provider/2066-allow-inactive-vals.md
@@ -1,3 +1,3 @@
-- Add `allow_inactive_vals`, a power shaping configuration that enables consumers 
+- Add `allow_inactive_vals`, a power shaping configuration parameter that enables consumers 
   to specify whether validators outside the active provider validator set are eligible to opt-in. 
   ([\#2066](https://github.com/cosmos/interchain-security/pull/2066))

--- a/.changelog/unreleased/state-breaking/provider/2066-inactive-vals.md
+++ b/.changelog/unreleased/state-breaking/provider/2066-inactive-vals.md
@@ -1,1 +1,0 @@
-- Add the `allow_inactive_vals` parameter for consumer chains to choose whether inactive validators can validate their chain ([\#2066](https://github.com/cosmos/interchain-security/pull/2066))

--- a/.changelog/unreleased/state-breaking/provider/2079-inactive-validators.md
+++ b/.changelog/unreleased/state-breaking/provider/2079-inactive-validators.md
@@ -1,0 +1,3 @@
+- Add the _Inactive Provider Validators_ feature (as per 
+  [ADR-017](https://cosmos.github.io/interchain-security/adrs/adr-017-allowing-inactive-validators)).
+  ([\#2079](https://github.com/cosmos/interchain-security/pull/2079))


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct `docs:` prefix in the PR title
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)
- [ ] Checked that the documentation website can be built and deployed successfully (run `make build-docs`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the _Inactive Provider Validators_ feature, enhancing provider functionality within the consensus mechanism.
	- Added a new `min_stake` configuration parameter for consumer chains to set minimum stake requirements for validators.
	- Launched the `allow_inactive_vals` option, providing flexibility in validator management by enabling inactive validators to participate in processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->