### PR TITLE
fix: Fix bug and add test case

### DIFF
--- a/tests/e2e/config.go
+++ b/tests/e2e/config.go
@@ -1297,6 +1297,12 @@ func GetHermesConfig(hermesVersion, queryNodeIP string, chainCfg ChainConfig, is
 	return hermesConfig
 }
 
+// GetExtraValidatorConfigs returns a map of extra validator configurations.
+// These are configurations that are not part of the default configurations,
+// for cases where more validators are needed.
+// Commented out fields are fields that can be set, but are not necessary for the test
+// they are used in so far.
+// These are left as guidance to fill out as they become relevant in the future.
 func GetExtraValidatorConfigs() map[ValidatorID]ValidatorConfig {
 	return map[ValidatorID]ValidatorConfig{
 		ValidatorID("david"): {

--- a/tests/e2e/main.go
+++ b/tests/e2e/main.go
@@ -246,6 +246,12 @@ var stepChoices = map[string]StepChoice{
 		description: "test minting without inactive validators as a sanity check",
 		testConfig:  MintTestCfg,
 	},
+	"inactive-vals-outside-max-validators": {
+		name:        "inactive-vals-outside-max-validators",
+		steps:       stepsInactiveValsTopNReproduce(),
+		description: "tests the behaviour of inactive validators with a top N = 100 chain and when max_validators is smaller than the total number of validators",
+		testConfig:  InactiveValsExtraValsTestCfg,
+	},
 }
 
 func getTestCaseUsageString() string {

--- a/tests/e2e/steps.go
+++ b/tests/e2e/steps.go
@@ -1,5 +1,12 @@
 package main
 
+import (
+	"strconv"
+
+	gov "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
+)
+
 type Step struct {
 	Action interface{}
 	State  State
@@ -138,3 +145,134 @@ var consumerDoubleDowntimeSteps = concatSteps(
 	stepsRedelegate("consu"),
 	stepsDoubleDowntime("consu"),
 )
+
+func stepsInactiveValsTopNReproduce() []Step {
+	alice_power := uint(30)
+	bob_power := uint(29)
+	carol_power := uint(20)
+	david_power := uint(10)
+	eve_power := uint(7)
+	fred_power := uint(4)
+
+	return []Step{
+		{
+			Action: StartChainAction{
+				Chain: ChainID("provi"),
+				Validators: []StartChainValidator{
+					{Id: ValidatorID("alice"), Stake: alice_power * 1000000, Allocation: 10000000000},
+					{Id: ValidatorID("bob"), Stake: bob_power * 1000000, Allocation: 10000000000},
+					{Id: ValidatorID("carol"), Stake: carol_power * 1000000, Allocation: 10000000000},
+					{Id: ValidatorID("david"), Stake: david_power * 1000000, Allocation: 10000000000},
+					{Id: ValidatorID("eve"), Stake: eve_power * 1000000, Allocation: 10000000000},
+					{Id: ValidatorID("fred"), Stake: fred_power * 1000000, Allocation: 10000000000},
+				},
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): alice_power,
+						ValidatorID("bob"):   bob_power,
+						ValidatorID("carol"): carol_power,
+						ValidatorID("david"): david_power,
+						ValidatorID("eve"):   0, // max provider consensus validators is 4, so eve and fred are at 0 power
+						ValidatorID("fred"):  0,
+					},
+					StakedTokens: &map[ValidatorID]uint{
+						ValidatorID("alice"): alice_power * 1000000,
+						ValidatorID("bob"):   bob_power * 1000000,
+						ValidatorID("carol"): carol_power * 1000000,
+						ValidatorID("david"): david_power * 1000000,
+						ValidatorID("eve"):   eve_power * 1000000,
+						ValidatorID("fred"):  fred_power * 1000000,
+					},
+				},
+			},
+		},
+		{
+			Action: SubmitConsumerAdditionProposalAction{
+				Chain:             ChainID("provi"),
+				From:              ValidatorID("alice"),
+				Deposit:           10000001,
+				ConsumerChain:     ChainID("consu"),
+				SpawnTime:         0,
+				InitialHeight:     clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+				TopN:              100,
+				AllowInactiveVals: false,
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					Proposals: &map[uint]Proposal{
+						1: ConsumerAdditionProposal{
+							Deposit:       10000001,
+							Chain:         ChainID("consu"),
+							SpawnTime:     0,
+							InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+							Status:        strconv.Itoa(int(gov.ProposalStatus_PROPOSAL_STATUS_VOTING_PERIOD)),
+						},
+					},
+				},
+			},
+		},
+		{
+			Action: VoteGovProposalAction{
+				Chain:      ChainID("provi"),
+				From:       []ValidatorID{ValidatorID("alice"), ValidatorID("bob"), ValidatorID("carol"), ValidatorID("david"), ValidatorID("eve")},
+				Vote:       []string{"yes", "yes", "yes", "yes", "yes"},
+				PropNumber: 1,
+			},
+			State: State{
+				ChainID("provi"): ChainState{
+					Proposals: &map[uint]Proposal{
+						1: ConsumerAdditionProposal{
+							Deposit:       10000001,
+							Chain:         ChainID("consu"),
+							SpawnTime:     0,
+							InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+							Status:        strconv.Itoa(int(gov.ProposalStatus_PROPOSAL_STATUS_PASSED)),
+						},
+					},
+					HasToValidate: &map[ValidatorID][]ChainID{
+						ValidatorID("alice"): {"consu"},
+						ValidatorID("bob"):   {"consu"},
+						ValidatorID("carol"): {"consu"},
+						ValidatorID("david"): {"consu"},
+						ValidatorID("eve"):   {},
+						ValidatorID("fred"):  {},
+					},
+				},
+			},
+		},
+		{
+			Action: StartConsumerChainAction{
+				ConsumerChain: ChainID("consu"),
+				ProviderChain: ChainID("provi"),
+				Validators: []StartChainValidator{
+					{Id: ValidatorID("alice"), Stake: alice_power * 1000000, Allocation: 10000000000},
+					{Id: ValidatorID("bob"), Stake: bob_power * 1000000, Allocation: 10000000000},
+					{Id: ValidatorID("carol"), Stake: carol_power * 1000000, Allocation: 10000000000},
+					{Id: ValidatorID("david"), Stake: david_power * 1000000, Allocation: 10000000000},
+					{Id: ValidatorID("eve"), Stake: eve_power * 1000000, Allocation: 10000000000},
+					{Id: ValidatorID("fred"), Stake: fred_power * 1000000, Allocation: 10000000000},
+				},
+				// For consumers that're launching with the provider being on an earlier version
+				// of ICS before the soft opt-out threshold was introduced, we need to set the
+				// soft opt-out threshold to 0.05 in the consumer genesis to ensure that the
+				// consumer binary doesn't panic. Sdk requires that all params are set to valid
+				// values from the genesis file.
+				GenesisChanges: ".app_state.ccvconsumer.params.soft_opt_out_threshold = \"0.05\"",
+			},
+			State: State{
+				ChainID("consu"): ChainState{
+					ValPowers: &map[ValidatorID]uint{
+						ValidatorID("alice"): alice_power,
+						ValidatorID("bob"):   bob_power,
+						ValidatorID("carol"): carol_power,
+						ValidatorID("david"): david_power,
+						ValidatorID("eve"):   0,
+						ValidatorID("fred"):  0,
+					},
+				},
+			},
+		},
+	}
+}

