### PR TITLE
fix: fixed file path handling

### DIFF
--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -7,7 +7,7 @@ cd proto
 proto_dirs=$(find ./interchain_security -path -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
 for dir in $proto_dirs; do
   for file in $(find "${dir}" -maxdepth 1 -name '*.proto'); do
-    if grep "option go_package" $file &> /dev/null ; then
+    if grep "option go_package" "$file" &> /dev/null ; then
       buf generate --template buf.gen.gogo.yaml $file
     fi
   done


### PR DESCRIPTION
Updated the script to properly handle file paths with spaces or special characters by enclosing `$file` in double quotes.
This prevents issues where filenames with spaces were being misinterpreted.