### PR TITLE
test: test unjail ops only when standalone staking is not available

### DIFF
--- a/tests/integration/unbonding.go
+++ b/tests/integration/unbonding.go
@@ -50,7 +50,9 @@ func (s *CCVTestSuite) TestUndelegationCompletion() {
 func (s *CCVTestSuite) TestConsumerUnjailNoOp() {
 	consumerKeeper := s.consumerApp.GetConsumerKeeper()
 
-	// this is a no-op
-	err := consumerKeeper.Unjail(s.consumerCtx(), sdk.ConsAddress([]byte{0x01, 0x02, 0x03}))
-	s.Require().NoError(err)
+	if s.consumerApp.GetStakingKeeper() == nil {
+		// this is a no-op
+		err := consumerKeeper.Unjail(s.consumerCtx(), sdk.ConsAddress([]byte{0x01, 0x02, 0x03}))
+		s.Require().NoError(err)
+	}
 }


### PR DESCRIPTION
Fixes test failures in democ test suite when `TestConsumerUnjailNoOp` is run.

This test would always fail for democ test suite because the standalone staking keeper is always available.
