### PR TITLE
chore: Forbid coderabbit on .md files

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -9,6 +9,7 @@ reviews:
     path_filters:
         - "!api/"
         - "!docs/"
+        - "!*.md"
     path_instructions:
         - path: "**/*.go"
           instructions: "Review the Golang code for conformity with the Uber Golang style guide, highlighting any deviations. Only report issues that you have a high degree of confidence in."

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -22,9 +22,6 @@ reviews:
         - path: "**/*_test.go"
           instructions: |
               "Assess the unit test code assessing sufficient code coverage for the changes associated in the pull request. Only report issues that you have a high degree of confidence in."
-        - path: ".changelog/*"
-          instructions: |
-              "Assess the changes in the changelog for correctness and completeness, particularly flagging missing changes. Only report issues that you have a high degree of confidence in."
     auto_review:
         enabled: true
         ignore_title_keywords:


### PR DESCRIPTION
Attempt #2.
#2099 just removed the path-specific instructions for coderabbit.
I hope this will work to stop it from touching .md files

It's hard to test locally, so unfortunately we have to iterate with PRs here

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a path filter to streamline the review process by excluding Markdown files from reviews.
  
- **Bug Fixes**
	- Removed the requirement for reviews on the changelog content.

- **Refactor**
	- Clarified review instructions for Golang code and unit tests, ensuring adherence to coding standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->