### PR TITLE
test:  extend slashing window in E2E-tests

### DIFF
--- a/tests/e2e/actions.go
+++ b/tests/e2e/actions.go
@@ -2290,7 +2290,7 @@ func (tr Chain) invokeDowntimeSlash(action DowntimeSlashAction, verbose bool) {
 	// Bring validator down
 	tr.setValidatorDowntime(action.Chain, action.Validator, true, verbose)
 	// Wait appropriate amount of blocks for validator to be slashed
-	tr.waitBlocks(action.Chain, 11, 3*time.Minute)
+	tr.waitBlocks(action.Chain, 16, 3*time.Minute)
 	// Bring validator back up
 	tr.setValidatorDowntime(action.Chain, action.Validator, false, verbose)
 }

--- a/tests/e2e/config.go
+++ b/tests/e2e/config.go
@@ -527,7 +527,7 @@ func DefaultTestConfig() TestConfig {
 				IpPrefix:       "7.7.8",
 				VotingWaitTime: 20,
 				GenesisChanges: ".app_state.gov.params.voting_period = \"20s\" | " +
-					".app_state.slashing.params.signed_blocks_window = \"20\" | " +
+					".app_state.slashing.params.signed_blocks_window = \"30\" | " +
 					".app_state.slashing.params.min_signed_per_window = \"0.500000000000000000\" | " +
 					".app_state.slashing.params.downtime_jail_duration = \"60s\" | " +
 					".app_state.slashing.params.slash_fraction_downtime = \"0.010000000000000000\"",

--- a/tests/e2e/test_runner.go
+++ b/tests/e2e/test_runner.go
@@ -94,7 +94,7 @@ func (tr *TestRunner) Run() error {
 	}
 
 	tr.result.Passed()
-	err = tr.teardownEnvironment()
+	// err = tr.teardownEnvironment()
 	fmt.Printf("==========================================\n")
 	return err
 }

--- a/tests/e2e/test_runner.go
+++ b/tests/e2e/test_runner.go
@@ -94,7 +94,7 @@ func (tr *TestRunner) Run() error {
 	}
 
 	tr.result.Passed()
-	// err = tr.teardownEnvironment()
+	err = tr.teardownEnvironment()
 	fmt.Printf("==========================================\n")
 	return err
 }


### PR DESCRIPTION
The slashing window param was too small and caused the e2e-test `stepsAssignConsumerKeyOnStartedChain` to fail randomly.