--- a/tests/integration/partial_set_security_test.go
+++ b/tests/integration/partial_set_security_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"slices"
+	"sort"
 	"testing"
 
 	"cosmossdk.io/math"
@@ -119,9 +120,19 @@ func TestMinStake(t *testing.T) {
 			lastVals, err := providerKeeper.GetLastBondedValidators(s.providerChain.GetContext())
 			s.Require().NoError(err)
 
+			// Assuming tc.stakedTokens is defined somewhere in your test case
+			// Create a copy of the tc.stakedTokens slice
+			sortedTokens := make([]int64, len(tc.stakedTokens))
+			copy(sortedTokens, tc.stakedTokens)
+
+			// Sort the copied slice in descending order
+			sort.Slice(sortedTokens, func(i, j int) bool {
+				return sortedTokens[i] > sortedTokens[j]
+			})
+
 			for i, val := range lastVals {
 				// check that the initial state was set correctly
-				require.Equal(s.T(), math.NewInt(tc.stakedTokens[i]), val.Tokens)
+				require.Equal(s.T(), math.NewInt(sortedTokens[i]), val.Tokens)
 			}
 
 			// check the validator set on the consumer chain is the original one

--- a/testutil/keeper/expectations.go
+++ b/testutil/keeper/expectations.go
@@ -217,36 +217,18 @@ func GetMocksForSlashValidator(
 	}
 }
 
