### PR TITLE
test: Add e2e tests for permissionless ICS

### DIFF
--- a/tests/e2e/main.go
+++ b/tests/e2e/main.go
@@ -246,13 +246,12 @@ var stepChoices = map[string]StepChoice{
 		description: "test minting without inactive validators as a sanity check",
 		testConfig:  MintTestCfg,
 	},
-	// TODO PERMISSIONLESS: ADD NEW E2E TEST
-	/* 	"permissionless-ics": {
+	"permissionless-ics": {
 		name:        "permissionless-ics",
 		steps:       stepsPermissionlessICS(),
 		description: "test permissionless ics",
-		testConfig:  DefaultTestCfg,
-	}, */
+		testConfig:  PermissionlessTestCfg,
+	},
 	"inactive-vals-outside-max-validators": {
 		name:        "inactive-vals-outside-max-validators",
 		steps:       stepsInactiveValsTopNReproduce(),
@@ -540,6 +539,7 @@ func printReport(runners []TestRunner, duration time.Duration) {
 	}
 	numTotalTests := len(runners)
 	report := `
+
 =================================================
 TEST RESULTS
 -------------------------------------------------
@@ -577,19 +577,6 @@ Summary:
 		len(remainingTests), numTotalTests,
 	)
 
-	report += fmt.Sprintln("\nFAILED TESTS:")
-	for _, t := range failedTests {
-		report += t.Report()
-	}
-	report += fmt.Sprintln("\n\nPASSED TESTS:")
-	for _, t := range passedTests {
-		report += t.Report()
-	}
-
-	report += fmt.Sprintln("\n\nREMAINING TESTS:")
-	for _, t := range remainingTests {
-		report += t.Report()
-	}
 	report += "=================================================="
 	fmt.Print(report)
 }

--- a/tests/e2e/state.go
+++ b/tests/e2e/state.go
@@ -316,7 +316,7 @@ func (tr Chain) getValidatorIP(chain ChainID, validator ValidatorID) string {
 }
 
 func (tr Chain) getValidatorHome(chain ChainID, validator ValidatorID) string {
-	return `/` + string(tr.testConfig.chainConfigs[chain].ChainId) + `/validator` + fmt.Sprint(validator)
+	return `/` + string(chain) + `/validator` + fmt.Sprint(validator)
 }
 
 func (tr Chain) curlJsonRPCRequest(method, params, address string) {
@@ -926,7 +926,7 @@ func (tr Commands) GetHasToValidate(
 		log.Fatal(err, "\n", string(bz))
 	}
 
-	arr := gjson.Get(string(bz), "consumer_chain_ids").Array()
+	arr := gjson.Get(string(bz), "consumer_ids").Array()
 	chains := []ChainID{}
 	for _, c := range arr {
 		for _, chain := range tr.chainConfigs {

--- a/tests/e2e/steps_partial_set_security.go
+++ b/tests/e2e/steps_partial_set_security.go
@@ -1752,7 +1752,7 @@ func stepsValidatorsDenylistedChain() []Step {
 				ChainID("consu"): ChainState{
 					ValPowers: &map[ValidatorID]uint{
 						ValidatorID("alice"): 100,
-						// "bob" is denylisted and hence does not valiate the consumer chain
+						// "bob" is denylisted and hence does not validate the consumer chain
 						ValidatorID("bob"):   0,
 						ValidatorID("carol"): 300,
 					},

--- a/tests/e2e/steps_permissionless_ics.go
+++ b/tests/e2e/steps_permissionless_ics.go
@@ -9,7 +9,7 @@ import (
 
 // stepsPermissionlessICS tests
 // - starting multiple permissionless consumer chains with the same chain ID
-// - opt-in of a validator on two different chains with the same chain ID
+// - that a validator CANNOT opt-in on two different chains with the same chain ID
 // - taking ownership of a consumer chain
 func stepsPermissionlessICS() []Step {
 	s := concatSteps(
@@ -39,8 +39,6 @@ func stepsPermissionlessICS() []Step {
 			// - create the consumer chain
 			// - opt-in a validator
 			// - launch the chain
-			// - TODO (PERMISSIONLESS): 'start the chain'. Note: due to hermes we can't yet start two chains with the same ChainID as it's not yet supported
-
 			{
 				Action: CreateConsumerChainAction{
 					Chain:         ChainID("provi"),

--- a/tests/e2e/steps_permissionless_ics.go
+++ b/tests/e2e/steps_permissionless_ics.go
@@ -1,0 +1,213 @@
+package main
+
+import (
+	"time"
+
+	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
+	e2e "github.com/cosmos/interchain-security/v6/tests/e2e/testlib"
+)
+
+// stepsPermissionlessICS tests
+// - starting multiple permissionless consumer chains with the same chain ID
+// - opt-in of a validator on two different chains with the same chain ID
+// - taking ownership of a consumer chain
+func stepsPermissionlessICS() []Step {
+	s := concatSteps(
+		[]Step{
+			// Start the provider chain
+			{
+				Action: StartChainAction{
+					Chain: ChainID("provi"),
+					Validators: []StartChainValidator{
+						{Id: ValidatorID("alice"), Stake: 100000000, Allocation: 10000000000},
+						{Id: ValidatorID("bob"), Stake: 200000000, Allocation: 10000000000},
+						{Id: ValidatorID("carol"), Stake: 300000000, Allocation: 10000000000},
+					},
+				},
+				State: State{
+					ChainID("provi"): ChainState{
+						ValPowers: &map[ValidatorID]uint{
+							ValidatorID("alice"): 100,
+							ValidatorID("bob"):   200,
+							ValidatorID("carol"): 300,
+						},
+					},
+				},
+			},
+
+			// Initialize a permissionless chain with ChainID `consu`
+			// - create the consumer chain
+			// - opt-in a validator
+			// - launch the chain
+			// - TODO (PERMISSIONLESS): 'start the chain'. Note: due to hermes we can't yet start two chains with the same ChainID as it's not yet supported
+
+			{
+				Action: CreateConsumerChainAction{
+					Chain:         ChainID("provi"),
+					From:          ValidatorID("alice"),
+					ConsumerChain: ChainID("cons2"), // test chain "cons2" is configured with ChainID "consu"
+					SpawnTime:     uint(time.Minute * 3),
+					InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+					TopN:          0,
+				},
+				State: State{},
+			},
+			{
+				Action: OptInAction{
+					Chain:     ChainID("cons2"),
+					Validator: ValidatorID("alice"),
+				},
+				State: State{
+					ChainID("provi"): ChainState{
+						HasToValidate: &map[ValidatorID][]ChainID{
+							ValidatorID("alice"): {},
+							ValidatorID("bob"):   {},
+							ValidatorID("carol"): {},
+						},
+					},
+				},
+			},
+		},
+		// Start another permissionless chain with ChainID `consu`
+		// test chain "cons1" is configured with ChainID "consu"
+		stepsStartPermissionlessChain(
+			"cons1", "consu",
+			[]string{"consu", "consu"}, // show up both consumer chains "consu" as proposed chains
+			[]ValidatorID{ValidatorID("bob")}, 0),
+
+		[]Step{
+			{
+				Action: RelayPacketsAction{
+					ChainA:  ChainID("provi"),
+					ChainB:  ChainID("cons1"),
+					Port:    "provider",
+					Channel: 0,
+				},
+				State: State{
+					ChainID("cons1"): ChainState{
+						ValPowers: &map[ValidatorID]uint{
+							ValidatorID("alice"): 0,
+							ValidatorID("bob"):   200,
+							ValidatorID("carol"): 0,
+						},
+					},
+					ChainID("provi"): e2e.ChainState{
+						HasToValidate: &map[ValidatorID][]ChainID{
+							ValidatorID("alice"): {},
+							ValidatorID("bob"):   {"consu"},
+							ValidatorID("carol"): {},
+						},
+					},
+				},
+			},
+		},
+
+		// Test that a validator CANNOT opt-in on a chain with the same ChainID it is already validating
+		[]Step{
+			{
+				Action: OptInAction{
+					Chain:         ChainID("cons2"),
+					Validator:     ValidatorID("alice"),
+					ExpectError:   true,
+					ExpectedError: "already opted in to a chain with the same chain id",
+				},
+				State: State{
+					ChainID("provi"): ChainState{
+						HasToValidate: &map[ValidatorID][]ChainID{
+							ValidatorID("alice"): {},
+							ValidatorID("bob"):   {"consu"},
+							ValidatorID("carol"): {},
+						},
+					},
+					ChainID("cons1"): ChainState{
+						ValPowers: &map[ValidatorID]uint{
+							ValidatorID("alice"): 0, // alice refused to opt in
+							ValidatorID("bob"):   200,
+							ValidatorID("carol"): 0,
+						},
+					},
+				},
+			},
+		},
+		[]Step{
+			{
+				Action: RelayPacketsAction{
+					ChainA:  ChainID("provi"),
+					ChainB:  ChainID("cons1"),
+					Port:    "provider",
+					Channel: 0,
+				},
+				State: State{
+					ChainID("cons1"): ChainState{
+						ValPowers: &map[ValidatorID]uint{
+							ValidatorID("alice"): 0,
+							ValidatorID("bob"):   200,
+							ValidatorID("carol"): 0,
+						},
+					},
+					ChainID("provi"): e2e.ChainState{
+						HasToValidate: &map[ValidatorID][]ChainID{
+							ValidatorID("alice"): {},
+							ValidatorID("bob"):   {"consu"},
+							ValidatorID("carol"): {},
+						},
+					},
+				},
+			},
+		},
+		// test chain hijacking prevention
+		[]Step{
+			// Try to change owner of chain and change deny-/allowlist
+			{
+				Action: UpdateConsumerChainAction{
+					Chain:         ChainID("provi"),
+					From:          ValidatorID("bob"),
+					ConsumerChain: ChainID("cons1"),
+					NewOwner:      getDefaultValidators()[ValidatorID("carol")].ValconsAddress,
+					SpawnTime:     0, // launch now
+					InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+					TopN:          0,
+				},
+				State: State{},
+			},
+			{
+				Action: UpdateConsumerChainAction{
+					Chain:         ChainID("provi"),
+					From:          ValidatorID("carol"),
+					ConsumerChain: ChainID("cons1"),
+					SpawnTime:     0,
+					InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+					TopN:          0,
+					Allowlist:     []string{getDefaultValidators()[ValidatorID("carol")].ValconsAddress},
+					Denylist:      []string{getDefaultValidators()[ValidatorID("bob")].ValconsAddress},
+				},
+				State: State{},
+			},
+			{
+				Action: RelayPacketsAction{
+					ChainA:  ChainID("provi"),
+					ChainB:  ChainID("cons1"),
+					Port:    "provider",
+					Channel: 0,
+				},
+				State: State{
+					ChainID("cons1"): ChainState{
+						ValPowers: &map[ValidatorID]uint{
+							ValidatorID("alice"): 0,
+							ValidatorID("bob"):   200, // bob is not 'denylisted'
+							ValidatorID("carol"): 0,
+						},
+					},
+					ChainID("provi"): e2e.ChainState{
+						HasToValidate: &map[ValidatorID][]ChainID{
+							ValidatorID("alice"): {},
+							ValidatorID("bob"):   {"consu"}, // bob is still a validator on consu chain
+							ValidatorID("carol"): {},
+						},
+					},
+				},
+			},
+		},
+	)
+	return s
+}

--- a/tests/e2e/steps_start_chains.go
+++ b/tests/e2e/steps_start_chains.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"time"
+
 	gov "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
+	e2e "github.com/cosmos/interchain-security/v6/tests/e2e/testlib"
 )
 
 func stepStartProviderChain() []Step {
@@ -27,6 +30,144 @@ func stepStartProviderChain() []Step {
 			},
 		},
 	}
+}
+
+func stepsStartPermissionlessChain(consumerName, consumerChainId string, proposedChains []string, validators []ValidatorID, chainIndex uint) []Step {
+	s := []Step{
+		{
+			Action: CreateConsumerChainAction{
+				Chain:         ChainID("provi"),
+				From:          ValidatorID("alice"),
+				ConsumerChain: ChainID(consumerName),
+				SpawnTime:     uint(time.Minute * 3),
+				InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+				TopN:          0,
+			},
+			State: State{
+				ChainID("provi"): e2e.ChainState{
+					ProposedConsumerChains: &proposedChains,
+				},
+			},
+		},
+	}
+
+	// Assign validator keys
+	// add a consumer key before the chain starts
+	// the key will be present in the consumer genesis initial_val_set
+	for _, valId := range validators {
+		valCfg := getDefaultValidators()[valId]
+		// no consumer-key assignment needed for validators using provider's public key
+		if !valCfg.UseConsumerKey {
+			continue
+		}
+		step := Step{
+			Action: AssignConsumerPubKeyAction{
+				Chain:          ChainID(consumerName),
+				Validator:      valId,
+				ConsumerPubkey: valCfg.ConsumerValPubKey,
+				// consumer chain has not started
+				// we don't need to reconfigure the node
+				// since it will start with consumer key
+				ReconfigureNode: false,
+			},
+			State: State{
+				ChainID(consumerName): ChainState{
+					AssignedKeys: &map[ValidatorID]string{
+						valId: valCfg.ConsumerValconsAddressOnProvider,
+					},
+					ProviderKeys: &map[ValidatorID]string{
+						valId: valCfg.ValconsAddress,
+					},
+				},
+			},
+		}
+		s = append(s, step)
+	}
+
+	// Opt-in Validators
+	for _, valId := range validators {
+		step := Step{
+			Action: OptInAction{
+				Chain:     ChainID(consumerName),
+				Validator: valId,
+			},
+			State: State{},
+		}
+		s = append(s, step)
+	}
+
+	// Launch chain
+	step := Step{
+		Action: UpdateConsumerChainAction{
+			Chain:         ChainID("provi"),
+			From:          ValidatorID("alice"),
+			ConsumerChain: ChainID(consumerName),
+			SpawnTime:     0, // launch now
+			InitialHeight: clienttypes.Height{RevisionNumber: 0, RevisionHeight: 1},
+			TopN:          0,
+		},
+		State: State{},
+	}
+	s = append(s, step)
+
+	// Setup validators for  chain
+	startChainVals := []StartChainValidator{}
+	valBalance := map[ValidatorID]uint{
+		ValidatorID("alice"): 0,
+		ValidatorID("bob"):   0,
+		ValidatorID("carol"): 0,
+	}
+
+	for idx, val := range validators {
+		startChainVals = append(startChainVals,
+			StartChainValidator{
+				Id:         val,
+				Stake:      uint(100000000 * (idx + 1)),
+				Allocation: 10000000000,
+			})
+		valBalance[val] = 10000000000
+	}
+
+	// Start the chain
+	step = Step{
+		Action: StartConsumerChainAction{
+			ConsumerChain: ChainID(consumerName),
+			ProviderChain: ChainID("provi"),
+			Validators:    startChainVals,
+		},
+		State: State{
+			ChainID(consumerName): ChainState{
+				ValBalances: &valBalance,
+			},
+		},
+	}
+	s = append(s, step)
+
+	// Establish IBC connection
+	steps := []Step{
+		{
+			Action: AddIbcConnectionAction{
+				ChainA:  ChainID(consumerName),
+				ChainB:  ChainID("provi"),
+				ClientA: 0,
+				ClientB: chainIndex,
+			},
+			State: State{},
+		},
+		{
+			Action: AddIbcChannelAction{
+				ChainA:      ChainID(consumerName),
+				ChainB:      ChainID("provi"),
+				ConnectionA: 0,
+				PortA:       "consumer",
+				PortB:       "provider",
+				Order:       "ordered",
+			},
+			State: State{},
+		},
+	}
+	s = append(s, steps...)
+	return s
 }
 
 func stepsStartConsumerChain(consumerName string, proposalIndex, chainIndex uint, setupTransferChans bool) []Step {

--- a/tests/e2e/test_runner.go
+++ b/tests/e2e/test_runner.go
@@ -72,7 +72,7 @@ func (res *TestResult) Error() {
 func (tr *TestRunner) Run() error {
 	tr.result = TestResult{}
 	tr.result.Started()
-	fmt.Printf("\n\n=============== running %s ===============\n", tr.config.name)
+	fmt.Printf("\n\n=============== running %s ===============\n", tr.stepChoice.name)
 	fmt.Println(tr.Info())
 	err := tr.checkConfig()
 	if err != nil {
@@ -131,11 +131,11 @@ func CreateTestRunner(config TestConfig, stepChoice StepChoice, target Execution
 // Info returns a header string containing useful information about the test runner
 func (tr *TestRunner) Info() string {
 	return fmt.Sprintf(`
-------------------------------------------
+-------------------------------------------------
 Test name : %s
 Config: %s
 Target: %s
-------------------------------------------`,
+-------------------------------------------------`,
 		tr.stepChoice.name,
 		tr.config.name,
 		tr.target.Info(),
@@ -144,7 +144,7 @@ Target: %s
 
 func (tr *TestRunner) Report() string {
 	return fmt.Sprintf(`
-------------------------------------------
+-------------------------------------------------
 Test name : %s
 Config: %s
 Target: %s
@@ -152,7 +152,7 @@ Target: %s
 - Result: %s
 - Duration: %s
 - StartTime: %s
-------------------------------------------`,
+-------------------------------------------------`,
 		tr.stepChoice.name,
 		tr.config.name,
 		tr.target.Info(),


### PR DESCRIPTION
## Description

Add basic e2e tests for permissionless ICS
Change e2e tests to allow chain configurations with same ChainID

Limitation:
Current hermes version does not support two chains with same 'ChainID'. Therefore the tests Initializes two
chains with same ChainID and launches only one of them.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [x] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] Confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] Confirmed all author checklist items have been addressed
- [ ] Confirmed that this PR does not change production code <!-- e.g., updating tests -->
