### PR TITLE
fix(provider): move MsgChangeRewardDenoms validation to msg server handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### IMPROVEMENTS
+
+- `[x/provider]` Move `MsgChangeRewardDenoms` validation logic from `ValidateBasic` into the msg server handler. ([\#2149](https://github.com/cosmos/interchain-security/issues/2149))
+
 ### DEPENDENCIES
 
 - Bump Cosmos SDK dependencies to v0.53. ([\#2594](https://github.com/cosmos/interchain-security/pull/2594))

--- a/x/ccv/provider/keeper/msg_server.go
+++ b/x/ccv/provider/keeper/msg_server.go
@@ -109,6 +109,26 @@ func (k msgServer) ChangeRewardDenoms(goCtx context.Context, msg *types.MsgChang
 		return nil, errorsmod.Wrapf(types.ErrUnauthorized, "expected %s, got %s", k.GetAuthority(), msg.Authority)
 	}
 
+	if len(msg.DenomsToAdd) == 0 && len(msg.DenomsToRemove) == 0 {
+		return nil, errorsmod.Wrapf(types.ErrInvalidMsgChangeRewardDenoms, "both DenomsToAdd and DenomsToRemove are empty")
+	}
+
+	denomMap := map[string]struct{}{}
+	for _, denom := range msg.DenomsToAdd {
+		if err := sdk.ValidateDenom(denom); err != nil {
+			return nil, errorsmod.Wrapf(types.ErrInvalidMsgChangeRewardDenoms, "DenomsToAdd: invalid denom(%s)", denom)
+		}
+		denomMap[denom] = struct{}{}
+	}
+	for _, denom := range msg.DenomsToRemove {
+		if err := sdk.ValidateDenom(denom); err != nil {
+			return nil, errorsmod.Wrapf(types.ErrInvalidMsgChangeRewardDenoms, "DenomsToRemove: invalid denom(%s)", denom)
+		}
+		if _, found := denomMap[denom]; found {
+			return nil, errorsmod.Wrapf(types.ErrInvalidMsgChangeRewardDenoms, "denom(%s) cannot be both added and removed", denom)
+		}
+	}
+
 	eventAttributes := k.Keeper.ChangeRewardDenoms(ctx, msg.DenomsToAdd, msg.DenomsToRemove)
 
 	ctx.EventManager().EmitEvent(

--- a/x/ccv/provider/keeper/msg_server_test.go
+++ b/x/ccv/provider/keeper/msg_server_test.go
@@ -382,3 +382,57 @@ func TestUpdateConsumer(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedInitializationParameters, actualInitializationParameters)
 }
+
+func TestChangeRewardDenomsValidation(t *testing.T) {
+	providerKeeper, ctx, ctrl, _ := testkeeper.GetProviderKeeperAndCtx(t, testkeeper.NewInMemKeeperParams(t))
+	defer ctrl.Finish()
+
+	msgServer := providerkeeper.NewMsgServerImpl(&providerKeeper)
+	authority := providerKeeper.GetAuthority()
+
+	testCases := []struct {
+		name        string
+		msg         *providertypes.MsgChangeRewardDenoms
+		expectError bool
+	}{
+		{
+			name:        "both sets empty",
+			msg:         &providertypes.MsgChangeRewardDenoms{Authority: authority},
+			expectError: true,
+		},
+		{
+			name: "invalid denom",
+			msg: &providertypes.MsgChangeRewardDenoms{
+				Authority:   authority,
+				DenomsToAdd: []string{"!!!bad"},
+			},
+			expectError: true,
+		},
+		{
+			name: "denom in both add and remove",
+			msg: &providertypes.MsgChangeRewardDenoms{
+				Authority:      authority,
+				DenomsToAdd:    []string{"uatom"},
+				DenomsToRemove: []string{"uatom"},
+			},
+			expectError: true,
+		},
+		{
+			name: "valid",
+			msg: &providertypes.MsgChangeRewardDenoms{
+				Authority:   authority,
+				DenomsToAdd: []string{"uatom"},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		_, err := msgServer.ChangeRewardDenoms(ctx, tc.msg)
+		if tc.expectError {
+			require.Error(t, err, tc.name)
+		} else {
+			require.NoError(t, err, tc.name)
+		}
+	}
+}

--- a/x/ccv/provider/types/msg.go
+++ b/x/ccv/provider/types/msg.go
@@ -96,33 +96,6 @@ func (msg MsgAssignConsumerKey) ValidateBasic() error {
 
 // ValidateBasic implements the sdk.HasValidateBasic interface.
 func (msg *MsgChangeRewardDenoms) ValidateBasic() error {
-	emptyDenomsToAdd := len(msg.DenomsToAdd) == 0
-	emptyDenomsToRemove := len(msg.DenomsToRemove) == 0
-	// Return error if both sets are empty or nil
-	if emptyDenomsToAdd && emptyDenomsToRemove {
-		return errorsmod.Wrapf(ErrInvalidMsgChangeRewardDenoms, "both DenomsToAdd and DenomsToRemove are empty")
-	}
-
-	denomMap := map[string]struct{}{}
-	for _, denom := range msg.DenomsToAdd {
-		// validate the denom
-		if !sdk.NewCoin(denom, math.NewInt(1)).IsValid() {
-			return errorsmod.Wrapf(ErrInvalidMsgChangeRewardDenoms, "DenomsToAdd: invalid denom(%s)", denom)
-		}
-		denomMap[denom] = struct{}{}
-	}
-	for _, denom := range msg.DenomsToRemove {
-		// validate the denom
-		if !sdk.NewCoin(denom, math.NewInt(1)).IsValid() {
-			return errorsmod.Wrapf(ErrInvalidMsgChangeRewardDenoms, "DenomsToRemove: invalid denom(%s)", denom)
-		}
-		// denom cannot be in both sets
-		if _, found := denomMap[denom]; found {
-			return errorsmod.Wrapf(ErrInvalidMsgChangeRewardDenoms,
-				"denom(%s) cannot be both added and removed", denom)
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Closes #2149

Moves the denom validation logic from `MsgChangeRewardDenoms.ValidateBasic()` into the `ChangeRewardDenoms` msg server handler, following the cosmos-sdk v0.50 pattern where `ValidateBasic` is soft-deprecated.

The validation checks (empty denoms, invalid denom format, denom in both add and remove sets) are now performed in the handler. `ValidateBasic` stubs to `nil`. Also swapped `sdk.NewCoin().IsValid()` for `sdk.ValidateDenom()` to avoid a panic on malformed input.

Tests added to `msg_server_test.go` covering the moved validation paths.