### PR TITLE
docs: fix the link for deploy-docs.yml workflow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -92,6 +92,6 @@ The `./docs/legacy` directory gets included into the rest of the documentation u
 
 # Building on remote
 
-Building on remote host is handled by [deploy-docs.yml workflow](.github/workflows/deploy-docs.yml).
+Building on remote host is handled by [deploy-docs.yml workflow](../.github/workflows/deploy-docs.yml).
 
 It executes `./sync_versions.sh` and `./build_deploy.sh` scripts and allows the output of the build process to be served by github pages.


### PR DESCRIPTION
## Description

The link to `deploy-docs.yml workflow` on [README.md](https://github.com/cosmos/interchain-security/blob/main/docs/README.md#building-on-remote) has an incorrect path.

### Changes 

Corrected the path to `deploy-docs.yml workflow`.

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [x] included the correct `docs:` prefix in the PR title
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/interchain-security/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [x] reviewed "Files changed" and left comments if necessary <!-- relevant if the changes are not obvious  -->
- [ ] confirmed all CI checks have passed
