### PR TITLE
fix: incorrect multiplication in `provConsumerModifiedGenesis`

### DIFF
--- a/tests/interchain/provider_consumers_suite.go
+++ b/tests/interchain/provider_consumers_suite.go
@@ -83,7 +83,7 @@ func (s *ProviderConsumersSuite) GetContext() context.Context {
 
 func provConsumerModifiedGenesis() []cosmos.GenesisKV {
 	return []cosmos.GenesisKV{
-		cosmos.NewGenesisKV("app_state.staking.params.unbonding_time", (chainsuite.ProviderUnbondingTime * 10000000).String()),
+		cosmos.NewGenesisKV("app_state.staking.params.unbonding_time", strconv.FormatInt(chainsuite.ProviderUnbondingTime.Nanoseconds(), 10)),
 		cosmos.NewGenesisKV("app_state.gov.params.voting_period", chainsuite.GovVotingPeriod.String()),
 		cosmos.NewGenesisKV("app_state.gov.params.max_deposit_period", chainsuite.GovDepositPeriod.String()),
 		cosmos.NewGenesisKV("app_state.gov.params.min_deposit.0.denom", chainsuite.Stake),


### PR DESCRIPTION
`chainsuite.ProviderUnbondingTime` is most likely a `time.Duration`, but it's being multiplied by `10000000` before converting to a string. This results in an incorrect value in the genesis config.  

Instead of multiplying, it's better to use `.Nanoseconds()` to get the correct format:  

**Before:**  
```go
cosmos.NewGenesisKV("app_state.staking.params.unbonding_time", (chainsuite.ProviderUnbondingTime * 10000000).String()),
```
**After:**  
```go
cosmos.NewGenesisKV("app_state.staking.params.unbonding_time", strconv.FormatInt(chainsuite.ProviderUnbondingTime.Nanoseconds(), 10)),
```
This ensures the unbonding time is correctly serialized in nanoseconds.