### PR TITLE
fix(ccv): return error when transfer memo is missing provider reward memo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Bump Cosmos SDK dependencies to v0.53. ([\#2594](https://github.com/cosmos/interchain-security/pull/2594))
 
+### BUG FIXES
+
+- `[x/ccv]` Return an error when the transfer memo is missing the provider reward memo. ([\#2626](https://github.com/cosmos/interchain-security/pull/2626))
+
 ## v6.4.1
 
 *February 25, 2025*

--- a/x/ccv/types/wire.go
+++ b/x/ccv/types/wire.go
@@ -236,7 +236,7 @@ func GetRewardMemoFromTransferMemo(memo string) (RewardMemo, error) {
 
 	providerMemo, ok := memoData["provider"]
 	if !ok {
-		return RewardMemo{}, err
+		return RewardMemo{}, errors.New("missing provider reward memo")
 	}
 
 	rewardMemo := RewardMemo{}

--- a/x/ccv/types/wire_test.go
+++ b/x/ccv/types/wire_test.go
@@ -237,3 +237,8 @@ func TestCreateTransferMemo(t *testing.T) {
 	require.Equal(t, chainId, rewardMemo.ChainId)
 	require.Equal(t, "ICS rewards", rewardMemo.Memo)
 }
+
+func TestGetRewardMemoFromTransferMemoMissingProvider(t *testing.T) {
+	_, err := types.GetRewardMemoFromTransferMemo(`{"foo":"bar"}`)
+	require.Error(t, err)
+}

--- a/x/ccv/types/wire_test.go
+++ b/x/ccv/types/wire_test.go
@@ -238,7 +238,57 @@ func TestCreateTransferMemo(t *testing.T) {
 	require.Equal(t, "ICS rewards", rewardMemo.Memo)
 }
 
-func TestGetRewardMemoFromTransferMemoMissingProvider(t *testing.T) {
-	_, err := types.GetRewardMemoFromTransferMemo(`{"foo":"bar"}`)
-	require.Error(t, err)
+func TestGetRewardMemoFromTransferMemo(t *testing.T) {
+	testCases := []struct {
+		name      string
+		memo      string
+		expectErr bool
+		want      types.RewardMemo
+	}{
+		{
+			name:      "missing provider key",
+			memo:      `{"foo":"bar"}`,
+			expectErr: true,
+		},
+		{
+			name:      "invalid JSON",
+			memo:      `{not-json}`,
+			expectErr: true,
+		},
+		{
+			name:      "provider present but wrong type",
+			memo:      `{"provider":"not-an-object"}`,
+			expectErr: true,
+		},
+		{
+			name:      "provider present but missing fields",
+			memo:      `{"provider":{"memo":"ICS rewards"}}`,
+			expectErr: false,
+			want:      types.RewardMemo{Memo: "ICS rewards"},
+		},
+		{
+			name:      "provider present and decodes",
+			memo:      `{"provider":{"consumerId":"13","chainId":"chain-13","memo":"memo"}}`,
+			expectErr: false,
+			want:      types.RewardMemo{ConsumerId: "13", ChainId: "chain-13", Memo: "memo"},
+		},
+		{
+			name:      "valid ICS rewards memo",
+			memo:      `{"provider":{"consumerId":"13","chainId":"chain-13","memo":"ICS rewards"}}`,
+			expectErr: false,
+			want:      types.RewardMemo{ConsumerId: "13", ChainId: "chain-13", Memo: "ICS rewards"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rewardMemo, err := types.GetRewardMemoFromTransferMemo(tc.memo)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, rewardMemo)
+		})
+	}
 }


### PR DESCRIPTION
Please go to the `Preview` tab and select the appropriate sub-template:

* [Production code](?expand=1&template=production.md) - for types `fix`, `feat`, and `refactor`.
* [Docs](?expand=1&template=docs.md) - for documentation changes.
* [Others](?expand=1&template=others.md) - for changes that do not affect production code.
