### PR TITLE
chore: Disable coderabbit auto reviews

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -6,8 +6,6 @@ reviews:
     poem: false
     review_status: false
     collapse_walkthrough: true
-    auto_review: 
-        enabled: false
     path_filters:
         - "!api/"
         - "!docs/"
@@ -25,7 +23,7 @@ reviews:
           instructions: |
               "Assess the unit test code assessing sufficient code coverage for the changes associated in the pull request. Only report issues that you have a high degree of confidence in."
     auto_review:
-        enabled: true
+        enabled: false
         ignore_title_keywords:
             - "WIP"
             - "DO NOT MERGE"

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -6,7 +6,8 @@ reviews:
     poem: false
     review_status: false
     collapse_walkthrough: true
-    auto_review: false
+    auto_review: 
+        enabled: false
     path_filters:
         - "!api/"
         - "!docs/"

--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -6,6 +6,7 @@ reviews:
     poem: false
     review_status: false
     collapse_walkthrough: true
+    auto_review: false
     path_filters:
         - "!api/"
         - "!docs/"


### PR DESCRIPTION
## Description


After this change, the bot should only review PRs when a review is manually requested.

The command should be
```
@coderabbitai review
```
to make it review a PR you want the bot to comment on

Closes: #XXXX

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
