### PR TITLE
fix: typo in documentation file

### DIFF
--- a/testutil/ibc_testing/generic_setup.go
+++ b/testutil/ibc_testing/generic_setup.go
@@ -156,7 +156,7 @@ func AddConsumer[Tp testutil.ProviderApp, Tc testutil.ConsumerApp](
 	powerShapingParameters := testkeeper.GetTestPowerShapingParameters()
 	powerShapingParameters.Top_N = consumerTopNParams[index] // isn't used in CreateConsumerClient
 
-	infractionPrameters := testkeeper.GetTestInfractionParameters()
+	infractionParameters := testkeeper.GetTestInfractionParameters()
 
 	consumerId := providerKeeper.FetchAndIncrementConsumerId(providerChain.GetContext())
 	providerKeeper.SetConsumerChainId(providerChain.GetContext(), consumerId, chainID)
@@ -166,7 +166,7 @@ func AddConsumer[Tp testutil.ProviderApp, Tc testutil.ConsumerApp](
 	s.Require().NoError(err)
 	err = providerKeeper.SetConsumerPowerShapingParameters(providerChain.GetContext(), consumerId, powerShapingParameters)
 	s.Require().NoError(err)
-	err = providerKeeper.SetInfractionParameters(providerChain.GetContext(), consumerId, infractionPrameters)
+	err = providerKeeper.SetInfractionParameters(providerChain.GetContext(), consumerId, infractionParameters)
 	s.Require().NoError(err)
 	providerKeeper.SetConsumerPhase(providerChain.GetContext(), consumerId, providertypes.CONSUMER_PHASE_INITIALIZED)
 	if chainID == firstConsumerChainID {


### PR DESCRIPTION
Corrected `infractionPrameters` → `infractionParameters`
