### PR TITLE
feat: Add ChannelKeeperV2 to IBC Keeper initialization

### DIFF
--- a/app/consumer-democracy/app.go
+++ b/app/consumer-democracy/app.go
@@ -466,6 +466,7 @@ func New(
 		app.GetSubspace(ibctransfertypes.ModuleName),
 		app.IBCKeeper.ChannelKeeper,
 		app.IBCKeeper.ChannelKeeper,
+		app.IBCKeeper.ChannelKeeperV2,
 		app.MsgServiceRouter(),
 		app.AccountKeeper,
 		app.BankKeeper,

--- a/app/consumer-democracy/app.go
+++ b/app/consumer-democracy/app.go
@@ -465,7 +465,6 @@ func New(
 		runtime.NewKVStoreService(keys[ibctransfertypes.StoreKey]),
 		app.GetSubspace(ibctransfertypes.ModuleName),
 		app.IBCKeeper.ChannelKeeper,
-		app.IBCKeeper.ChannelKeeper,
 		app.IBCKeeper.ChannelKeeperV2,
 		app.MsgServiceRouter(),
 		app.AccountKeeper,

--- a/app/consumer/app.go
+++ b/app/consumer/app.go
@@ -372,6 +372,7 @@ func New(
 		app.GetSubspace(ibctransfertypes.ModuleName),
 		app.IBCKeeper.ChannelKeeper,
 		app.IBCKeeper.ChannelKeeper,
+		app.IBCKeeper.ChannelKeeperV2
 		app.MsgServiceRouter(),
 		app.AccountKeeper,
 		app.BankKeeper,

--- a/app/consumer/app.go
+++ b/app/consumer/app.go
@@ -371,7 +371,6 @@ func New(
 		runtime.NewKVStoreService(keys[ibctransfertypes.StoreKey]),
 		app.GetSubspace(ibctransfertypes.ModuleName),
 		app.IBCKeeper.ChannelKeeper,
-		app.IBCKeeper.ChannelKeeper,
 		app.IBCKeeper.ChannelKeeperV2
 		app.MsgServiceRouter(),
 		app.AccountKeeper,


### PR DESCRIPTION
This PR updates the IBC Keeper initialization to include ChannelKeeperV2 in the sovereign app. The change adds support for the new IBC channel keeper version while maintaining compatibility with the existing channel keeper implementation.

Changes:
- Added ChannelKeeperV2 to the TransferKeeper initialization
- Updated the IBC Keeper dependencies to include both channel keeper versions
- Maintains backwards compatibility with existing IBC channel functionality

This enhancement allows for improved IBC channel management capabilities while ensuring smooth integration with the existing IBC infrastructure.