### PR TITLE
fix: minor documentation and comment improvements in simibc utilities

### DIFF
--- a/testutil/simibc/chain_util.go
+++ b/testutil/simibc/chain_util.go
@@ -17,7 +17,7 @@ import (
 // FinalizeBlock calls app.FinalizeBlock and app.Commit.
 // It sets the next block time to currentBlockTime + dt.
 // This function returns the TMHeader of the block that was just ended,
-//
+// along with all packets emitted during FinalizeBlock.
 // NOTE: this method may be used independently of the rest of simibc.
 func FinalizeBlock(c *ibctesting.TestChain, dt time.Duration) (*ibctmtypes.Header, []channeltypes.Packet) {
 	res, err := c.App.FinalizeBlock(&abci.RequestFinalizeBlock{

--- a/testutil/simibc/doc.go
+++ b/testutil/simibc/doc.go
@@ -1,4 +1,4 @@
 /*
-simibc is a collection of utilities wrapping the ibc-go testing framework which make is easier to write test scenarios involving precise orders of packet and ack delivery and calls to BeginBlock and EndBlock.
+simibc is a collection of utilities wrapping the ibc-go testing framework which make it easier to write test scenarios involving precise orders of packet and ack delivery and calls to BeginBlock and EndBlock.
 */
 package simibc

--- a/testutil/simibc/ordered_outbox.go
+++ b/testutil/simibc/ordered_outbox.go
@@ -26,7 +26,7 @@ type Ack struct {
 type Packet struct {
 	Packet channeltypes.Packet
 	// The number of App.Commits that have occurred since this packet was sent
-	// For example, if the ack was sent at height h, and the blockchain
+	// For example, if the packet was sent at height h, and the blockchain
 	// has headers ..., h, h+1, h+2 then Commits = 3
 	Commits int
 }
@@ -86,7 +86,7 @@ func (n OrderedOutbox) ConsumePackets(sender string, num int) []Packet {
 	return ret
 }
 
-// ConsumerAcks returns the first num packets with 2 or more commits. Returned
+// ConsumeAcks returns the first num packets with 2 or more commits. Returned
 // acks are removed from the outbox and will not be returned again (consumed).
 func (n OrderedOutbox) ConsumeAcks(sender string, num int) []Ack {
 	ret := []Ack{}

--- a/testutil/simibc/relayed_path.go
+++ b/testutil/simibc/relayed_path.go
@@ -70,7 +70,7 @@ func (f *RelayedPath) PacketSentByB(packet channeltypes.Packet) bool {
 // AddPacket adds a packet to the outbox of the chain with chainID.
 // It will fail if the chain is not involved in the relayed path,
 // or if the packet does not belong to this path,
-// i.e. if the pace
+// i.e. if the packet does not belong to this path.
 func (f *RelayedPath) AddPacket(chainID string, packet channeltypes.Packet) {
 	if !f.InvolvesChain(chainID) {
 		f.t.Fatal("in relayed path could not add packet to chain: ", chainID, " because it is not involved in the relayed path")


### PR DESCRIPTION
chain_util.go
  - Completed an unfinished comment in `FinalizeBlock` for clarity.

doc.go
  - Fixed a grammatical mistake: `make is easier` → `make it easier`.

ordered_outbox.go
  - Fixed a misleading comment in `Packet` struct referencing `ack` instead of `packet`.
  - Renamed `ConsumerAcks` → `ConsumeAcks` to match function name and usage.

relayed_path.go
  - Completed an unfinished inline comment in `AddPacket`.