-// SetupMocksForLastBondedValidatorsExpectation sets up the expectation for the `IterateLastValidatorPowers` `MaxValidators`, and `GetValidator` methods of the `mockStakingKeeper` object.
+// SetupMocksForLastBondedValidatorsExpectation sets up the expectation for the `GetBondedValidatorsByPower` and `MaxValidators` methods of the `mockStakingKeeper` object.
 // These are needed in particular when calling `GetLastBondedValidators` from the provider keeper.
 // Times is the number of times the expectation should be called. Provide -1 for `AnyTimes“.
-func SetupMocksForLastBondedValidatorsExpectation(mockStakingKeeper *MockStakingKeeper, maxValidators uint32, vals []stakingtypes.Validator, powers []int64, times int) {
-	iteratorCall := mockStakingKeeper.EXPECT().IterateLastValidatorPowers(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx sdk.Context, cb func(sdk.ValAddress, int64) bool) error {
-			for i, val := range vals {
-				if stop := cb(sdk.ValAddress(val.OperatorAddress), powers[i]); stop {
-					break
-				}
-			}
-			return nil
-		})
+func SetupMocksForLastBondedValidatorsExpectation(mockStakingKeeper *MockStakingKeeper, maxValidators uint32, vals []stakingtypes.Validator, times int) {
+	validatorsCall := mockStakingKeeper.EXPECT().GetBondedValidatorsByPower(gomock.Any()).Return(vals, nil)
 	maxValidatorsCall := mockStakingKeeper.EXPECT().MaxValidators(gomock.Any()).Return(maxValidators, nil)
 
 	if times == -1 {
-		iteratorCall.AnyTimes()
+		validatorsCall.AnyTimes()
 		maxValidatorsCall.AnyTimes()
 	} else {
-		iteratorCall.Times(times)
+		validatorsCall.Times(times)
 		maxValidatorsCall.Times(times)
-	}
-
-	// set up mocks for GetValidator calls
-	for _, val := range vals {
-		getValCall := mockStakingKeeper.EXPECT().GetValidator(gomock.Any(), sdk.ValAddress(val.OperatorAddress)).Return(val, nil)
-		if times == -1 {
-			getValCall.AnyTimes()
-		} else {
-			getValCall.Times(times)
-		}
 	}
 }

--- a/testutil/keeper/unit_test_helpers.go
+++ b/testutil/keeper/unit_test_helpers.go
@@ -222,7 +222,7 @@ func SetupForStoppingConsumerChain(t *testing.T, ctx sdk.Context,
 ) {
 	t.Helper()
 
-	SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 1, []stakingtypes.Validator{}, []int64{}, 1)
+	SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 1, []stakingtypes.Validator{}, 1)
 
 	expectations := GetMocksForCreateConsumerClient(ctx, &mocks,
 		"chainID", clienttypes.NewHeight(4, 5))

--- a/x/ccv/consumer/keeper/changeover_test.go
+++ b/x/ccv/consumer/keeper/changeover_test.go
@@ -29,8 +29,6 @@ func TestChangeoverToConsumer(t *testing.T) {
 		cIds[4].SDKStakingValidator(),
 	}
 
