### PR TITLE
refactor: replace golang.org/x/exp with stdlib

### DIFF
--- a/app/consumer/genesis.go
+++ b/app/consumer/genesis.go
@@ -3,12 +3,12 @@ package app
 import (
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/maps"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/gjson v1.18.0
 	golang.org/x/crypto v0.32.0 // indirect
-	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56
+	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
 	google.golang.org/genproto v0.0.0-20240701130421-f6361c86f094 // indirect


### PR DESCRIPTION
# Description

These experimental packages are now available in the Go standard library since Go 1.21 and Go 1.23:

`golang.org/x/exp/maps `-> maps ([https://go.dev/doc/go1.21#maps](https://go.dev/doc/go1.21#maps))
The key difference is that maps.Keys in the golang.org/x/exp/maps package return a slice, whereas maps.Keys in the standard library return an iterator. 

Reference: https://go.dev/doc/go1.23#iterators