### PR TITLE
feat: Check Docker image existence in SetImage method

### DIFF
--- a/tests/e2e/test_target.go
+++ b/tests/e2e/test_target.go
@@ -73,6 +73,11 @@ func (dc *DockerContainer) GetTargetConfig() TargetConfig {
 func (dc *DockerContainer) SetImage(image string) error {
 	dc.ImageName = image
 	// TODO: check if image exists
+	// Check if the image exists
+	cmd := exec.Command("docker", "image", "inspect", image)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("docker image '%s' not found: %v", image, err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Implements the TODO in the DockerContainer.SetImage method to verify 
if the specified Docker image exists before setting it. This prevents 
potential errors when trying to use non-existent images later in the 
execution flow.

The implementation uses `docker image inspect` to check if the image 
exists and provides a clear error message if it doesn't.
