### PR TITLE
Typo fix relay.go

### DIFF
--- a/x/ccv/provider/keeper/relay.go
+++ b/x/ccv/provider/keeper/relay.go
@@ -489,7 +489,7 @@ func (k Keeper) HandleSlashPacket(ctx sdk.Context, consumerId string, data ccv.S
 		_, err = k.stakingKeeper.SlashWithInfractionReason(ctx, providerConsAddr.ToSdkConsAddr(), int64(infractionHeight),
 			data.Validator.Power, infractionParams.Downtime.SlashFraction, stakingtypes.Infraction_INFRACTION_DOWNTIME)
 		if err != nil {
-			k.Logger(ctx).Error("failed to slash vaidator", providerConsAddr.ToSdkConsAddr().String(), "err", err.Error())
+			k.Logger(ctx).Error("failed to slash validator", providerConsAddr.ToSdkConsAddr().String(), "err", err.Error())
 			return
 		}
 


### PR DESCRIPTION
Fixed a typo in relay.go, correcting "vaidator" to "validator" for better clarity and accuracy in the log message.