### PR TITLE
fix: correct log format string in init functions

### DIFF
--- a/app/consumer-democracy/app.go
+++ b/app/consumer-democracy/app.go
@@ -126,7 +126,7 @@ const (
 func init() {
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
-		stdlog.Println("Failed to get home dir %2", err)
+		stdlog.Printf("Failed to get home dir: %v", err)
 	}
 
 	DefaultNodeHome = filepath.Join(userHomeDir, "."+AppName)

--- a/app/consumer/app.go
+++ b/app/consumer/app.go
@@ -106,7 +106,7 @@ const (
 func init() {
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
-		stdlog.Println("Failed to get home dir %2", err)
+		stdlog.Printf("Failed to get home dir: %v", err)
 	}
 
 	DefaultNodeHome = filepath.Join(userHomeDir, "."+AppName)

--- a/app/provider/app.go
+++ b/app/provider/app.go
@@ -221,7 +221,7 @@ type App struct { // nolint: golint
 func init() {
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
-		stdlog.Println("Failed to get home dir %2", err)
+		stdlog.Printf("Failed to get home dir: %v", err)
 	}
 
 	DefaultNodeHome = filepath.Join(userHomeDir, "."+AppName)

--- a/app/sovereign/app.go
+++ b/app/sovereign/app.go
@@ -213,7 +213,7 @@ type App struct { // nolint: golint
 func init() {
 	userHomeDir, err := os.UserHomeDir()
 	if err != nil {
-		stdlog.Println("Failed to get home dir %2", err)
+		stdlog.Printf("Failed to get home dir: %v", err)
 	}
 
 	DefaultNodeHome = filepath.Join(userHomeDir, "."+AppName)


### PR DESCRIPTION
Replace stdlog.Println with stdlog.Printf to properly format error messages in init functions across all app packages. The previous format string "%2" was being printed literally instead of formatting the error value.

Fixed in: consumer, provider, sovereign, and consumer-democracy apps.