### PR TITLE
fix: correct error message in consumer keeper field validation

### DIFF
--- a/x/ccv/consumer/keeper/keeper.go
+++ b/x/ccv/consumer/keeper/keeper.go
@@ -125,7 +125,7 @@ func (k *Keeper) SetStandaloneStakingKeeper(sk ccv.StakingKeeper) {
 func (k Keeper) mustValidateFields() {
 	// Ensures no fields are missed in this validation
 	if reflect.ValueOf(k).NumField() != 19 {
-		panic("number of fields in consumer keeper is not 16")
+		panic("number of fields in consumer keeper is not 19")
 	}
 
 	// Note 116 / 16 fields will be validated,


### PR DESCRIPTION
## Description

Closes: #XXXX

This PR fixes an inconsistency in the error message displayed when validating the number of fields in the consumer keeper. The current implementation checks for 19 fields but displays an error message mentioning 16 fields, which could lead to confusion during debugging. This fix aligns the error message with the actual validation check.

The change is in `x/ccv/consumer/keeper/keeper.go` where the panic message is updated to correctly reflect the expected number of fields (19 instead of 16).

---

### Author Checklist

I have...

* [x] Included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] Added `!` to the type prefix if the change is [state-machine breaking](https://github.com/cosmos/interchain-security/blob/main/RELEASES.md#breaking-changes) (N/A - this is not a state-machine breaking change)
* [x] Confirmed this PR does not introduce changes requiring state migrations
* [x] Targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
* [x] Provided a link to the relevant issue or specification
* [x] Followed the guidelines for [building SDK modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/build/building-modules/00-intro.md)
* [x] Included the necessary unit and integration [tests](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#testing)
* [x] Added a changelog entry to `CHANGELOG.md`
* [x] Included comments for [documenting Go code](https://blog.golang.org/godoc)
* [x] Updated the relevant documentation or specification
* [x] Reviewed "Files changed" and left comments if necessary
* [x] Confirmed all CI checks have passed
* [ ] If this PR is library API breaking, bump the go.mod version string of the repo (N/A - not API breaking)

### Reviewers Checklist

I have...

* [x] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [x] confirmed `!` the type prefix if the change is state-machine breaking
* [x] confirmed this PR does not introduce changes requiring state migrations
* [x] confirmed all author checklist items have been addressed 
* [x] reviewed state machine logic
* [x] reviewed API design and naming
* [x] reviewed documentation is accurate
* [x] reviewed tests and test coverage
