### PR TITLE
fix: incorrect argument type in `NewDisabledModulesDecorator`

### DIFF
--- a/app/consumer-democracy/ante_handler.go
+++ b/app/consumer-democracy/ante_handler.go
@@ -43,7 +43,7 @@ func NewAnteHandler(options HandlerOptions) (sdk.AnteHandler, error) {
 		ante.NewSetUpContextDecorator(),
 		ante.NewExtensionOptionsDecorator(nil),
 		consumerante.NewMsgFilterDecorator(options.ConsumerKeeper),
-		consumerante.NewDisabledModulesDecorator("/cosmos.evidence", "/cosmos.slashing"),
+		consumerante.NewDisabledModulesDecorator([]string{"/cosmos.evidence", "/cosmos.slashing"}),
 		ante.NewValidateBasicDecorator(),
 		ante.NewTxTimeoutHeightDecorator(),
 		ante.NewValidateMemoDecorator(options.AccountKeeper),


### PR DESCRIPTION
The `NewDisabledModulesDecorator` function expects a slice of strings (`[]string`), but individual string arguments were passed instead. Updated the call to correctly wrap the module names in a slice.