### PR TITLE
fix: make consumer-democracy read the sovereign genesis from nodeHome

### DIFF
--- a/app/consumer-democracy/app.go
+++ b/app/consumer-democracy/app.go
@@ -38,6 +38,7 @@ import (
 	"cosmossdk.io/x/feegrant"
 	feegrantkeeper "cosmossdk.io/x/feegrant/keeper"
 	feegrantmodule "cosmossdk.io/x/feegrant/module"
+
 	// add mint
 	"cosmossdk.io/x/upgrade"
 	upgradekeeper "cosmossdk.io/x/upgrade/keeper"
@@ -681,12 +682,7 @@ func New(
 			// upgrade handler code is application specific. However, as an example, standalone to consumer
 			// changeover chains should utilize customized upgrade handler code similar to below.
 
-			// TODO: should have a way to read from current node home
-			userHomeDir, err := os.UserHomeDir()
-			if err != nil {
-				stdlog.Println("Failed to get home dir %2", err)
-			}
-			nodeHome := userHomeDir + "/.sovereign/config/genesis.json"
+			nodeHome := homePath + "/.sovereign/config/genesis.json"
 			appState, _, err := genutiltypes.GenesisStateFromGenFile(nodeHome)
 			if err != nil {
 				return fromVM, fmt.Errorf("failed to unmarshal genesis state: %w", err)

--- a/tests/e2e/testnet-scripts/start-changeover.sh
+++ b/tests/e2e/testnet-scripts/start-changeover.sh
@@ -38,14 +38,16 @@ TENDERMINT_CONFIG_TRANSFORM=$6
 echo "killing nodes"
 pkill -f "^"interchain-security-sd &> /dev/null || true
 
-mkdir -p /root/.sovereign/config
-
-# apply genesis changes to existing genesis -> this creates the changeover genesis file with initial validator set
-jq "$GENESIS_TRANSFORM" /sover/validatoralice/config/genesis.json > /root/.sovereign/config/genesis.json
-
-
 # Get number of nodes from length of validators array
 NODES=$(echo "$VALIDATORS" | jq '. | length')
+
+for i in $(seq 0 $(($NODES - 1)));
+do
+    VAL_ID=$(echo "$VALIDATORS" | jq -r ".[$i].val_id")
+    mkdir -p /$CHAIN_ID/validator$VAL_ID/.sovereign/config
+    # apply genesis changes to existing genesis -> this creates the changeover genesis file with initial validator set
+    jq "$GENESIS_TRANSFORM" /sover/validatoralice/config/genesis.json > /$CHAIN_ID/validator$VAL_ID/.sovereign/config/genesis.json
+done
 
 # SETUP NETWORK NAMESPACES, see: https://adil.medium.com/container-networking-under-the-hood-network-namespaces-6b2b8fe8dc2a
 


### PR DESCRIPTION
## Description

This makes the dummy consumer-democracy-cdd binary more flexible. It's really useful for testing sovereign to consumer changeovers.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Provided a link to the relevant issue or specification
- [ ] Reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious -->
- [ ] Confirmed all CI checks have passed