### PR TITLE
docs: Add integration doc for inactive validators

### DIFF
--- a/docs/docs/adrs/_category_.json
+++ b/docs/docs/adrs/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "ADRs",
-  "position": 6
+  "position": 7
 }

--- a/docs/docs/frequently-asked-questions.md
+++ b/docs/docs/frequently-asked-questions.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 title: "Frequently Asked Questions"
 slug: /faq
 ---

--- a/docs/docs/integrators/_category_.json
+++ b/docs/docs/integrators/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Integrators Guide",
+  "position": 5
+}

--- a/docs/docs/integrators/integrating_inactive_validators.md
+++ b/docs/docs/integrators/integrating_inactive_validators.md
@@ -24,4 +24,4 @@ The `bonded_tokens` will include the stake of all *bonded* validators. As the nu
 
 * All queries in the staking module that return a `Validator`
 
-All *bonded* validators will show with `Status=Bonded` . To identify *active* validators, query the validator set from Tendermint (https://docs.cometbft.com/v0.37/rpc/#/Info/validators or `query comet-validator-set [height]`), which will return the set of all *active* validators.
+All *bonded* validators will show with `Status=Bonded`. To identify *active* validators, query the validator set from Tendermint (https://docs.cometbft.com/v0.37/rpc/#/Info/validators or `query comet-validator-set [height]`), which will return the set of all *active* validators.

--- a/docs/docs/integrators/integrating_inactive_validators.md
+++ b/docs/docs/integrators/integrating_inactive_validators.md
@@ -18,7 +18,7 @@ Importantly, only *active* validators receive inflation rewards from ATOM; only 
 
 The following queries will change after this upgrade:
 
-* `/cosmos/staking/v1beta1/pool` / `gaiad query staking pool`
+* `/cosmos/staking/v1beta1/pool` / `query staking pool`
 
 The `bonded_tokens` will include the stake of all *bonded* validators. As the number of bonded validators will be increased as part of the upgrade, the number of `bonded_tokens` is expected to have a sudden increase after the upgrade is applied.
 

--- a/docs/docs/integrators/integrating_inactive_validators.md
+++ b/docs/docs/integrators/integrating_inactive_validators.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 ---
 
 # Inactive Validators Integration Guide

--- a/docs/docs/upgrading/integrating_inactive_validators.md
+++ b/docs/docs/upgrading/integrating_inactive_validators.md
@@ -22,6 +22,6 @@ The following queries will change after this upgrade:
 
 The `bonded_tokens` will include the stake of all *bonded* validators. As the number of bonded validators will be increased as part of the upgrade, the number of `bonded_tokens` is expected to have a sudden increase after the upgrade is applied.
 
-### All queries in the staking module that return a `Validator`
+* All queries in the staking module that return a `Validator`
 
 All *bonded* validators will show with `Status=Bonded` . To identify *active* validators, query the validator set from Tendermint (https://docs.cometbft.com/v0.37/rpc/#/Info/validators or `query comet-validator-set [height]`), which will return the set of all *active* validators.

--- a/docs/docs/upgrading/integrating_inactive_validators.md
+++ b/docs/docs/upgrading/integrating_inactive_validators.md
@@ -18,10 +18,10 @@ Importantly, only *active* validators receive inflation rewards from ATOM; only 
 
 The following queries will change after this upgrade:
 
-### `/cosmos/staking/v1beta1/pool`
+* `/cosmos/staking/v1beta1/pool` / `gaiad query staking pool`
 
-The *bonded_tokens* will include the stake of all *bonded* validators. As the number of bonded validators will be increased as part of the upgrade, the number of bonded_tokens is expected to have a sudden increase after the upgrade is applied.
+The `bonded_tokens` will include the stake of all *bonded* validators. As the number of bonded validators will be increased as part of the upgrade, the number of `bonded_tokens` is expected to have a sudden increase after the upgrade is applied.
 
 ### All queries in the staking module that return a `Validator`
 
-All *bonded* validators will show with `Status=Bonded` . To identify *active* validators, query the validator set from Tendermint (https://docs.cometbft.com/v0.37/rpc/#/Info/validators), which will return the set of all *active* validators.
+All *bonded* validators will show with `Status=Bonded` . To identify *active* validators, query the validator set from Tendermint (https://docs.cometbft.com/v0.37/rpc/#/Info/validators or `query comet-validator-set [height]`), which will return the set of all *active* validators.

--- a/docs/docs/upgrading/integrating_inactive_validators.md
+++ b/docs/docs/upgrading/integrating_inactive_validators.md
@@ -1,0 +1,27 @@
+---
+sidebar_position: 2
+---
+
+# Inactive Validators Integration Guide
+
+With the [inactive validators feature of Interchain Security](../adrs/adr-017-allowing-inactive-validators.md), validators outside of the active set on the provider chain can validate on consumer chains that allow this. Technically, this is achieved by *increasing* the MaxValidators paramater in the staking module, to let additional validators be part of the set of bonded validators. However, to keep the set of validators participating in consensus on the Cosmos Hub the same, we introduce the MaxProviderConsensusValidators parameter in the provider module, which will restrict the number of validators that actively validate on the provider chain.
+
+To clarify the terminology:
+
+*bonded* validators are all validators that are bonded on the Cosmos Hub, and
+
+*active* validators are all validators that actively participate in consensus on the Cosmos Hub.
+
+Before the introduction of the feature, these two terms were equivalent: every bonded validator was active, and every active validator was bonded. *After* the introduction of this feature, it still holds that every active validator is bonded, but not every bonded validator is active.
+
+Importantly, only *active* validators receive inflation rewards from ATOM; only *active* validators may vote on behalf of their delegators in governance, and *only active* validators can get slashed for downtime (because only those validators participate in consensus and produce blocks). Apart from these differences, *bonded but inactive* validators are just like *active* validators - they can receive delegations, and they can validate on consumer chains (and receive rewards for this) just like active validators.
+
+The following queries will change after this upgrade:
+
+### `/cosmos/staking/v1beta1/pool`
+
+The *bonded_tokens* will include the stake of all *bonded* validators. As the number of bonded validators will be increased as part of the upgrade, the number of bonded_tokens is expected to have a sudden increase after the upgrade is applied.
+
+### All queries in the staking module that return a `Validator`
+
+All *bonded* validators will show with `Status=Bonded` . To identify *active* validators, query the validator set from Tendermint (https://docs.cometbft.com/v0.37/rpc/#/Info/validators), which will return the set of all *active* validators.


### PR DESCRIPTION
## Description

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Improve docs for inactive vals, aimed at integrators.

We will link to these as part of an outreach to block explorers, wallets, staking platforms, and other integrators.

Please review the docs locally to see how this looks on the web:

`make build-docs-local`

In particular, interested in opinions on where this page should be (is it ok under `Upgrading`, should there be an extra section called `Integration`; other ideas on where it could be?)

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct `docs:` prefix in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct `docs:` prefix in the PR title
- [ ] Confirmed all author checklist items have been addressed 
- [ ] Confirmed that this PR only changes documentation
- [ ] Reviewed content for consistency
- [ ] Reviewed content for spelling and grammar
- [ ] Tested instructions (if applicable)
- [ ] Checked that the documentation website can be built and deployed successfully (run `make build-docs`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a detailed integration guide for the inactive validators feature, enhancing participation in Interchain Security.
	- Clarified the distinction between bonded and active validators, including implications for rewards and governance.
	- Updated information on query changes, specifically regarding the bonded_tokens reflecting all bonded validators.
	- Added a new "Integrators Guide" to improve documentation organization and accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->