### PR TITLE
docs: remove duplicated "Consumer Chain" term

### DIFF
--- a/docs/docs/introduction/terminology.md
+++ b/docs/docs/introduction/terminology.md
@@ -39,11 +39,6 @@ PSS allows for more flexible security tradeoffs than Replicated Security.
 [Permissionless ICS](../features/permissionless.md) is the latest version of ICS that allows to launch Opt In chains in
 a permissionless way (i.e., without requiring a governance proposal).
 
-## Consumer Chain
-
-Chain that is secured by the validator set of the provider, instead of its own.
-Interchain Security allows a subset of the provider chain's validator set to validate blocks on the consumer chain.
-
 ## Standalone Chain
 
 Chain that is secured by its own validator set. This chain does not participate in Interchain Security.


### PR DESCRIPTION
## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review. -->

Removes duplicated term **Consumer Chain**  in [`docs/docs/introduction/terminology.md`](https://github.com/ahdzib-maya/interchain-security/blob/main/docs/docs/introduction/terminology.md)

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct `docs:` prefix in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
- [x] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [x] Confirmed the correct `docs:` prefix in the PR title
- [x] Confirmed all author checklist items have been addressed 
- [x] Confirmed that this PR only changes documentation
- [x] Reviewed content for consistency
- [x] Reviewed content for spelling and grammar
- [x] Tested instructions (if applicable)
- [x] Checked that the documentation website can be built and deployed successfully (run `make build-docs`)