-	powers := []int64{55, 87324, 2, 42389479, 9089080}
-
 	// Instantiate 5 ics val updates for use in test
 	initialValUpdates := []abci.ValidatorUpdate{
 		{Power: 55, PubKey: cIds[5].TMProtoCryptoPublicKey()},
@@ -106,7 +104,6 @@ func TestChangeoverToConsumer(t *testing.T) {
 			mocks.MockStakingKeeper,
 			180, // max validators
 			tc.lastSovVals,
-			powers,
 			-1) // any times
 
 		// Add ref to standalone staking keeper

--- a/x/ccv/consumer/keeper/keeper_test.go
+++ b/x/ccv/consumer/keeper/keeper_test.go
@@ -188,7 +188,6 @@ func TestGetLastSovereignValidators(t *testing.T) {
 		mocks.MockStakingKeeper,
 		180,
 		[]stakingtypes.Validator{val},
-		[]int64{1000},
 		1,
 	)
 

--- a/x/ccv/provider/keeper/grpc_query_test.go
+++ b/x/ccv/provider/keeper/grpc_query_test.go
@@ -146,7 +146,6 @@ func TestQueryConsumerValidators(t *testing.T) {
 		ctx, providerAddr1.ToSdkConsAddr()).Return(val, nil).Times(1)
 	res, _ = pk.QueryConsumerValidators(ctx, &req)
 	require.Equal(t, expectedCommissionRate, res.Validators[0].Rate)
-
 }
 
 func TestQueryConsumerChainsValidatorHasToValidate(t *testing.T) {
@@ -157,7 +156,7 @@ func TestQueryConsumerChainsValidatorHasToValidate(t *testing.T) {
 	valConsAddr, _ := val.GetConsAddr()
 	providerAddr := types.NewProviderConsAddress(valConsAddr)
 	mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(ctx, valConsAddr).Return(val, nil).AnyTimes()
-	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 1, []stakingtypes.Validator{val}, []int64{1}, -1) // -1 to allow the calls "AnyTimes"
+	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 1, []stakingtypes.Validator{val}, -1) // -1 to allow the calls "AnyTimes"
 
 	req := types.QueryConsumerChainsValidatorHasToValidateRequest{
 		ProviderAddress: providerAddr.String(),
@@ -248,7 +247,7 @@ func TestGetConsumerChain(t *testing.T) {
 	}
 	powers := []int64{50, 150, 300, 500} // sum = 1000
 	maxValidators := uint32(180)
-	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, maxValidators, vals, powers, -1) // -1 to allow the calls "AnyTimes"
+	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, maxValidators, vals, -1) // -1 to allow the calls "AnyTimes"
 
 	for i, val := range vals {
 		valAddr, err := sdk.ValAddressFromBech32(val.GetOperator())

--- a/x/ccv/provider/keeper/legacy_proposal_test.go
+++ b/x/ccv/provider/keeper/legacy_proposal_test.go
@@ -111,7 +111,7 @@ func TestHandleLegacyConsumerAdditionProposal(t *testing.T) {
 
 		if tc.expAppendProp {
 			// Mock calls are only asserted if we expect a client to be created.
-			testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 1, []stakingtypes.Validator{}, []int64{}, 1)
+			testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 1, []stakingtypes.Validator{}, 1)
 			gomock.InOrder(
 				testkeeper.GetMocksForCreateConsumerClient(ctx, &mocks, tc.prop.ChainId, clienttypes.NewHeight(2, 3))...,
 			)

--- a/x/ccv/provider/keeper/partial_set_security.go
+++ b/x/ccv/provider/keeper/partial_set_security.go
@@ -92,7 +92,7 @@ func (k Keeper) HandleOptOut(ctx sdk.Context, chainID string, providerAddr types
 func (k Keeper) OptInTopNValidators(ctx sdk.Context, chainID string, bondedValidators []stakingtypes.Validator, minPowerToOptIn int64) {
 	for _, val := range bondedValidators {
 		// log the validator
-		k.Logger(ctx).Info("Checking whether to opt in validator because of top N", "validator", val.GetOperator())
+		k.Logger(ctx).Debug("Checking whether to opt in validator because of top N", "validator", val.GetOperator())
 
 		valAddr, err := sdk.ValAddressFromBech32(val.GetOperator())
 		if err != nil {
@@ -114,7 +114,7 @@ func (k Keeper) OptInTopNValidators(ctx sdk.Context, chainID string, bondedValid
 				continue
 			}
 
-			k.Logger(ctx).Info("Opting in validator", "validator", val.GetOperator())
+			k.Logger(ctx).Debug("Opting in validator", "validator", val.GetOperator())
 
 			// if validator already exists it gets overwritten
 			k.SetOptedIn(ctx, chainID, types.NewProviderConsAddress(consAddr))

--- a/x/ccv/provider/keeper/partial_set_security.go
+++ b/x/ccv/provider/keeper/partial_set_security.go
@@ -92,7 +92,7 @@ func (k Keeper) HandleOptOut(ctx sdk.Context, chainID string, providerAddr types
 func (k Keeper) OptInTopNValidators(ctx sdk.Context, chainID string, bondedValidators []stakingtypes.Validator, minPowerToOptIn int64) {
 	for _, val := range bondedValidators {
 		// log the validator
-		k.Logger(ctx).Info("Opting in validator", "validator", val.GetOperator())
+		k.Logger(ctx).Info("Checking whether to opt in validator because of top N", "validator", val.GetOperator())
 
 		valAddr, err := sdk.ValAddressFromBech32(val.GetOperator())
 		if err != nil {
@@ -107,9 +107,6 @@ func (k Keeper) OptInTopNValidators(ctx sdk.Context, chainID string, bondedValid
 			continue
 		}
 		if power >= minPowerToOptIn {
-			k.Logger(ctx).Info("Before getting cons addr, but power is good",
-				"validator", val.GetOperator(),
-				"power", power)
 			consAddr, err := val.GetConsAddr()
 			if err != nil {
 				k.Logger(ctx).Error("could not retrieve validators consensus address: %s: %s",
@@ -121,13 +118,6 @@ func (k Keeper) OptInTopNValidators(ctx sdk.Context, chainID string, bondedValid
 
 			// if validator already exists it gets overwritten
 			k.SetOptedIn(ctx, chainID, types.NewProviderConsAddress(consAddr))
-		} else {
-			// else validators that do not belong to the top N validators but were opted in, remain opted in
-			k.Logger(ctx).Info("After getting cons addr, but power is not good",
-				"validator", val.GetOperator(),
-				"power", power,
-				"minPowerToOptIn",
-				minPowerToOptIn)
 		}
 	}
 }

--- a/x/ccv/provider/keeper/partial_set_security_test.go
+++ b/x/ccv/provider/keeper/partial_set_security_test.go
@@ -134,7 +134,7 @@ func TestHandleOptOutFromTopNChain(t *testing.T) {
 	valDConsAddr, _ := valD.GetConsAddr()
 	mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(ctx, valDConsAddr).Return(valD, nil).AnyTimes()
 
-	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 4, []stakingtypes.Validator{valA, valB, valC, valD}, []int64{1, 2, 3, 4}, -1) // -1 to allow mocks AnyTimes
+	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 4, []stakingtypes.Validator{valA, valB, valC, valD}, -1) // -1 to allow mocks AnyTimes
 
 	// initialize the minPowerInTopN correctly
 	minPowerInTopN, err := providerKeeper.ComputeMinPowerInTopN(ctx, []stakingtypes.Validator{valA, valB, valC, valD}, 50)

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -275,13 +275,33 @@ func (k Keeper) MakeConsumerGenesis(
 		if err != nil {
 			return gen, nil, errorsmod.Wrapf(stakingtypes.ErrNoValidatorFound, "error getting last active bonded validators: %s", err)
 		}
+
+		// for debugging purposes, log the active validators
+		for _, val := range activeValidators {
+			k.Logger(ctx).Info("active validator",
+				"operator", val.GetOperator(),
+				"power", val.Tokens,
+			)
+		}
+
 		// in a Top-N chain, we automatically opt in all validators that belong to the top N
 		minPower, err := k.ComputeMinPowerInTopN(ctx, activeValidators, prop.Top_N)
 		if err != nil {
 			return gen, nil, err
 		}
+		// log the minimum power in top N
+		k.Logger(ctx).Info("minimum power in top N",
+			"chainID", chainID,
+			"minPower", minPower,
+		)
 		k.OptInTopNValidators(ctx, chainID, activeValidators, minPower)
 		k.SetMinimumPowerInTopN(ctx, chainID, minPower)
+
+		// log the minimum power in top N
+		k.Logger(ctx).Info("minimum power in top N",
+			"chainID", chainID,
+			"minPower", minPower,
+		)
 	}
 	// need to use the bondedValidators, not activeValidators, here since the chain might be opt-in and allow inactive vals
 	nextValidators := k.ComputeNextValidators(ctx, chainID, bondedValidators)

--- a/x/ccv/provider/keeper/proposal.go
+++ b/x/ccv/provider/keeper/proposal.go
@@ -276,32 +276,18 @@ func (k Keeper) MakeConsumerGenesis(
 			return gen, nil, errorsmod.Wrapf(stakingtypes.ErrNoValidatorFound, "error getting last active bonded validators: %s", err)
 		}
 
-		// for debugging purposes, log the active validators
-		for _, val := range activeValidators {
-			k.Logger(ctx).Info("active validator",
-				"operator", val.GetOperator(),
-				"power", val.Tokens,
-			)
-		}
-
 		// in a Top-N chain, we automatically opt in all validators that belong to the top N
 		minPower, err := k.ComputeMinPowerInTopN(ctx, activeValidators, prop.Top_N)
 		if err != nil {
 			return gen, nil, err
 		}
 		// log the minimum power in top N
-		k.Logger(ctx).Info("minimum power in top N",
+		k.Logger(ctx).Info("minimum power in top N at consumer genesis",
 			"chainID", chainID,
 			"minPower", minPower,
 		)
 		k.OptInTopNValidators(ctx, chainID, activeValidators, minPower)
 		k.SetMinimumPowerInTopN(ctx, chainID, minPower)
-
-		// log the minimum power in top N
-		k.Logger(ctx).Info("minimum power in top N",
-			"chainID", chainID,
-			"minPower", minPower,
-		)
 	}
 	// need to use the bondedValidators, not activeValidators, here since the chain might be opt-in and allow inactive vals
 	nextValidators := k.ComputeNextValidators(ctx, chainID, bondedValidators)

--- a/x/ccv/provider/keeper/proposal_test.go
+++ b/x/ccv/provider/keeper/proposal_test.go
@@ -121,7 +121,7 @@ func TestHandleConsumerAdditionProposal(t *testing.T) {
 
 		if tc.expAppendProp {
 			// Mock calls are only asserted if we expect a client to be created.
-			testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 0, []stakingtypes.Validator{}, []int64{}, 1) // returns empty validator set
+			testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 0, []stakingtypes.Validator{}, 1) // returns empty validator set
 			gomock.InOrder(
 				testkeeper.GetMocksForCreateConsumerClient(ctx, &mocks, tc.prop.ChainId, clienttypes.NewHeight(2, 3))...,
 			)
@@ -165,7 +165,7 @@ func TestCreateConsumerClient(t *testing.T) {
 			description: "No state mutation, new client should be created",
 			setup: func(providerKeeper *providerkeeper.Keeper, ctx sdk.Context, mocks *testkeeper.MockedKeepers) {
 				// Valid client creation is asserted with mock expectations here
-				testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 0, []stakingtypes.Validator{}, []int64{}, 1) // returns empty validator set
+				testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 0, []stakingtypes.Validator{}, 1) // returns empty validator set
 				gomock.InOrder(
 					testkeeper.GetMocksForCreateConsumerClient(ctx, mocks, "chainID", clienttypes.NewHeight(4, 5))...,
 				)
@@ -181,7 +181,7 @@ func TestCreateConsumerClient(t *testing.T) {
 				mocks.MockStakingKeeper.EXPECT().UnbondingTime(gomock.Any()).Times(0)
 				mocks.MockClientKeeper.EXPECT().CreateClient(gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 				mocks.MockClientKeeper.EXPECT().GetSelfConsensusState(gomock.Any(), gomock.Any()).Times(0)
-				testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 0, []stakingtypes.Validator{}, []int64{}, 0) // returns empty validator set
+				testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 0, []stakingtypes.Validator{}, 0) // returns empty validator set
 			},
 			expClientCreated: false,
 		},
@@ -671,7 +671,7 @@ func TestMakeConsumerGenesis(t *testing.T) {
 	//
 	ctx = ctx.WithChainID("testchain1") // chainID is obtained from ctx
 	ctx = ctx.WithBlockHeight(5)        // RevisionHeight obtained from ctx
-	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 0, []stakingtypes.Validator{}, []int64{}, 1)
+	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 0, []stakingtypes.Validator{}, 1)
 	gomock.InOrder(testkeeper.GetMocksForMakeConsumerGenesis(ctx, &mocks, 1814400000000000)...)
 
 	// matches params from jsonString
@@ -929,7 +929,7 @@ func TestBeginBlockInit(t *testing.T) {
 	// opt in a sample validator so the chain's proposal can successfully execute
 	validator := cryptotestutil.NewCryptoIdentityFromIntSeed(0).SDKStakingValidator()
 	consAddr, _ := validator.GetConsAddr()
-	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 1, []stakingtypes.Validator{validator}, []int64{0}, -1) // -1 to allow any number of calls
+	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 1, []stakingtypes.Validator{validator}, -1) // -1 to allow any number of calls
 
 	valAddr, _ := sdk.ValAddressFromBech32(validator.GetOperator())
 	mocks.MockStakingKeeper.EXPECT().GetLastValidatorPower(gomock.Any(), valAddr).Return(int64(1), nil).AnyTimes()
@@ -1041,7 +1041,7 @@ func TestBeginBlockCCR(t *testing.T) {
 	expectations := []*gomock.Call{}
 	for _, prop := range pendingProps {
 		// A consumer chain is setup corresponding to each prop, making these mocks necessary
-		testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 0, []stakingtypes.Validator{}, []int64{}, 1)
+		testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 0, []stakingtypes.Validator{}, 1)
 		expectations = append(expectations, testkeeper.GetMocksForCreateConsumerClient(ctx, &mocks,
 			prop.ChainId, clienttypes.NewHeight(2, 3))...)
 		expectations = append(expectations, testkeeper.GetMocksForSetConsumerChain(ctx, &mocks, prop.ChainId)...)

--- a/x/ccv/provider/keeper/relay_test.go
+++ b/x/ccv/provider/keeper/relay_test.go
@@ -66,7 +66,7 @@ func TestQueueVSCPackets(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		mocks := testkeeper.NewMockedKeepers(ctrl)
-		testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 0, []stakingtypes.Validator{}, []int64{}, 1)
+		testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 0, []stakingtypes.Validator{}, 1)
 
 		pk := testkeeper.NewInMemProviderKeeper(keeperParams, mocks)
 		// no-op if tc.packets is empty
@@ -101,7 +101,7 @@ func TestQueueVSCPacketsDoesNotResetConsumerValidatorsHeights(t *testing.T) {
 	valB := createStakingValidator(ctx, mocks, 2, 2, 2)
 	valBConsAddr, _ := valB.GetConsAddr()
 	mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(ctx, valBConsAddr).Return(valB, nil).AnyTimes()
-	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 2, []stakingtypes.Validator{valA, valB}, []int64{1, 2}, -1)
+	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 2, []stakingtypes.Validator{valA, valB}, -1)
 
 	// set a consumer client, so we have a consumer chain (i.e., `k.GetAllConsumerChains(ctx)` is non empty)
 	providerKeeper.SetConsumerClientId(ctx, "chainID", "clientID")
@@ -603,7 +603,7 @@ func TestEndBlockVSU(t *testing.T) {
 		powers = append(powers, int64(i+1))
 	}
 
-	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 5, lastValidators, powers, -1)
+	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 5, lastValidators, -1)
 
 	sort.Slice(lastValidators, func(i, j int) bool {
 		return lastValidators[i].GetConsensusPower(sdk.DefaultPowerReduction) >
@@ -732,7 +732,7 @@ func TestQueueVSCPacketsWithPowerCapping(t *testing.T) {
 	valEPubKey, _ := valE.TmConsPublicKey()
 	mocks.MockStakingKeeper.EXPECT().GetValidatorByConsAddr(ctx, valEConsAddr).Return(valE, nil).AnyTimes()
 
-	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 5, []stakingtypes.Validator{valA, valB, valC, valD, valE}, []int64{1, 3, 4, 8, 16}, -1)
+	testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 5, []stakingtypes.Validator{valA, valB, valC, valD, valE}, -1)
 
 	// add a consumer chain
 	providerKeeper.SetConsumerClientId(ctx, "chainID", "clientID")

--- a/x/ccv/provider/proposal_handler_test.go
+++ b/x/ccv/provider/proposal_handler_test.go
@@ -100,7 +100,7 @@ func TestProviderProposalHandler(t *testing.T) {
 		// Mock expectations depending on expected outcome
 		switch {
 		case tc.expValidConsumerAddition:
-			testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 1, []stakingtypes.Validator{}, []int64{}, 1)
+			testkeeper.SetupMocksForLastBondedValidatorsExpectation(mocks.MockStakingKeeper, 1, []stakingtypes.Validator{}, 1)
 			gomock.InOrder(testkeeper.GetMocksForCreateConsumerClient(
 				ctx, &mocks, "chainID", clienttypes.NewHeight(2, 3),
 			)...)

--- a/x/ccv/types/utils.go
+++ b/x/ccv/types/utils.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"errors"
-	fmt "fmt"
 	"reflect"
 	"sort"
 	"strings"
@@ -132,7 +131,7 @@ func GetLastBondedValidatorsUtil(ctx sdk.Context, stakingKeeper StakingKeeper, l
 	// get the bonded validators from the staking module, sorted by power
 	bondedValidators, err := stakingKeeper.GetBondedValidatorsByPower(ctx)
 	if err != nil {
-		panic(fmt.Errorf("failed to get bonded validators: %w", err))
+		return nil, err
 	}
 
 	// get the first maxVals many validators

--- a/x/ccv/types/utils.go
+++ b/x/ccv/types/utils.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"errors"
+	fmt "fmt"
 	"reflect"
 	"sort"
 	"strings"
@@ -128,38 +129,18 @@ func GetConsAddrFromBech32(bech32str string) (sdk.ConsAddress, error) {
 // GetLastBondedValidatorsUtil iterates the last validator powers in the staking module
 // and returns the first maxVals many validators with the largest powers.
 func GetLastBondedValidatorsUtil(ctx sdk.Context, stakingKeeper StakingKeeper, logger log.Logger, maxVals uint32) ([]stakingtypes.Validator, error) {
-	lastPowers := make([]stakingtypes.LastValidatorPower, maxVals)
-
-	i := 0
-	err := stakingKeeper.IterateLastValidatorPowers(ctx, func(addr sdk.ValAddress, power int64) (stop bool) {
-		lastPowers[i] = stakingtypes.LastValidatorPower{Address: addr.String(), Power: power}
-		i++
-		return i >= int(maxVals) // stop iteration if true
-	})
+	// get the bonded validators from the staking module, sorted by power
+	bondedValidators, err := stakingKeeper.GetBondedValidatorsByPower(ctx)
 	if err != nil {
-		return nil, err
+		panic(fmt.Errorf("failed to get bonded validators: %w", err))
 	}
 
-	// truncate the lastPowers
-	lastPowers = lastPowers[:i]
-
-	bondedValidators := make([]stakingtypes.Validator, len(lastPowers))
-
-	for index, p := range lastPowers {
-		addr, err := sdk.ValAddressFromBech32(p.Address)
-		if err != nil {
-			logger.Error("Invalid validator address", "address", p.Address, "error", err)
-			continue
-		}
-
-		val, err := stakingKeeper.GetValidator(ctx, addr)
-		if err != nil {
-			logger.Error(err.Error(), addr.String())
-			continue
-		}
-
-		// gather all the bonded validators in order to construct the consumer validator set for consumer chain `chainID`
-		bondedValidators[index] = val
+	// get the first maxVals many validators
+	if uint32(len(bondedValidators)) < maxVals {
+		return bondedValidators, nil // no need to truncate
 	}
+
+	bondedValidators = bondedValidators[:maxVals]
+
 	return bondedValidators, nil
 }


### PR DESCRIPTION
<!--
The production pull request template is for types feat, fix, or refactor.
-->

## Description

Closes: #2169

Bug reported by @fastfadingviolets via Slack

In the test scenario presented in the new e2e test, namely:
* provider chain with max_validators=5, max_provider_consensus_validators=4
* validators with powers 30, 29, 20, 10, 7, 4
* a consumer chain with top N=100
* then validators 30, 29, 20, 10 should have to validate on the consumer chain.

The previous behaviour was that validator 10 did not have to validate, and only 30, 29, and 20 had to validate.

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

The bug was this:
In https://github.com/cosmos/interchain-security/blob/0e080c3e4ad2df5667695d890740175d8212c4c4/x/ccv/types/utils.go#L134 in the function GetLastBondedValidatorsUtil, the staking keeper method IterateLastValidatorPowers is called assuming that it returns validators sorted by power.
This is not true, so wrong validators would be returned, which caused wrong validators to be used when computing the consumer chain validator set.

The fix is in x/ccv/types/utils.go

tests/e2e contains a regression tests outlining the scenario explained above.

In the integration tests, a test actually depended on the broken behaviour, so it was adjusted.

Further, the mocks were adjusted, since GetLastBondedValidatorsUtil calls GetBondedValidatorsByPower instead of IterateLastValidatorPowers now, and doesn't need to take the powers as an input.



---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] Added `!` to the type prefix if the change is [state-machine breaking](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes)
* [ ] Confirmed this PR does not introduce changes requiring state migrations, OR migration code has been added to consumer and/or provider modules
* [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] Provided a link to the relevant issue or specification
* [ ] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/00-intro.md)
* [ ] Included the necessary unit and integration [tests](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#testing)
* [ ] Added a changelog entry to `CHANGELOG.md`
* [ ] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] Updated the relevant documentation or specification
* [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
* [ ] Confirmed all CI checks have passed
* [ ] If this PR is library API breaking, bump the go.mod version string of the repo, and follow through on a new major release

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` the type prefix if the change is state-machine breaking
* [ ] confirmed this PR does not introduce changes requiring state migrations, OR confirmed migration code has been added to consumer and/or provider modules
* [ ] confirmed all author checklist items have been addressed
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced new test configurations for inactive validators, enhancing the testing framework's flexibility.
  - Added logging for validator opting-in processes, improving traceability.

- **Bug Fixes**
  - Enhanced assertions by sorting staked tokens in integration tests for more accurate validation.

- **Refactor**
  - Simplified function calls in mock setups by removing unnecessary parameters across various tests.
  - Refactored logic for retrieving last bonded validators, improving efficiency and error handling.

- **Tests**
  - Expanded test scenarios to include edge cases related to inactive validators and their configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->