### PR TITLE
Typos fix relay.go

### DIFF
--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -489,14 +489,14 @@ func (k Keeper) HandleSlashPacket(ctx sdk.Context, consumerId string, data ccv.S
 		_, err = k.stakingKeeper.SlashWithInfractionReason(ctx, providerConsAddr.ToSdkConsAddr(), int64(infractionHeight),
 			data.Validator.Power, infractionParams.Downtime.SlashFraction, stakingtypes.Infraction_INFRACTION_DOWNTIME)
 		if err != nil {
-			k.Logger(ctx).Error("failed to slash vaidator", providerConsAddr.ToSdkConsAddr().String(), "err", err.Error())
+			k.Logger(ctx).Error("failed to slash validator", providerConsAddr.ToSdkConsAddr().String(), "err", err.Error())
 			return
 		}
 
 		// jail validator
 		err := k.stakingKeeper.Jail(ctx, providerConsAddr.ToSdkConsAddr())
 		if err != nil {
-			k.Logger(ctx).Error("failed to jail vaidator", providerConsAddr.ToSdkConsAddr().String(), "err", err.Error())
+			k.Logger(ctx).Error("failed to jail validator", providerConsAddr.ToSdkConsAddr().String(), "err", err.Error())
 			return
 		}
 		k.Logger(ctx).Info("HandleSlashPacket - validator jailed", "provider cons addr", providerConsAddr.String())


### PR DESCRIPTION
## Pull Request Title
fix: typo correction in relay.go ("vaidator" to "validator")

### Description
This pull request fixes a typo in the `relay.go` file where "vaidator" was used instead of the correct spelling, "validator." 

### Changes Made
- Corrected the typo "vaidator" to "validator" in two places in the file.

### Related Issues
- N/A

### Additional Notes
- This is a simple typo correction that improves the clarity of the code.
